### PR TITLE
Exception handling

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -29,6 +29,10 @@ async def websocket_endpoint(session):
     await session.close()
 ```
 
+### Instantiating the application
+
+* `App(debug=False)` - Create a new Starlette application.
+
 ### Adding routes to the application
 
 You can use any of the following to add handled routes to the application:

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -32,8 +32,21 @@ async def websocket_endpoint(session):
 
 You can use any of the following to add handled routes to the application:
 
-* `.add_route(path, func, methods=["GET"])` - Add an HTTP route. The function may be either a coroutine or a regular function, with a signature like `func(request **kwargs) -> response`.
-* `.add_websocket_route(path, func)` - Add a websocket session route. The function must be a coroutine, with a signature like `func(session, **kwargs)`.
-* `.mount(prefix, app)` - Include an ASGI app, mounted under the given path prefix
-* `.route(path)` - Add an HTTP route, decorator style.
-* `.websocket_route(path)` - Add a WebSocket route, decorator style.
+* `app.add_route(path, func, methods=["GET"])` - Add an HTTP route. The function may be either a coroutine or a regular function, with a signature like `func(request, **kwargs) -> response`.
+* `app.add_websocket_route(path, func)` - Add a websocket session route. The function must be a coroutine, with a signature like `func(session, **kwargs)`.
+* `@app.route(path)` - Add an HTTP route, decorator style.
+* `@app.websocket_route(path)` - Add a WebSocket route, decorator style.
+
+### Submounting other applications
+
+Submounting applications is a powerful way to include reusable ASGI applications.
+
+* `app.mount(prefix, app)` - Include an ASGI app, mounted under the given path prefix
+
+### Customizing exception handling
+
+You can use either of the following to catch and handle particular types of
+exceptions that occur within the application:
+
+* `app.add_exception_handler(exc_class, handler)` - Add an error handler. The handler function may be either a coroutine or a regular function, with a signature like `func(request, exc) -> response`.
+* `@app.exception_handler(exc_class)` - Add an error handler, decorator style.

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -8,6 +8,7 @@ from starlette.staticfiles import StaticFiles
 
 
 app = App()
+app.debug = True
 app.mount("/static", StaticFiles(directory="static"))
 
 
@@ -50,3 +51,4 @@ exceptions that occur within the application:
 
 * `app.add_exception_handler(exc_class, handler)` - Add an error handler. The handler function may be either a coroutine or a regular function, with a signature like `func(request, exc) -> response`.
 * `@app.exception_handler(exc_class)` - Add an error handler, decorator style.
+* `app.debug` - Enable or disable error tracebacks in the browser.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -15,3 +15,7 @@ class App:
 
 app = DebugMiddleware(App)
 ```
+
+For a mode complete handling of exception cases you may wish to use Starlette's
+[`ExceptionMiddleware`](../exceptions) class instead, which also includes
+optional debug handling.

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -45,18 +45,40 @@ app.add_exception_handler(HTTPException, handler)
 Now if we make a request to the application, we'll get back a JSON encoded
 HTTP response.
 
+By default two types of exceptions are caught and dealt with:
+
+* `HTTPException` - Used to raise standard HTTP error codes.
+* `Exception` - Used as a catch-all handler to deal with any `500 Internal
+Server Error` responses. The `Exception` case also wraps any other exception
+handling.
+
+The catch-all `Exception` case is used to return simple `500 Internal Server Error`
+responses. During development you might want to switch the behaviour so that
+it displays an error traceback in the browser:
+
+```
+app = ExceptionMiddleware(App, debug=True)
+```
+
+This uses the same error tracebacks as the more minimal [`DebugMiddleware`](../debugging).
+
 ## ExceptionMiddleware
 
 The exception middleware catches and handles the exceptions, returning
 appropriate HTTP responses.
 
-* `ExceptionMiddleware(app)` - Instantiate the exception handler, wrapping up
-it around an inner ASGI application.
+* `ExceptionMiddleware(app, debug=False)` - Instantiate the exception handler,
+wrapping up it around an inner ASGI application.
 
 Adding handlers:
 
 * `.add_exception_handler(exc_class, handler)` - Set a handler function to run
 for the given exception class.
+
+Enabling debug mode:
+
+* `.debug` - If set to `True`, then the catch-all handler for `Exception` will
+not be used, and error tracebacks will be sent as responses instead.
 
 ## HTTPException
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -62,6 +62,10 @@ app = ExceptionMiddleware(App, debug=True)
 
 This uses the same error tracebacks as the more minimal [`DebugMiddleware`](../debugging).
 
