### PR TITLE
Add link to latest TechEmpower benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ in isolation.
 
 ## Performance
 
-Our testing shows that Starlette applications running under Uvicorn as one of
-the fastest Python frameworks available. As an example, application performance
-should roughly equal or out-perform Sanic.
+Independent TechEmpower benchmarks show Starlette applications running under Uvicorn
+as [one of the fastest Python frameworks available](https://www.techempower.com/benchmarks/#section=test&runid=14a815b6-93c1-4207-96bb-3960c29719e2&hw=ph&test=fortune&l=zijw1r-1&d=e3). *(\*)*
 
 For high throughput loads you should:
 
@@ -121,6 +120,8 @@ so you can also run under `PyPy` if your application code has parts that are
 CPU constrained.
 
 Eg. `uvicorn.run(..., http='h11', loop='asyncio')`
+
+*(\*) TechEmpower [continuous benchmarking results](https://tfb-status.techempower.com/), from 13th Sept 2018. Filtered to JavaScript, Python, and Ruby frameworks backed by Postgres, for comparision against similar candidates. To be updated to Round 17 once available.*
 
 <p align="center">&mdash; ⭐️ &mdash;</p>
 <p align="center"><i>Starlette is <a href="https://github.com/tomchristie/starlette/blob/master/LICENSE.md">BSD licensed</a> code. Designed & built in Brighton, England.</i></p>


### PR DESCRIPTION
TechEmpower have continuous benchmarking now, so we're able to link to their results for Starlette even though Round 17 isn't yet available...

![screen shot 2018-09-20 at 09 53 58](https://user-images.githubusercontent.com/647359/45807451-638ea880-bcbb-11e8-8dfb-3fcc21a762e8.png)

![screen shot 2018-09-20 at 09 53 51](https://user-images.githubusercontent.com/647359/45807475-6e493d80-bcbb-11e8-9813-c5bd1173f240.png)

![screen shot 2018-09-20 at 09 53 44](https://user-images.githubusercontent.com/647359/45807525-89b44880-bcbb-11e8-85d5-57b06b6cfe25.png)

![screen shot 2018-09-20 at 09 53 34](https://user-images.githubusercontent.com/647359/45807530-8caf3900-bcbb-11e8-8e51-a154afd0f243.png)

![screen shot 2018-09-20 at 09 54 04](https://user-images.githubusercontent.com/647359/45807532-8e78fc80-bcbb-11e8-89d3-3dfcc3c9cf37.png)

![screen shot 2018-09-20 at 09 54 12](https://user-images.githubusercontent.com/647359/45807534-9042c000-bcbb-11e8-91c8-ea8c81e41800.png)
