### PR TITLE
Performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ Signature: `Response(content=b'', status_code=200, headers=None, media_type=None
 
 * `content` - A string or bytestring.
 * `status_code` - An integer HTTP status code.
-* `headers` - A dictionary of strings or list of pairs of strings.
-* `media_type` - A string giving the content type.
+* `headers` - A dictionary of strings.
+* `media_type` - A string giving the media type. eg. "text/html"
 
-Starlette will automatically include a content-length header. It will also
-set the content-type header, including a charset for text types.
+Starlette will automatically include a Content-Length header. It will also
+include a Content-Type header, based on the media_type and appending a charset
+for text types.
 
 Once you've instantiated a response, you can send it by calling it as an
 ASGI application instance.
@@ -95,7 +96,24 @@ class App:
         self.scope = scope
 
     async def __call__(self, receive, send):
-        response = HTMLResponse('<html><body><h1>Hello, world!</h1></body></html')
+        response = HTMLResponse('<html><body><h1>Hello, world!</h1></body></html>')
+        await response(receive, send)
+```
+
+### PlainTextResponse
+
+Takes some text or bytes and returns an plain text response.
+
+```python
+from starlette import PlainTextResponse
+
+
+class App:
+    def __init__(self, scope):
+        self.scope = scope
+
+    async def __call__(self, receive, send):
+        response = PlainTextResponse('Hello, world!')
         await response(receive, send)
 ```
 

--- a/starlette/__init__.py
+++ b/starlette/__init__.py
@@ -1,5 +1,11 @@
 from starlette.decorators import asgi_application
-from starlette.response import HTMLResponse, JSONResponse, Response, PlainTextResponse, StreamingResponse
+from starlette.response import (
+    HTMLResponse,
+    JSONResponse,
+    Response,
+    PlainTextResponse,
+    StreamingResponse,
+)
 from starlette.request import Request
 from starlette.routing import Path, PathPrefix, Router
 from starlette.testclient import TestClient

--- a/starlette/__init__.py
+++ b/starlette/__init__.py
@@ -1,5 +1,5 @@
 from starlette.decorators import asgi_application
-from starlette.response import HTMLResponse, JSONResponse, Response, StreamingResponse
+from starlette.response import HTMLResponse, JSONResponse, Response, PlainTextResponse, StreamingResponse
 from starlette.request import Request
 from starlette.routing import Path, PathPrefix, Router
 from starlette.testclient import TestClient
@@ -11,10 +11,11 @@ __all__ = (
     "JSONResponse",
     "Path",
     "PathPrefix",
+    "PlainTextResponse",
     "Response",
     "Router",
     "StreamingResponse",
     "Request",
     "TestClient",
 )
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -131,14 +131,14 @@ class Headers(typing.Mapping[str, str]):
             self._list = value
 
     def keys(self):
-        return [key.decode('latin-1') for key, value in self._list]
+        return [key.decode("latin-1") for key, value in self._list]
 
     def values(self):
-        return [value.decode('latin-1') for key, value in self._list]
+        return [value.decode("latin-1") for key, value in self._list]
 
     def items(self):
         return [
-            (key.decode('latin-1'), value.decode('latin-1'))
+            (key.decode("latin-1"), value.decode("latin-1"))
             for key, value in self._list
         ]
 
@@ -149,17 +149,18 @@ class Headers(typing.Mapping[str, str]):
             return default
 
     def get_list(self, key: str) -> typing.List[str]:
-        get_header_key = key.lower().encode('latin-1')
+        get_header_key = key.lower().encode("latin-1")
         return [
-            item_value.decode('latin-1') for item_key, item_value in self._list
+            item_value.decode("latin-1")
+            for item_key, item_value in self._list
             if item_key == get_header_key
         ]
 
     def __getitem__(self, key: str):
-        get_header_key = key.lower().encode('latin-1')
+        get_header_key = key.lower().encode("latin-1")
         for header_key, header_value in self._list:
             if header_key == get_header_key:
-                return header_value.decode('latin-1')
+                return header_value.decode("latin-1")
         raise KeyError(key)
 
     def __contains__(self, key: str):
@@ -182,8 +183,8 @@ class Headers(typing.Mapping[str, str]):
 
 class MutableHeaders(Headers):
     def __setitem__(self, key: str, value: str):
-        set_key = key.lower().encode('latin-1')
-        set_value = value.encode('latin-1')
+        set_key = key.lower().encode("latin-1")
+        set_value = value.encode("latin-1")
 
         pop_indexes = []
         for idx, (item_key, item_value) in enumerate(self._list):

--- a/starlette/request.py
+++ b/starlette/request.py
@@ -28,7 +28,7 @@ class Request(Mapping):
         if not hasattr(self, "_url"):
             scheme = self._scope["scheme"]
             host, port = self._scope["server"]
-            path = self._scope["path"]
+            path = self._scope.get("root_path", "") + self._scope["path"]
             query_string = self._scope["query_string"]
 
             if (scheme == "http" and port != 80) or (scheme == "https" and port != 443):
@@ -45,12 +45,7 @@ class Request(Mapping):
     @property
     def headers(self) -> Headers:
         if not hasattr(self, "_headers"):
-            self._headers = Headers(
-                [
-                    (key.decode(), value.decode())
-                    for key, value in self._scope["headers"]
-                ]
-            )
+            self._headers = Headers(self._scope["headers"])
         return self._headers
 
     @property