+The exception handler currently only catches and deals with exceptions within
+HTTP requests. Any websocket exceptions will simply be raised to the server
+and result in an error log.
+
 ## ExceptionMiddleware
 
 The exception middleware catches and handles the exceptions, returning

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -10,7 +10,7 @@ from starlette.exceptions import ExceptionMiddleware, HTTPException
 
 class App:
     def __init__(self, scope):
-        raise HTTPException(403)
+        raise HTTPException(status_code=403)
 
 
 app = ExceptionMiddleware(App)
@@ -31,7 +31,7 @@ from starlette.response import JSONResponse
 
 class App:
     def __init__(self, scope):
-        raise HTTPException(403)
+        raise HTTPException(status_code=403)
 
 
 def handler(request, exc):

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -1,0 +1,67 @@
+
+Starlette includes an exception handling middleware that you can use in order
+to dispatch different classes of exceptions to different handlers.
+
+To see how this works, we'll start by with this small ASGI application:
+
+```python
+from starlette.exceptions import ExceptionMiddleware, HTTPException
+
+
+class App:
+    def __init__(self, scope):
+        raise HTTPException(403)
+
+
+app = ExceptionMiddleware(App)
+```
+
+If you run the app and make an HTTP request to it, you'll get a plain text
+response with a "403 Permission Denied" response. This is the behaviour that the
+default handler responds with when an `HTTPException` class or subclass is raised.
+
+Let's change the exception handling, so that we get JSON error responses
+instead:
+
+
+```python
+from starlette.exceptions import ExceptionMiddleware, HTTPException
+from starlette.response import JSONResponse
+
+
+class App:
+    def __init__(self, scope):
+        raise HTTPException(403)
+
+
+def handler(request, exc):
+    return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+
+
+app = ExceptionMiddleware(App)
+app.add_exception_handler(HTTPException, handler)
+```
+
+Now if we make a request to the application, we'll get back a JSON encoded
+HTTP response.
+
+## ExceptionMiddleware
+
+The exception middleware catches and handles the exceptions, returning
+appropriate HTTP responses.
+
+* `ExceptionMiddleware(app)` - Instantiate the exception handler, wrapping up
+it around an inner ASGI application.
+
+Adding handlers:
+
+* `.add_exception_handler(exc_class, handler)` - Set a handler function to run
+for the given exception class.
+
+## HTTPException
+
+The `HTTPException` class provides a base class that you can use for any
+standard HTTP error conditions. The `ExceptionMiddleware` implementation
+defaults to returning plain-text HTTP responses for any `HTTPException`.
+
+* `HTTPException(status_code, detail=None)`

--- a/docs/test_client.md
+++ b/docs/test_client.md
@@ -26,9 +26,17 @@ The test client exposes the same interface as any other `requests` session.
 In particular, note that the calls to make a request are just standard
 function calls, not awaitables.
 
-### Testing WebSocket applications
+You can use any of `requests` standard API, such as authentication, session
+cookies handling, or file uploads.
 
-You can also test websocket applications with the test client.
+By default the `TestClient` will raise any exceptions that occur in the
+application. Occasionally you might want to test the content of 500 error
+responses, rather than allowing client to raise the server exception. In this
+case you should use `client = TestClient(app, raise_server_exceptions=False)`.
+
+### Testing WebSocket sessions
+
+You can also test websocket sessions with the test client.
 
 The `requests` library will be used to build the initial handshake, meaning you
 can use the same authentication options and other headers between both http and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
     - Requests: 'requests.md'
     - WebSockets: 'websockets.md'
     - Routing: 'routing.md'
+    - Exceptions: 'exceptions.md'
     - Static Files: 'staticfiles.md'
     - Applications: 'applications.md'
     - Test Client: 'test_client.md'

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -58,7 +58,7 @@ class App:
         self.exception_middleware.set_error_handler(handler)
 
     def add_exception_handler(self, exc_class: type, handler) -> None:
-        self.exception_middleware.add_handler(exc_class, handler)
+        self.exception_middleware.add_exception_handler(exc_class, handler)
 
     def add_route(self, path: str, route, methods=None) -> None:
         if not inspect.isclass(route):

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -46,9 +46,9 @@ def websocket_session(func):
 
 
 class App:
-    def __init__(self) -> None:
+    def __init__(self, debug=False) -> None:
         self.router = Router(routes=[])
-        self.exception_middleware = ExceptionMiddleware(self.router)
+        self.exception_middleware = ExceptionMiddleware(self.router, debug=debug)
 
     def mount(self, path: str, app: ASGIApp, methods=None):
         prefix = PathPrefix(path, app=app, methods=methods)

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -50,8 +50,8 @@ class App:
         self.router = Router(routes=[])
         self.exception_middleware = ExceptionMiddleware(self.router)
 
