### PR TITLE
Routing decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,20 @@ app = Router([
 The router will respond with "404 Not found" or "406 Method not allowed"
 responses for requests which do not match.
 
+Additionally, the router offers a convenience decorator method for defining ASGI application routes.
+
+```python
+from starlette import Router, Response
+
+
+app = Router()
+
+
+@app.route('/', methods=['GET'])
+def homepage(scope):
+    return Response('Hello, world', media_type='text/plain')
+```
+
 ---
 
 ## Test Client

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ app = Router([
 The router will respond with "404 Not found" or "406 Method not allowed"
 responses for requests which do not match.
 
-Additionally, the router offers a convenience decorator method for defining ASGI application routes.
+Additionally, the router offers a convenience method for defining ASGI application routes.
 
 ```python
 from starlette import Router, Response

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -69,7 +69,7 @@ class PathPrefix(Route):
 
 
 class Router:
-    def __init__(self, routes: typing.List[Route], default: ASGIApp = None) -> None:
+    def __init__(self, routes: typing.List[Route] = [], default: ASGIApp = None) -> None:
         self.routes = routes
         self.default = self.not_found if default is None else default
 
@@ -82,3 +82,10 @@ class Router:
 
     def not_found(self, scope: Scope) -> ASGIInstance:
         return Response("Not found", 404, media_type="text/plain")
+
+    def route(self, path: str, methods: typing.Sequence[str] = ()) -> None:
+        def _route(app: ASGIApp) -> ASGIApp:
+            route = Path(path=path, app=app, methods=methods)
+            self.routes.append(route)
+            return app
+        return _route

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -69,7 +69,9 @@ class PathPrefix(Route):
 
 
 class Router:
-    def __init__(self, routes: typing.List[Route] = [], default: ASGIApp = None) -> None:
+    def __init__(
+        self, routes: typing.List[Route] = [], default: ASGIApp = None
+    ) -> None:
         self.routes = routes
         self.default = self.not_found if default is None else default
 
@@ -88,4 +90,5 @@ class Router:
             route = Path(path=path, app=app, methods=methods)
             self.routes.append(route)
             return app
+
         return _route

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -30,12 +30,12 @@ app = Router(
 
 
 @app.route("/decorated", methods=["GET"])
-def decorated_app(scope):
+def decorated_homepage(scope):
     return Response("Hello, world", media_type="text/plain")
 
 
 @app.route("/decorated/{username}", methods=["GET"])
-def decorated_app(scope):
+def decorated_user(scope):
     content = "User " + scope["kwargs"]["username"]
     return Response(content, media_type="text/plain")
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -29,6 +29,17 @@ app = Router(
 )
 
 
+@app.route("/decorated", methods=["GET"])
+def decorated_app(scope):
+    return Response("Hello, world", media_type="text/plain")
+
+
+@app.route("/decorated/{username}", methods=["GET"])
+def decorated_app(scope):
+    content = "User " + scope["kwargs"]["username"]
+    return Response(content, media_type="text/plain")
+
+
 def test_router():
     client = TestClient(app)
 
@@ -59,3 +70,15 @@ def test_router():
     response = client.post("/static/123")
     assert response.status_code == 406
     assert response.text == "Method not allowed"
+
+    response = client.get("/decorated")
+    assert response.status_code == 200
+    assert response.text == "Hello, world"
+
+    response = client.post("/decorated")
+    assert response.status_code == 406
+    assert response.text == "Method not allowed"
+
+    response = client.get("/decorated/tomchristie")
+    assert response.status_code == 200
+    assert response.text == "User tomchristie"


### PR DESCRIPTION
Refs https://github.com/encode/starlette/issues/12

Implements a method on the `Router` class to allow a simple means of routing ASGI applications to `Path` objects via a decorator.

Example:

```python
from starlette import Router, Response


app = Router()


@app.route('/', methods=['GET'])
def homepage(scope):
    return Response('Hello, world', media_type='text/plain')
```