### PR TITLE
Missing annotations added on routing module.

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -105,7 +105,7 @@ class Router:
 
 
 class ProtocolRouter:
-    def __init__(self, protocols: typing.Dict[str, ASGIApp]):
+    def __init__(self, protocols: typing.Dict[str, ASGIApp]) -> None:
         self.protocols = protocols
 
     def __call__(self, scope: Scope) -> ASGIInstance:


### PR DESCRIPTION
Command: ` mypy starlette/routing.py --disallow-untyped-defs --ignore-missing-imports --follow-imports=silent `