-    def mount(self, path: str, app: ASGIApp):
-        prefix = PathPrefix(path, app=app)
+    def mount(self, path: str, app: ASGIApp, methods=None):
+        prefix = PathPrefix(path, app=app, methods=methods)
         self.router.routes.append(prefix)
 
     def set_error_handler(self, handler) -> None:
@@ -105,4 +105,5 @@ class App:
         return decorator
 
     def __call__(self, scope: Scope) -> ASGIInstance:
+        scope["app"] = self
         return self.exception_middleware(scope)

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -54,9 +54,6 @@ class App:
         prefix = PathPrefix(path, app=app, methods=methods)
         self.router.routes.append(prefix)
 
-    def set_error_handler(self, handler) -> None:
-        self.exception_middleware.set_error_handler(handler)
-
     def add_exception_handler(self, exc_class: type, handler) -> None:
         self.exception_middleware.add_exception_handler(exc_class, handler)
 
@@ -75,13 +72,6 @@ class App:
 
         instance = Path(path, route, protocol="websocket")
         self.router.routes.append(instance)
-
-    def error_handler(self):
-        def decorator(func):
-            self.set_error_handler(func)
-            return func
-
-        return decorator
 
     def exception_handler(self, exc_class: type):
         def decorator(func):

--- a/starlette/app.py
+++ b/starlette/app.py
@@ -50,7 +50,15 @@ class App:
         self.router = Router(routes=[])
         self.exception_middleware = ExceptionMiddleware(self.router, debug=debug)
 
-    def mount(self, path: str, app: ASGIApp, methods=None):
+    @property
+    def debug(self) -> bool:
+        return self.exception_middleware.debug
+
+    @debug.setter
+    def debug(self, value: bool) -> None:
+        self.exception_middleware.debug = value
+
+    def mount(self, path: str, app: ASGIApp, methods=None) -> None:
         prefix = PathPrefix(path, app=app, methods=methods)
         self.router.routes.append(prefix)
 

--- a/starlette/debug.py
+++ b/starlette/debug.py
@@ -5,10 +5,12 @@ import traceback
 
 
 def get_debug_response(request):
-    accept =request.headers.get("accept", "")
+    accept = request.headers.get("accept", "")
     if "text/html" in accept:
         exc_html = html.escape(traceback.format_exc())
-        content = f"<html><body><h1>500 Server Error</h1><pre>{exc_html}</pre></body></html>"
+        content = (
+            f"<html><body><h1>500 Server Error</h1><pre>{exc_html}</pre></body></html>"
+        )
         return HTMLResponse(content, status_code=500)
     content = traceback.format_exc()
     return PlainTextResponse(content, status_code=500)

--- a/starlette/debug.py
+++ b/starlette/debug.py
@@ -1,7 +1,17 @@
-from starlette.datastructures import Headers
+from starlette.request import Request
 from starlette.response import HTMLResponse, PlainTextResponse
 import html
 import traceback
+
+
+def get_debug_response(request):
+    accept =request.headers.get("accept", "")
+    if "text/html" in accept:
+        exc_html = html.escape(traceback.format_exc())
+        content = f"<html><body><h1>500 Server Error</h1><pre>{exc_html}</pre></body></html>"
+        return HTMLResponse(content, status_code=500)
+    content = traceback.format_exc()
+    return PlainTextResponse(content, status_code=500)
 
 
 class DebugMiddleware:
@@ -26,18 +36,11 @@ class _DebugResponder:
             asgi = self.app(self.scope)
             await asgi(receive, self.send)
         except:
-            if self.response_started:
-                raise
-            headers = Headers(self.scope.get("headers", []))
-            accept = headers.get("accept", "")
-            if "text/html" in accept:
-                exc_html = html.escape(traceback.format_exc())
-                content = f"<html><body><h1>500 Server Error</h1><pre>{exc_html}</pre></body></html>"
-                response = HTMLResponse(content, status_code=500)
-            else:
-                content = traceback.format_exc()
-                response = PlainTextResponse(content, status_code=500)
-            await response(receive, send)
+            if not self.response_started:
+                request = Request(self.scope)
+                response = get_debug_response(request)
+                await response(receive, send)
+            raise
 
     async def send(self, message):
         if message["type"] == "http.response.start":

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -1,5 +1,5 @@
 from starlette.request import Request
-from starlette.response import PlainTextResponse
+from starlette.response import PlainTextResponse, Response
 import asyncio
 import http
 
@@ -88,6 +88,8 @@ class ExceptionMiddleware:
         return app
 
     def http_exception(self, request, exc):
+        if exc.status_code in {204, 304}:
+            return Response(b'', status_code=exc.status_code)
         return PlainTextResponse(exc.detail, status_code=exc.status_code)
 
     def server_error(self, request, exc):

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -13,21 +13,21 @@ class HTTPException(Exception):
 
 
 class ExceptionMiddleware:
