### PR TITLE
Fixed encoding issues on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_long_description():
     """
     Return the README.
     """
-    return open('README.md', 'r').read()
+    return open('README.md', 'r', encoding="utf8").read()
 
 
 def get_packages(package):


### PR DESCRIPTION
Attempting to install the package on windows throws 
```UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 1549: character maps to <undefined>```

This is an attempted fix