### PR TITLE
Datastructure tweaks

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -196,16 +196,16 @@ class MutableHeaders(Headers):
         set_key = key.lower().encode("latin-1")
         set_value = value.encode("latin-1")
 
-        pop_indexes = []
+        found_indexes = []
         for idx, (item_key, item_value) in enumerate(self._list):
             if item_key == set_key:
-                pop_indexes.append(idx)
+                found_indexes.append(idx)
 
-        for idx in reversed(pop_indexes[1:]):
+        for idx in reversed(found_indexes[1:]):
             del self._list[idx]
 
-        if pop_indexes:
-            idx = pop_indexes[0]
+        if found_indexes:
+            idx = found_indexes[0]
             self._list[idx] = (set_key, set_value)
         else:
             self._list.append((set_key, set_value))

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -191,6 +191,7 @@ class MutableHeaders(Headers):
     def __setitem__(self, key: str, value: str):
         """
         Set the header `key` to `value`, removing any duplicate entries.
+        Retains insertion order.
         """
         set_key = key.lower().encode("latin-1")
         set_value = value.encode("latin-1")
@@ -200,10 +201,14 @@ class MutableHeaders(Headers):
             if item_key == set_key:
                 pop_indexes.append(idx)
 
-        for idx in reversed(pop_indexes):
+        for idx in reversed(pop_indexes[1:]):
             del self._list[idx]
 
-        self._list.append((set_key, set_value))
+        if pop_indexes:
+            idx = pop_indexes[0]
+            self._list[idx] = (set_key, set_value)
+        else:
+            self._list.append((set_key, set_value))
 
     def __delitem__(self, key: str):
         """

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -155,6 +155,9 @@ class Headers(typing.Mapping[str, str]):
             if item_key == get_header_key
         ]
 
+    def mutablecopy(self):
+        return MutableHeaders(self._list[:])
+
     def __getitem__(self, key: str):
         get_header_key = key.lower().encode("latin-1")
         for header_key, header_value in self._list:

--- a/starlette/request.py
+++ b/starlette/request.py
@@ -1,5 +1,6 @@
 from starlette.datastructures import URL, Headers, QueryParams
 from collections.abc import Mapping
+from urllib.parse import unquote
 import json
 import typing
 
@@ -37,10 +38,22 @@ class Request(Mapping):
                 url = "%s://%s%s" % (scheme, host, path)
 
             if query_string:
-                url += "?" + query_string.decode()
+                url += "?" + unquote(query_string.decode())
 
             self._url = URL(url)
         return self._url
+
+    @property
+    def relative_url(self) -> URL:
+        if not hasattr(self, "_relative_url"):
+            url = self._scope["path"]
+            query_string = self._scope["query_string"]
+
+            if query_string:
+                url += "?" + unquote(query_string.decode())
+
+            self._relative_url = URL(url)
+        return self._relative_url
 
     @property
     def headers(self) -> Headers:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -56,7 +56,7 @@ def test_headers_mutablecopy():
     c = h.mutablecopy()
     assert c.items() == [("a", "123"), ("a", "456"), ("b", "789")]
     c["a"] = "abc"
-    assert c.items() == [("b", "789"), ("a", "abc")]
+    assert c.items() == [("a", "abc"), ("b", "789")]
 
 def test_queryparams():
     q = QueryParams([("a", "123"), ("a", "456"), ("b", "789")])

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -58,6 +58,7 @@ def test_headers_mutablecopy():
     c["a"] = "abc"
     assert c.items() == [("a", "abc"), ("b", "789")]
 
+
 def test_queryparams():
     q = QueryParams([("a", "123"), ("a", "456"), ("b", "789")])
     assert "a" in q

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -51,6 +51,13 @@ def test_mutable_headers():
     assert dict(h) == {"b": "4"}
 
 
+def test_headers_mutablecopy():
+    h = Headers([(b"a", b"123"), (b"a", b"456"), (b"b", b"789")])
+    c = h.mutablecopy()
+    assert c.items() == [("a", "123"), ("a", "456"), ("b", "789")]
+    c["a"] = "abc"
+    assert c.items() == [("b", "789"), ("a", "abc")]
+
 def test_queryparams():
     q = QueryParams([("a", "123"), ("a", "456"), ("b", "789")])
     assert "a" in q

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -19,6 +19,24 @@ def test_request_url():
     assert response.json() == {"method": "GET", "url": "https://example.org:123/"}
 
 
+def test_request_relative_url():
+    def app(scope):
+        async def asgi(receive, send):
+            request = Request(scope, receive)
+            data = {"method": request.method, "relative_url": request.relative_url}
+            response = JSONResponse(data)
+            await response(receive, send)
+
+        return asgi
+
+    client = TestClient(app)
+    response = client.get("/123?a=abc")
+    assert response.json() == {"method": "GET", "relative_url": "/123?a=abc"}
+
+    response = client.get("https://example.org:123/")
+    assert response.json() == {"method": "GET", "relative_url": "/"}
+
+
 def test_request_query_params():
     def app(scope):
         async def asgi(receive, send):


### PR DESCRIPTION
* Add `Request.relative_url`.
* Add `Headers.mutablecopy()`.
* `MutableHeaders` now retains insertion order.