-    def __init__(self, app, handlers=None, error_handler=None):
+    def __init__(self, app, exception_handlers=None, error_handler=None):
         self.app = app
-        self.handlers = handlers or {}
+        self.exception_handlers = exception_handlers or {}
+        self.exception_handlers.setdefault(HTTPException, self.http_exception)
         self.error_handler = error_handler or self.server_error
-        self.handlers.setdefault(HTTPException, self.http_exception)
 
     def set_error_handler(self, handler):
         self.error_handler = handler
 
     def add_exception_handler(self, exc_class, handler):
-        self.handlers[exc_class] = handler
+        self.exception_handlers[exc_class] = handler
 
     def lookup_exception_handler(self, exc):
         for cls in type(exc).__mro__:
-            handler = self.handlers.get(cls)
+            handler = self.exception_handlers.get(cls)
             if handler is not None:
                 return handler
         return None

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -6,7 +6,7 @@ import http
 
 
 class HTTPException(Exception):
-    def __init__(self, status_code: int, detail=None):
+    def __init__(self, status_code: int, detail: str = None) -> None:
         if detail is None:
             detail = http.HTTPStatus(status_code).phrase
         self.status_code = status_code

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -22,12 +22,13 @@ class ExceptionMiddleware:
     def set_error_handler(self, handler):
         self.error_handler = handler
 
-    def add_handler(self, exc_class, handler):
+    def add_exception_handler(self, exc_class, handler):
         self.handlers[exc_class] = handler
 
-    def lookup_handler(self, exc):
-        for cls, handler in self.handlers.items():
-            if isinstance(exc, cls):
+    def lookup_exception_handler(self, exc):
+        for cls in type(exc).__mro__:
+            handler = self.handlers.get(cls)
+            if handler is not None:
                 return handler
         return None
 
@@ -52,7 +53,7 @@ class ExceptionMiddleware:
                 except BaseException as exc:
                     # Exception handling is applied to any registed exception
                     # class or subclass that occurs within the application.
-                    handler = self.lookup_handler(exc)
+                    handler = self.lookup_exception_handler(exc)
                     if handler is None:
                         # Any unhandled cases get raised to the error handler.
                         raise exc from None

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -89,7 +89,7 @@ class ExceptionMiddleware:
 
     def http_exception(self, request, exc):
         if exc.status_code in {204, 304}:
-            return Response(b'', status_code=exc.status_code)
+            return Response(b"", status_code=exc.status_code)
         return PlainTextResponse(exc.detail, status_code=exc.status_code)
 
     def server_error(self, request, exc):

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -19,7 +19,7 @@ class ExceptionMiddleware:
         self.handlers.setdefault(HTTPException, self.http_exception)
 
     def __call__(self, scope):
-        if scope['type'] != 'http':
+        if scope["type"] != "http":
             return self.app(scope)
 
         async def app(receive, send):
@@ -40,6 +40,7 @@ class ExceptionMiddleware:
                 response = await self.error_handler(request, exc)
                 await response(receive, send)
                 raise
+
         return app
 
     async def http_exception(self, request, exc):

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -91,4 +91,4 @@ class ExceptionMiddleware:
         return PlainTextResponse(exc.detail, status_code=exc.status_code)
 
     def server_error(self, request, exc):
-        return PlainTextResponse("Server Error", status_code=500)
+        return PlainTextResponse("Internal Server Error", status_code=500)

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -1,0 +1,49 @@
+from starlette.request import Request
+from starlette.response import PlainTextResponse
+import http
+
+
+class HTTPException(Exception):
+    def __init__(self, status_code, detail=None):
+        if detail is None:
+            detail = http.HTTPStatus(status_code).phrase
+        self.status_code = status_code
+        self.detail = detail
+
+
+class ExceptionMiddleware:
+    def __init__(self, app, handlers=None, error_handler=None):
+        self.app = app
+        self.handlers = handlers or {}
+        self.error_handler = error_handler or self.server_error
+        self.handlers.setdefault(HTTPException, self.http_exception)
+
+    def __call__(self, scope):
+        if scope['type'] != 'http':
+            return self.app(scope)
+
+        async def app(receive, send):
+            try:
+                try:
+                    instance = self.app(scope)
+                    await instance(receive, send)
+                except BaseException as exc:
+                    request = Request(scope, receive=receive)
+                    for cls, handler in self.handlers.items():
+                        if isinstance(exc, cls):
+                            response = await handler(request, exc)
+                            await response(receive, send)
+                            return
+                    raise exc from None
+            except BaseException as exc:
+                request = Request(scope, receive=receive)
+                response = await self.error_handler(request, exc)
+                await response(receive, send)
+                raise
+        return app
+
+    async def http_exception(self, request, exc):
+        return PlainTextResponse(exc.detail, status_code=exc.status_code)
+
+    async def server_error(self, request, exc):
+        return PlainTextResponse("Server Error", status_code=500)

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -1,3 +1,4 @@
+from starlette.exceptions import HTTPException
 from starlette.response import Response
 from starlette.types import Scope, ASGIApp, ASGIInstance
 import re
