### PR TITLE
Correctly handle static files larger than 4096 bytes

### DIFF
--- a/starlette/response.py
+++ b/starlette/response.py
@@ -177,5 +177,9 @@ class FileResponse(Response):
                 chunk = await file.read(self.chunk_size)
                 more_body = len(chunk) == self.chunk_size
                 await send(
-                    {"type": "http.response.body", "body": chunk, "more_body": False}
+                    {
+                        "type": "http.response.body",
+                        "body": chunk,
+                        "more_body": more_body,
+                    }
                 )

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -70,8 +70,9 @@ def test_response_headers():
 
 def test_file_response(tmpdir):
     path = os.path.join(tmpdir, "xyz")
+    content = b"<file content>" * 1000
     with open(path, "wb") as file:
-        file.write(b"<file content>")
+        file.write(content)
 
     def app(scope):
         return FileResponse(path=path, filename="example.png")
@@ -80,7 +81,7 @@ def test_file_response(tmpdir):
     response = client.get("/")
     expected_disposition = 'attachment; filename="example.png"'
     assert response.status_code == 200
-    assert response.content == b"<file content>"
+    assert response.content == content
     assert response.headers["content-type"] == "image/png"
     assert response.headers["content-disposition"] == expected_disposition
     assert "content-length" in response.headers

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -16,6 +16,21 @@ def test_staticfile(tmpdir):
     assert response.text == "<file content>"
 
 
+def test_large_staticfile(tmpdir):
+    path = os.path.join(tmpdir, "example.txt")
+    content = "this is a lot of content" * 200
+    print("content len = ", len(content))
+    with open(path, "w") as file:
+        file.write(content)
+
+    app = StaticFile(path=path)
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert len(content) == len(response.text)
+    assert content == response.text
+
+
 def test_staticfile_post(tmpdir):
     path = os.path.join(tmpdir, "example.txt")
     with open(path, "w") as file:


### PR DESCRIPTION
Fixes a bug where FileResponse did not work correctly for files larger than the 4096 byte chunk_size. Closes #32.