### PR TITLE
Add App class

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Starlette is a small library for working with [ASGI](https://asgi.readthedocs.io/en/latest/).
 
-It gives you `Request` and `Response` classes, request routing, websocket support,
+It gives you `Request` and `Response` classes, websocket support, routing,
 static files support, and a test client.
 
 **Requirements:**
@@ -72,6 +72,7 @@ You can run the application with any ASGI server, including [uvicorn](http://www
 * [Static Files](#static-files)
 * [Test Client](#test-client)
 * [Debugging](#debugging)
+* [Applications](#applications)
 
 ---
 
@@ -612,6 +613,50 @@ class App:
 
 app = DebugMiddleware(App)
 ```
+
+---
+
+## Applications
+
+Starlette also includes an `App` class that nicely ties together all of
+its other functionality.
+
+```python
+from starlette import App
+from starlette.response import PlainTextResponse
+from starlette.staticfiles import StaticFiles
+
+
+app = App()
+app.mount("/static", StaticFiles(directory="static"))
+
+
+@app.route('/')
+def homepage(request):
+    return PlainTextResponse('Hello, world!')
+
+
+@app.route('/user/{username}')
+def user(request, username):
+    return PlainTextResponse('Hello, %s!' % username)
+
+
+@app.websocket_route('/ws')
+async def websocket_endpoint(session):
+    await session.accept()
+    await session.send_text('Hello, websocket!')
+    await session.close()
+```
+
+### Adding routes to the application
+
+You can use any of the following to add handled routes to the application:
+
+* `.add_route(path, func, methods=["GET"])` - Add an HTTP route. The function may be either a coroutine or a regular function, with a signature like `func(request **kwargs) -> response`.
+* `.add_websocket_route(path, func)` - Add a websocket session route. The function must be a coroutine, with a signature like `func(session, **kwargs)`.
+* `.mount(prefix, app)` - Include an ASGI app, mounted under the given path prefix
+* `.route(path)` - Add an HTTP route, decorator style.
+* `.websocket_route(path)` - Add a WebSocket route, decorator style.
 
 ---
 

--- a/starlette/__init__.py
+++ b/starlette/__init__.py
@@ -1,3 +1,4 @@
+from starlette.app import App
 from starlette.response import (
     FileResponse,
     HTMLResponse,
@@ -12,6 +13,7 @@ from starlette.testclient import TestClient
 
 
 __all__ = (
+    "App",
     "FileResponse",
     "HTMLResponse",
     "JSONResponse",

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -31,6 +31,7 @@ def websocket_session(func):
     """
     Takes a coroutine `func(session, **kwargs)`, and returns an ASGI application.
     """
+
     def app(scope: Scope) -> ASGIInstance:
         async def awaitable(receive: Receive, send: Send) -> None:
             session = WebSocketSession(scope, receive=receive, send=send)

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -1,0 +1,59 @@
+from starlette.request import Request
+from starlette.routing import Router, Path
+from starlette.types import ASGIInstance, Receive, Scope, Send
+from starlette.websockets import WebSocketSession
+import asyncio
+
+
+def request_response(func):
+    is_coroutine = asyncio.iscoroutinefunction(func)
+
+    def app(scope: Scope) -> ASGIInstance:
+        async def awaitable(receive: Receive, send: Send) -> None:
+            request = Request(scope, receive=receive)
+            if is_coroutine:
+                response = await func(request)
+            else:
+                response = func(request)
+            await response(receive, send)
+
+        return awaitable
+
+    return app
+
+
+def websocket_session(func):
+    def app(scope: Scope) -> ASGIInstance:
+        async def awaitable(receive: Receive, send: Send) -> None:
+            session = WebSocketSession(scope, receive=receive, send=send)
+            await func(session)
+
+        return awaitable
+
+    return app
+
+
+class App:
+    def __init__(self) -> None:
+        self.router = Router(routes=[])
+
+    def add_route(self, path: str, route) -> None:
+        instance = Path(path, request_response(route))
+        self.router.routes.append(instance)
+
+    def add_websocket_route(self, path: str, route) -> None:
+        instance = Path(path, websocket_session(route))
+        self.router.routes.append(instance)
+
+    def route(self, path: str):
+        def decorator(func):
+            self.add_route(path, func)
+        return decorator
+
+    def websocket_route(self, path: str):
+        def decorator(func):
+            self.add_websocket_route(path, func)
+        return decorator
+
+    def __call__(self, scope: Scope) -> ASGIInstance:
+        return self.router(scope)

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -11,7 +11,7 @@ def request_response(func):
     def app(scope: Scope) -> ASGIInstance:
         async def awaitable(receive: Receive, send: Send) -> None:
             request = Request(scope, receive=receive)
-            kwargs = scope.get('kwargs', {})
+            kwargs = scope.get("kwargs", {})
             if is_coroutine:
                 response = await func(request, **kwargs)
             else:
@@ -27,7 +27,7 @@ def websocket_session(func):
     def app(scope: Scope) -> ASGIInstance:
         async def awaitable(receive: Receive, send: Send) -> None:
             session = WebSocketSession(scope, receive=receive, send=send)
-            kwargs = scope.get('kwargs', {})
+            kwargs = scope.get("kwargs", {})
             await func(session, **kwargs)
 
         return awaitable

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -48,11 +48,13 @@ class App:
     def route(self, path: str):
         def decorator(func):
             self.add_route(path, func)
+
         return decorator
 
     def websocket_route(self, path: str):
         def decorator(func):
             self.add_websocket_route(path, func)
+
         return decorator
 
     def __call__(self, scope: Scope) -> ASGIInstance:

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -11,10 +11,11 @@ def request_response(func):
     def app(scope: Scope) -> ASGIInstance:
         async def awaitable(receive: Receive, send: Send) -> None:
             request = Request(scope, receive=receive)
+            kwargs = scope.get('kwargs', {})
             if is_coroutine:
-                response = await func(request)
+                response = await func(request, **kwargs)
             else:
-                response = func(request)
+                response = func(request, **kwargs)
             await response(receive, send)
 
         return awaitable
@@ -26,7 +27,8 @@ def websocket_session(func):
     def app(scope: Scope) -> ASGIInstance:
         async def awaitable(receive: Receive, send: Send) -> None:
             session = WebSocketSession(scope, receive=receive, send=send)
-            await func(session)
+            kwargs = scope.get('kwargs', {})
+            await func(session, **kwargs)
 
         return awaitable
 

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -1,5 +1,5 @@
 from starlette.request import Request
-from starlette.routing import Router, Path
+from starlette.routing import Path, ProtocolRouter, Router
 from starlette.types import ASGIInstance, Receive, Scope, Send
 from starlette.websockets import WebSocketSession
 import asyncio
@@ -37,15 +37,19 @@ def websocket_session(func):
 
 class App:
     def __init__(self) -> None:
-        self.router = Router(routes=[])
+        self.http_router = Router(routes=[])
+        self.websocket_router = Router(routes=[])
+        self.router = ProtocolRouter(
+            {"http": self.http_router, "websocket": self.websocket_router}
+        )
 
     def add_route(self, path: str, route) -> None:
         instance = Path(path, request_response(route))
-        self.router.routes.append(instance)
+        self.http_router.routes.append(instance)
 
     def add_websocket_route(self, path: str, route) -> None:
         instance = Path(path, websocket_session(route))
-        self.router.routes.append(instance)
+        self.websocket_router.routes.append(instance)
 
     def route(self, path: str):
         def decorator(func):

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -1,4 +1,4 @@
-from starlette import Response
+from starlette.response import Response
 from starlette.types import Scope, ASGIApp, ASGIInstance
 import re
 import typing

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -14,23 +14,25 @@ class Route:
 
 class Path(Route):
     def __init__(
-        self, path: str, app: ASGIApp, methods: typing.Sequence[str] = ()
+        self, path: str, app: ASGIApp, methods: typing.Sequence[str] = (), protocol: str=None
     ) -> None:
         self.path = path
         self.app = app
+        self.protocol = protocol
         self.methods = methods
         regex = "^" + path + "$"
         regex = re.sub("{([a-zA-Z_][a-zA-Z0-9_]*)}", r"(?P<\1>[^/]+)", regex)
         self.path_regex = re.compile(regex)
 
     def matches(self, scope: Scope) -> typing.Tuple[bool, Scope]:
-        match = self.path_regex.match(scope["path"])
-        if match:
-            kwargs = dict(scope.get("kwargs", {}))
-            kwargs.update(match.groupdict())
-            child_scope = dict(scope)
-            child_scope["kwargs"] = kwargs
-            return True, child_scope
+        if self.protocol is None or scope['type'] == self.protocol:
+            match = self.path_regex.match(scope["path"])
+            if match:
+                kwargs = dict(scope.get("kwargs", {}))
+                kwargs.update(match.groupdict())
+                child_scope = dict(scope)
+                child_scope["kwargs"] = kwargs
+                return True, child_scope
         return False, {}
 
     def __call__(self, scope: Scope) -> ASGIInstance:

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -81,6 +81,12 @@ class Router:
         return self.not_found(scope)
 
     def not_found(self, scope: Scope) -> ASGIInstance:
+        if scope["type"] == "websocket":
+
+            async def close(receive, send):
+                await send({"type": "websocket.close"})
+
+            return close
         return Response("Not found", 404, media_type="text/plain")
 
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -14,7 +14,11 @@ class Route:
 
 class Path(Route):
     def __init__(
-        self, path: str, app: ASGIApp, methods: typing.Sequence[str] = (), protocol: str=None
+        self,
+        path: str,
+        app: ASGIApp,
+        methods: typing.Sequence[str] = (),
+        protocol: str = None,
     ) -> None:
         self.path = path
         self.app = app
@@ -25,7 +29,7 @@ class Path(Route):
         self.path_regex = re.compile(regex)
 
     def matches(self, scope: Scope) -> typing.Tuple[bool, Scope]:
-        if self.protocol is None or scope['type'] == self.protocol:
+        if self.protocol is None or scope["type"] == self.protocol:
             match = self.path_regex.match(scope["path"])
             if match:
                 kwargs = dict(scope.get("kwargs", {}))

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -142,8 +142,8 @@ class WebSocketTestSession:
         self._thread = threading.Thread(target=self._run)
         self._receive_queue.put({"type": "websocket.connect"})
         self._thread.start()
-        message = self._send_queue.get()
-        self._raise_on_close_or_exception(message)
+        message = self.receive()
+        self._raise_on_close(message)
         self.accepted_subprotocol = message["subprotocol"]
 
     def __enter__(self):
@@ -174,38 +174,45 @@ class WebSocketTestSession:
     async def _asgi_send(self, message):
         self._send_queue.put(message)
 
-    def _raise_on_close_or_exception(self, message):
-        if isinstance(message, BaseException):
-            raise message
+    def _raise_on_close(self, message):
         if message["type"] == "websocket.close":
-            raise WebSocketDisconnect(message["code"])
+            raise WebSocketDisconnect(message.get("code", 1000))
+
+    def send(self, message):
+        self._receive_queue.put(message)
 
     def send_text(self, data):
-        self._receive_queue.put({"type": "websocket.receive", "text": data})
+        self.send({"type": "websocket.receive", "text": data})
 
     def send_bytes(self, data):
-        self._receive_queue.put({"type": "websocket.receive", "bytes": data})
+        self.send({"type": "websocket.receive", "bytes": data})
 
     def send_json(self, data):
         encoded = json.dumps(data).encode("utf-8")
-        self._receive_queue.put({"type": "websocket.receive", "bytes": encoded})
+        self.send({"type": "websocket.receive", "bytes": encoded})
 
     def close(self, code=1000):
         self._receive_queue.put({"type": "websocket.disconnect", "code": code})
 
-    def receive_text(self):
+    def receive(self):
         message = self._send_queue.get()
-        self._raise_on_close_or_exception(message)
+        if isinstance(message, BaseException):
+            raise message
+        return message
+
+    def receive_text(self):
+        message = self.receive()
+        self._raise_on_close(message)
         return message["text"]
 
     def receive_bytes(self):
-        message = self._send_queue.get()
-        self._raise_on_close_or_exception(message)
+        message = self.receive()
+        self._raise_on_close(message)
         return message["bytes"]
 
     def receive_json(self):
-        message = self._send_queue.get()
-        self._raise_on_close_or_exception(message)
+        message = self.receive()
+        self._raise_on_close(message)
         encoded = message["bytes"]
         return json.loads(encoded.decode("utf-8"))
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -140,11 +140,11 @@ class WebSocketTestSession:
         self._receive_queue = queue.Queue()
         self._send_queue = queue.Queue()
         self._thread = threading.Thread(target=self._run)
-        self._receive_queue.put({"type": "websocket.connect"})
+        self.send({"type": "websocket.connect"})
         self._thread.start()
         message = self.receive()
         self._raise_on_close(message)
-        self.accepted_subprotocol = message["subprotocol"]
+        self.accepted_subprotocol = message.get("subprotocol", None)
 
     def __enter__(self):
         return self
@@ -192,7 +192,7 @@ class WebSocketTestSession:
         self.send({"type": "websocket.receive", "bytes": encoded})
 
     def close(self, code=1000):
-        self._receive_queue.put({"type": "websocket.disconnect", "code": code})
+        self.send({"type": "websocket.disconnect", "code": code})
 
     def receive(self):
         message = self._send_queue.get()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,6 +16,11 @@ async def async_homepage(request):
     return PlainTextResponse("Hello, world!")
 
 
+@app.route("/user/{username}")
+def user_page(request, username):
+    return PlainTextResponse("Hello, %s!" % username)
+
+
 @app.websocket_route("/ws")
 async def websocket_endpoint(session):
     await session.accept()
@@ -36,6 +41,12 @@ def test_async_route():
     response = client.get("/async")
     assert response.status_code == 200
     assert response.text == "Hello, world!"
+
+
+def test_route_kwargs():
+    response = client.get("/user/tomchristie")
+    assert response.status_code == 200
+    assert response.text == "Hello, tomchristie!"
 
 
 def test_websocket_route():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,20 +6,20 @@ from starlette.testclient import TestClient
 app = App()
 
 
-@app.route('/func')
+@app.route("/func")
 def func_homepage(request):
-    return PlainTextResponse('Hello, world!')
+    return PlainTextResponse("Hello, world!")
 
 
-@app.route('/async')
+@app.route("/async")
 async def async_homepage(request):
-    return PlainTextResponse('Hello, world!')
+    return PlainTextResponse("Hello, world!")
 
 
-@app.websocket_route('/ws')
+@app.websocket_route("/ws")
 async def websocket_endpoint(session):
     await session.accept()
-    await session.send_text('Hello, world!')
+    await session.send_text("Hello, world!")
     await session.close()
 
 
@@ -27,23 +27,23 @@ client = TestClient(app)
 
 
 def test_func_route():
-    response = client.get('/func')
+    response = client.get("/func")
     assert response.status_code == 200
-    assert response.text == 'Hello, world!'
+    assert response.text == "Hello, world!"
 
 
 def test_async_route():
-    response = client.get('/async')
+    response = client.get("/async")
     assert response.status_code == 200
-    assert response.text == 'Hello, world!'
+    assert response.text == "Hello, world!"
 
 
 def test_websocket_route():
-    with client.wsconnect('/ws') as session:
+    with client.wsconnect("/ws") as session:
         text = session.receive_text()
-        assert text == 'Hello, world!'
+        assert text == "Hello, world!"
 
 
 def test_400():
-    response = client.get('/404')
+    response = client.get("/404")
     assert response.status_code == 404

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,10 +1,11 @@
 from starlette import App
 from starlette.response import PlainTextResponse
+from starlette.staticfiles import StaticFiles
 from starlette.testclient import TestClient
+import os
 
 
 app = App()
-
 
 @app.route("/func")
 def func_homepage(request):
@@ -58,3 +59,16 @@ def test_websocket_route():
 def test_400():
     response = client.get("/404")
     assert response.status_code == 404
+
+
+def test_app_mount(tmpdir):
+    path = os.path.join(tmpdir, "example.txt")
+    with open(path, "w") as file:
+        file.write("<file content>")
+
+    app = App()
+    app.mount('/static', StaticFiles(directory=tmpdir))
+    client = TestClient(app)
+    response = client.get("/static/example.txt")
+    assert response.status_code == 200
+    assert response.text == "<file content>"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,6 +7,7 @@ import os
 
 app = App()
 
+
 @app.route("/func")
 def func_homepage(request):
     return PlainTextResponse("Hello, world!")
@@ -67,7 +68,7 @@ def test_app_mount(tmpdir):
         file.write("<file content>")
 
     app = App()
-    app.mount('/static', StaticFiles(directory=tmpdir))
+    app.mount("/static", StaticFiles(directory=tmpdir))
     client = TestClient(app)
     response = client.get("/static/example.txt")
     assert response.status_code == 200

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,49 @@
+from starlette import App
+from starlette.response import PlainTextResponse
+from starlette.testclient import TestClient
+
+
+app = App()
+
+
+@app.route('/func')
+def func_homepage(request):
+    return PlainTextResponse('Hello, world!')
+
+
+@app.route('/async')
+async def async_homepage(request):
+    return PlainTextResponse('Hello, world!')
+
+
+@app.websocket_route('/ws')
+async def websocket_endpoint(session):
+    await session.accept()
+    await session.send_text('Hello, world!')
+    await session.close()
+
+
+client = TestClient(app)
+
+
+def test_func_route():
+    response = client.get('/func')
+    assert response.status_code == 200
+    assert response.text == 'Hello, world!'
+
+
+def test_async_route():
+    response = client.get('/async')
+    assert response.status_code == 200
+    assert response.text == 'Hello, world!'
+
+
+def test_websocket_route():
+    with client.wsconnect('/ws') as session:
+        text = session.receive_text()
+        assert text == 'Hello, world!'
+
+
+def test_400():
+    response = client.get('/404')
+    assert response.status_code == 404

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,6 +1,7 @@
 from starlette import Response, TestClient
 from starlette.routing import Path, PathPrefix, Router, ProtocolRouter
-from starlette.websockets import WebSocketSession
+from starlette.websockets import WebSocketSession, WebSocketDisconnect
+import pytest
 
 
 def homepage(scope):
@@ -78,7 +79,10 @@ def websocket_endpoint(scope):
 
 
 mixed_protocol_app = ProtocolRouter(
-    {"http": http_endpoint, "websocket": websocket_endpoint}
+    {
+        "http": Router([Path("/", app=http_endpoint)]),
+        "websocket": Router([Path("/", app=websocket_endpoint)]),
+    }
 )
 
 
@@ -91,3 +95,6 @@ def test_protocol_switch():
 
     with client.wsconnect("/") as session:
         assert session.receive_json() == {"hello": "world"}
+
+    with pytest.raises(WebSocketDisconnect):
+        client.wsconnect("/404")


### PR DESCRIPTION
Example:

```python
from starlette import App
from starlette.response import PlainTextResponse
from starlette.staticfiles import StaticFiles


app = App()
app.mount("/static", StaticFiles(directory="static"))


@app.route('/')
def homepage(request):
    return PlainTextResponse('Hello, world!')


@app.route('/user/{username}')
def user(request, username):
    return PlainTextResponse('Hello, %s!' % username)


@app.websocket_route('/ws')
async def websocket_endpoint(session):
    await session.accept()
    await session.send_text('Hello, world!')
    await session.close()
```

* `app.add_route(path, route, methods=["GET"])` - Add an HTTP route (async or sync function)
* `app.add_websocket_route(path, route)` - Add a websocket session route (async)
* `app.mount(prefix, app)` - Submount an ASGI app, under the given path prefix
* `@app.route(path)` - Add an HTTP route, decorator style.
* `@app.websocket_route(path)` - Add a WebSocket route, decorator style.

TODO:

- [x] Protocol routing. (Right now it'll just route to paths regardless.)
- [x] WebSocket behavior on 404.
- [x] `methods=...`.
- [x] Include routed kwargs in request function calls.
- [ ] `.url_for(...)` and `name=` for routes.
- [x] `.mount()` for sub-mounting ASGI apps.
- [ ] Docs