@@ -41,7 +42,7 @@ class Path(Route):
 
     def __call__(self, scope: Scope) -> ASGIInstance:
         if self.methods and scope["method"] not in self.methods:
-            return Response("Method not allowed", 405, media_type="text/plain")
+            raise HTTPException(status_code=405, detail="Method Not Allowed")
         return self.app(scope)
 
 
@@ -70,7 +71,7 @@ class PathPrefix(Route):
 
     def __call__(self, scope: Scope) -> ASGIInstance:
         if self.methods and scope["method"] not in self.methods:
-            return Response("Method not allowed", 405, media_type="text/plain")
+            raise HTTPException(status_code=405, detail="Method Not Allowed")
         return self.app(scope)
 
 
@@ -93,7 +94,7 @@ class Router:
                 await send({"type": "websocket.close"})
 
             return close
-        return Response("Not found", 404, media_type="text/plain")
+        raise HTTPException(status_code=404, detail="Not Found")
 
 
 class ProtocolRouter:

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -1,6 +1,7 @@
 from starlette.exceptions import HTTPException
 from starlette.response import PlainTextResponse
 from starlette.types import Scope, ASGIApp, ASGIInstance
+from starlette.websockets import WebSocketClose
 import re
 import typing
 
@@ -93,11 +94,7 @@ class Router:
 
     def not_found(self, scope: Scope) -> ASGIInstance:
         if scope["type"] == "websocket":
-
-            async def close(receive, send):
-                await send({"type": "websocket.close"})
-
-            return close
+            return WebSocketClose()
 
         # If we're running inside a starlette application then raise an
         # exception, so that the configurable exception handler can deal with

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -10,7 +10,7 @@ class StaticFile:
 
     def __call__(self, scope):
         if scope["method"] not in ("GET", "HEAD"):
-            return PlainTextResponse("Method not allowed", status_code=405)
+            return PlainTextResponse("Method Not Allowed", status_code=405)
         return _StaticFileResponder(scope, path=self.path)
 
 
@@ -21,7 +21,7 @@ class StaticFiles:
 
     def __call__(self, scope):
         if scope["method"] not in ("GET", "HEAD"):
-            return PlainTextResponse("Method not allowed", status_code=405)
+            return PlainTextResponse("Method Not Allowed", status_code=405)
         path = os.path.normpath(os.path.join(*scope["path"].split("/")))
         if path.startswith(".."):
             return PlainTextResponse("Not Found", status_code=404)

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -24,7 +24,7 @@ class StaticFiles:
             return PlainTextResponse("Method not allowed", status_code=405)
         path = os.path.normpath(os.path.join(*scope["path"].split("/")))
         if path.startswith(".."):
-            return PlainTextResponse("Not found", status_code=404)
+            return PlainTextResponse("Not Found", status_code=404)
         path = os.path.join(self.directory, path)
         if self.config_checked:
             check_directory = None
@@ -80,11 +80,11 @@ class _StaticFilesResponder:
         try:
             stat_result = await aio_stat(self.path)
         except FileNotFoundError:
-            response = PlainTextResponse("Not found", status_code=404)
+            response = PlainTextResponse("Not Found", status_code=404)
         else:
             mode = stat_result.st_mode
             if not stat.S_ISREG(mode):
-                response = PlainTextResponse("Not found", status_code=404)
+                response = PlainTextResponse("Not Found", status_code=404)
             else:
                 response = FileResponse(self.path, stat_result=stat_result)
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -228,7 +228,9 @@ class WebSocketTestSession:
 
 
 class _TestClient(requests.Session):
-    def __init__(self, app: typing.Callable, base_url: str, raise_exceptions=True) -> None:
+    def __init__(
+        self, app: typing.Callable, base_url: str, raise_exceptions=True
+    ) -> None:
         super(_TestClient, self).__init__()
         adapter = _ASGIAdapter(app, raise_exceptions=raise_exceptions)
         self.mount("http://", adapter)

--- a/starlette/views.py
+++ b/starlette/views.py
@@ -2,6 +2,7 @@ from starlette.exceptions import HTTPException
 from starlette.request import Request
 from starlette.response import Response, PlainTextResponse
 from starlette.types import Receive, Send, Scope