--- a/starlette/response.py
+++ b/starlette/response.py
@@ -13,7 +13,7 @@ class Response:
         content: typing.Any,
         status_code: int = 200,
         headers: dict = None,
-        media_type: str = None
+        media_type: str = None,
     ) -> None:
         self.body = self.render(content)
         self.status_code = status_code
@@ -33,7 +33,7 @@ class Response:
             missing_content_type = True
         else:
             raw_headers = [
-                (k.lower().encode('latin-1'), v.encode('latin-1'))
+                (k.lower().encode("latin-1"), v.encode("latin-1"))
                 for k, v in headers.items()
             ]
             missing_content_length = "content-length" not in headers
@@ -47,14 +47,14 @@ class Response:
             content_type = self.media_type
             if content_type.startswith("text/") and self.charset is not None:
                 content_type += "; charset=%s" % self.charset
-            content_type_value = content_type.encode('latin-1')
+            content_type_value = content_type.encode("latin-1")
             raw_headers.append((b"content-type", content_type_value))
 
         self.raw_headers = raw_headers
 
     @property
     def headers(self):
-        if not hasattr(self, '_headers'):
+        if not hasattr(self, "_headers"):
             self._headers = MutableHeaders(self.raw_headers)
         return self._headers
 
@@ -96,7 +96,7 @@ class StreamingResponse(Response):
         content: typing.Any,
         status_code: int = 200,
         headers: dict = None,
-        media_type: str = None
+        media_type: str = None,
     ) -> None:
         self.body_iterator = content
         self.status_code = status_code
@@ -126,7 +126,7 @@ class StreamingResponse(Response):
             missing_content_type = True
         else:
             raw_headers = [
-                (k.lower().encode('latin-1'), v.encode('latin-1'))
+                (k.lower().encode("latin-1"), v.encode("latin-1"))
                 for k, v in headers.items()
             ]
             missing_content_type = "content-type" not in headers
@@ -135,7 +135,7 @@ class StreamingResponse(Response):
             content_type = self.media_type
             if content_type.startswith("text/") and self.charset is not None:
                 content_type += "; charset=%s" % self.charset
-            content_type_value = content_type.encode('latin-1')
+            content_type_value = content_type.encode("latin-1")
             raw_headers.append((b"content-type", content_type_value))
 
         self.raw_headers = raw_headers

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -48,7 +48,8 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
 
         # Include other request headers.
         headers += [
-            [key.lower().encode(), value.encode()] for key, value in request.headers.items()
+            [key.lower().encode(), value.encode()]
+            for key, value in request.headers.items()
         ]
 
         scope = {

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -48,7 +48,7 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
 
         # Include other request headers.
         headers += [
-            [key.encode(), value.encode()] for key, value in request.headers.items()
+            [key.lower().encode(), value.encode()] for key, value in request.headers.items()
         ]
 
         scope = {

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -16,7 +16,7 @@ def test_url():
 
 
 def test_headers():
-    h = Headers([("a", "123"), ("A", "456"), ("b", "789")])
+    h = Headers([(b"a", b"123"), (b"a", b"456"), (b"b", b"789")])
     assert "a" in h
     assert "A" in h
     assert "b" in h
@@ -32,11 +32,10 @@ def test_headers():
     assert list(h) == [("a", "123"), ("a", "456"), ("b", "789")]
     assert dict(h) == {"a": "123", "b": "789"}
     assert repr(h) == "Headers([('a', '123'), ('a', '456'), ('b', '789')])"
-    assert Headers({"a": "123", "b": "456"}) == Headers([("a", "123"), ("b", "456")])
-    assert Headers({"a": "123", "b": "456"}) == {"B": "456", "a": "123"}
-    assert Headers({"a": "123", "b": "456"}) == [("B", "456"), ("a", "123")]
-    assert {"B": "456", "a": "123"} == Headers({"a": "123", "b": "456"})
-    assert [("B", "456"), ("a", "123")] == Headers({"a": "123", "b": "456"})
+    assert h == Headers([(b"a", b"123"), (b"b", b"789"), (b"a", b"456")])
+    assert h != [(b"a", b"123"), (b"A", b"456"), (b"b", b"789")]
+    h = Headers()
+    assert not h.items()
 
 
 def test_queryparams():

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -65,3 +65,24 @@ def test_response_headers():
     response = client.get("/")
     assert response.headers["x-header-1"] == "123"
     assert response.headers["x-header-2"] == "789"
+
+
+def test_streaming_response_headers():
+    def app(scope):
+        async def asgi(receive, send):
+            async def stream(msg):
+                yield "hello, world"
+
+            headers = {"x-header-1": "123", "x-header-2": "456"}
+            response = StreamingResponse(
+                stream("hello, world"), media_type="text/plain", headers=headers
+            )
+            response.headers["x-header-2"] = "789"
+            await response(receive, send)
+
+        return asgi
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.headers["x-header-1"] == "123"
+    assert response.headers["x-header-2"] == "789"


### PR DESCRIPTION
* Added `Response.raw_headers`
* Headers becomes a wrapper around `raw_headers` list.
* Performance improvements - lazy creation of `response.headers`

Changes include...

Mutating `request.scope['headers']` will now also be reflected in `request.headers`
`response.raw_headers` is exposed, and is a list of `(byte, byte)` tuples.