+import asyncio
 
 
 class View:
@@ -17,7 +18,16 @@ class View:
     async def dispatch(self, request: Request, **kwargs) -> Response:
         handler_name = "get" if request.method == "HEAD" else request.method.lower()
         handler = getattr(self, handler_name, self.method_not_allowed)
-        return await handler(request, **kwargs)
+        if asyncio.iscoroutinefunction(handler):
+            response = await handler(request, **kwargs)
+        else:
+            response = handler(request, **kwargs)
+        return response
 
     async def method_not_allowed(self, request: Request, **kwargs) -> Response:
-        raise HTTPException(status_code=405, detail="Method Not Allowed")
+        # If we're running inside a starlette application then raise an
+        # exception, so that the configurable exception handler can deal with
+        # returning the response. For plain ASGI apps, just return the response.
+        if "app" in self.scope:
+            raise HTTPException(status_code=405)
+        return PlainTextResponse("Method Not Allowed", status_code=405)

--- a/starlette/views.py
+++ b/starlette/views.py
@@ -1,3 +1,4 @@
+from starlette.exceptions import HTTPException
 from starlette.request import Request
 from starlette.response import Response, PlainTextResponse
 from starlette.types import Receive, Send, Scope
@@ -19,4 +20,4 @@ class View:
         return await handler(request, **kwargs)
 
     async def method_not_allowed(self, request: Request, **kwargs) -> Response:
-        return PlainTextResponse("Method not allowed", 405)
+        raise HTTPException(status_code=405, detail="Method Not Allowed")

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -151,3 +151,11 @@ class WebSocketSession(Mapping):
 
     async def close(self, code=1000):
         await self.send({"type": "websocket.close", "code": code})
+
+
+class WebSocketClose:
+    def __init__(self, code=1000):
+        self.code = code
+
+    async def __call__(self, receive, send):
+        await send({"type": "websocket.close", "code": self.code})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -103,7 +103,7 @@ def test_405():
 
 
 def test_500():
-    client = TestClient(app, raise_exceptions=False)
+    client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/500")
     assert response.status_code == 500
     assert response.json() == {"detail": "Server Error"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -125,3 +125,18 @@ def test_app_mount(tmpdir):
     response = client.post("/static/example.txt")
     assert response.status_code == 405
     assert response.text == "Method Not Allowed"
+
+
+def test_app_debug():
+    app = App()
+    app.debug = True
+
+    @app.route("/")
+    async def homepage(request):
+        raise RuntimeError()
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/")
+    assert response.status_code == 500
+    assert "RuntimeError" in response.text
+    assert app.debug

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,7 +10,7 @@ import os
 app = App()
 
 
-@app.error_handler()
+@app.exception_handler(Exception)
 async def error_500(request, exc):
     return JSONResponse({"detail": "Server Error"}, status_code=500)
 

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -64,6 +64,7 @@ def test_debug_not_http():
     """
     DebugMiddleware should just pass through any non-http messages as-is.
     """
+
     def app(scope):
         raise RuntimeError("Something went wrong")
 

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -10,7 +10,8 @@ def test_debug_text():
 
         return asgi
 
-    client = TestClient(DebugMiddleware(app))
+    app = DebugMiddleware(app)
+    client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/")
     assert response.status_code == 500
     assert response.headers["content-type"].startswith("text/plain")
@@ -24,7 +25,8 @@ def test_debug_html():
 
         return asgi
 
-    client = TestClient(DebugMiddleware(app))
+    app = DebugMiddleware(app)
+    client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/", headers={"Accept": "text/html, */*"})
     assert response.status_code == 500
     assert response.headers["content-type"].startswith("text/html")
@@ -40,7 +42,8 @@ def test_debug_after_response_sent():
 
         return asgi
 
-    client = TestClient(DebugMiddleware(app))
+    app = DebugMiddleware(app)
+    client = TestClient(app)
     with pytest.raises(RuntimeError):
         response = client.get("/")
 
@@ -50,7 +53,7 @@ def test_debug_error_during_scope():
         raise RuntimeError("Something went wrong")
 
     app = DebugMiddleware(app)
-    client = TestClient(DebugMiddleware(app))
+    client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/", headers={"Accept": "text/html, */*"})
     assert response.status_code == 500
     assert response.headers["content-type"].startswith("text/html")
@@ -58,6 +61,9 @@ def test_debug_error_during_scope():
 
 
 def test_debug_not_http():
+    """
+    DebugMiddleware should just pass through any non-http messages as-is.
+    """
     def app(scope):
         raise RuntimeError("Something went wrong")
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -38,11 +38,15 @@ app = Router(
 
 
 app = ExceptionMiddleware(app)
-client = TestClient(app, raise_exceptions=False)
+client = TestClient(app)
 
 
 def test_server_error():
-    response = client.get("/runtime_error")
+    with pytest.raises(RuntimeError):
+        response = client.get("/runtime_error")
+
+    allow_500_client = TestClient(app, raise_exceptions=False)
+    response = allow_500_client.get("/runtime_error")
     assert response.status_code == 500
     assert response.text == "Server Error"
 
@@ -59,10 +63,10 @@ def test_websockets_should_raise():
 
 
 def test_handled_exc_after_response():
-    response = client.get("/handled_exc_after_response")
+    with pytest.raises(RuntimeError):
+        client.get("/handled_exc_after_response")
+
+    allow_200_client = TestClient(app, raise_exceptions=False)
+    response = allow_200_client.get("/handled_exc_after_response")
     assert response.status_code == 200
     assert response.text == "OK"
-
-    raising_client = TestClient(app)
-    with pytest.raises(RuntimeError):
-        raising_client.get("/handled_exc_after_response")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -8,19 +8,23 @@ import pytest
 def raise_runtime_error(scope):
     async def asgi(receive, send):
         raise RuntimeError("Yikes")
+
     return asgi
 
 
 def raise_http_exception(scope):
     async def asgi(receive, send):
         raise HTTPException(406)
+
     return asgi
 
 
-app = Router(routes=[
-    Path('/runtime_error', app=raise_runtime_error),
-    Path('/not_acceptable', app=raise_http_exception),
-])
+app = Router(
+    routes=[
+        Path("/runtime_error", app=raise_runtime_error),
+        Path("/not_acceptable", app=raise_http_exception),
+    ]
+)
 
 
 app = ExceptionMiddleware(app)
@@ -30,13 +34,13 @@ client = TestClient(app, raise_exceptions=False)
 def test_server_error():
     response = client.get("/runtime_error")
     assert response.status_code == 500
-    assert response.text == 'Server Error'
+    assert response.text == "Server Error"
 
 
 def test_not_acceptable():
     response = client.get("/not_acceptable")
     assert response.status_code == 406
-    assert response.text == 'Not Acceptable'
+    assert response.text == "Not Acceptable"
 
 
 def test_websockets_should_raise():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -48,7 +48,7 @@ def test_server_error():
     allow_500_client = TestClient(app, raise_server_exceptions=False)
     response = allow_500_client.get("/runtime_error")
     assert response.status_code == 500
-    assert response.text == "Server Error"
+    assert response.text == "Internal Server Error"
 
 
 def test_not_acceptable():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -35,7 +35,7 @@ def handled_exc_after_response(scope):
     return asgi
 
 
-app = Router(
+router = Router(
     routes=[
         Path("/runtime_error", app=raise_runtime_error),
         Path("/not_acceptable", app=not_acceptable),
@@ -45,7 +45,7 @@ app = Router(
 )
 
 
-app = ExceptionMiddleware(app)
+app = ExceptionMiddleware(router)
 client = TestClient(app)
 
 
@@ -57,6 +57,15 @@ def test_server_error():
     response = allow_500_client.get("/runtime_error")
     assert response.status_code == 500
     assert response.text == "Internal Server Error"
+
+
+def test_debug_enabled():
+    app = ExceptionMiddleware(router)
+    app.debug = True
+    allow_500_client = TestClient(app, raise_server_exceptions=False)
+    response = allow_500_client.get("/runtime_error")
+    assert response.status_code == 500
+    assert "RuntimeError" in response.text
 
 
 def test_not_acceptable():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,44 @@
+from starlette.exceptions import ExceptionMiddleware, HTTPException
+from starlette.response import PlainTextResponse
+from starlette.routing import Router, Path
+from starlette.testclient import TestClient
+import pytest
+
+
+def raise_runtime_error(scope):
+    async def asgi(receive, send):
+        raise RuntimeError("Yikes")
+    return asgi
+
+
+def raise_http_exception(scope):
+    async def asgi(receive, send):
+        raise HTTPException(406)
+    return asgi
+
+
+app = Router(routes=[
+    Path('/runtime_error', app=raise_runtime_error),
+    Path('/not_acceptable', app=raise_http_exception),
+])
+
+
+app = ExceptionMiddleware(app)
+client = TestClient(app, raise_exceptions=False)
+
+
+def test_server_error():
+    response = client.get("/runtime_error")
+    assert response.status_code == 500
+    assert response.text == 'Server Error'
+
+
+def test_not_acceptable():
+    response = client.get("/not_acceptable")
+    assert response.status_code == 406
+    assert response.text == 'Not Acceptable'
+
+
+def test_websockets_should_raise():
+    with pytest.raises(RuntimeError):
+        client.websocket_connect("/runtime_error")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -31,7 +31,6 @@ app = Router(
         PathPrefix("/static", app=staticfiles, methods=["GET"]),
     ]
 )
-app = ExceptionMiddleware(app)
 
 
 def test_router():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,4 +1,5 @@
 from starlette import Response, TestClient
+from starlette.exceptions import ExceptionMiddleware
 from starlette.routing import Path, PathPrefix, Router, ProtocolRouter
 from starlette.websockets import WebSocketSession, WebSocketDisconnect
 import pytest
@@ -30,6 +31,7 @@ app = Router(
         PathPrefix("/static", app=staticfiles, methods=["GET"]),
     ]
 )
+app = ExceptionMiddleware(app)
 
 
 def test_router():
@@ -41,11 +43,11 @@ def test_router():
 
     response = client.post("/")
     assert response.status_code == 405
-    assert response.text == "Method not allowed"
+    assert response.text == "Method Not Allowed"
 
     response = client.get("/foo")
     assert response.status_code == 404
-    assert response.text == "Not found"
+    assert response.text == "Not Found"
 
     response = client.get("/users")
     assert response.status_code == 200
@@ -61,7 +63,7 @@ def test_router():
 
     response = client.post("/static/123")
     assert response.status_code == 405
-    assert response.text == "Method not allowed"
+    assert response.text == "Method Not Allowed"
 
 
 def http_endpoint(scope):

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -40,7 +40,7 @@ def test_staticfile_post(tmpdir):
     client = TestClient(app)
     response = client.post("/")
     assert response.status_code == 405
-    assert response.text == "Method not allowed"
+    assert response.text == "Method Not Allowed"
 
 
 def test_staticfile_with_directory_raises_error(tmpdir):
@@ -81,7 +81,7 @@ def test_staticfiles_post(tmpdir):
     client = TestClient(app)
     response = client.post("/example.txt")
     assert response.status_code == 405
-    assert response.text == "Method not allowed"
+    assert response.text == "Method Not Allowed"
 
 
 def test_staticfiles_with_directory_returns_404(tmpdir):
@@ -93,7 +93,7 @@ def test_staticfiles_with_directory_returns_404(tmpdir):
     client = TestClient(app)
     response = client.get("/")
     assert response.status_code == 404
-    assert response.text == "Not found"
+    assert response.text == "Not Found"
 
 
 def test_staticfiles_with_missing_file_returns_404(tmpdir):
@@ -105,7 +105,7 @@ def test_staticfiles_with_missing_file_returns_404(tmpdir):
     client = TestClient(app)
     response = client.get("/404.txt")
     assert response.status_code == 404
-    assert response.text == "Not found"
+    assert response.text == "Not Found"
 
 
 def test_staticfiles_configured_with_missing_directory(tmpdir):
@@ -151,4 +151,4 @@ def test_staticfiles_prevents_breaking_out_of_directory(tmpdir):
     # We can't test this with 'requests', so we call the app directly here.
     response = app({"method": "GET", "path": "/../example.txt"})
     assert response.status_code == 404
-    assert response.body == b"Not found"
+    assert response.body == b"Not Found"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -35,4 +35,4 @@ def test_route_kwargs():
 def test_route_method():
     response = client.post("/")
     assert response.status_code == 405
-    assert response.text == "Method not allowed"
+    assert response.text == "Method Not Allowed"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,21 +1,18 @@
 import pytest
-from starlette import App
-from starlette.views import View
 from starlette.response import PlainTextResponse
+from starlette.routing import Router, Path
 from starlette.testclient import TestClient
+from starlette.views import View
 
 
-app = App()
-
-
-@app.route("/")
-@app.route("/{username}")
 class Homepage(View):
     async def get(self, request, username=None):
         if username is None:
             return PlainTextResponse("Hello, world!")
         return PlainTextResponse(f"Hello, {username}!")
 
+
+app = Router(routes=[Path("/", Homepage), Path("/{username}", Homepage)])
 
 client = TestClient(app)
 


### PR DESCRIPTION
Adds an ExceptionHandler middleware, that allows you to delegate classes of exceptions to given handlers.

- [x] Add into `App`, with functions for adding new handlers.
- [x] Ordering of handlers so that subclasses are ordered by specificity 
- [x] Use `HTTPException` in `View` and `Router`.
- [ ] Smarter behavior for exceptions on websockets. (Perhaps `request` should be `connection` instead?)
- [x] Consider interaction with `DebugMiddleware`.
- [x] Consider interaction when response has already started.
- [x] Document `TestClient(app, raise_exceptions=False)` (and possible also add a 500 fallback when no response is sent).
- [x] Support both async and regular functions.