### PR TITLE
Tweaks to URL datastructure

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -38,7 +38,7 @@ The request method is accessed as `request.method`.
 
 The request URL is accessed as `request.url`.
 
-The property is actually a subclass of `str`, and also exposes all the
+The property is a string-like object that exposes all the
 components that can be parsed out of the URL.
 
 For example: `request.url.path`, `request.url.port`, `request.url.scheme`.

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -4,7 +4,7 @@ from urllib.parse import parse_qsl, unquote, urlparse, ParseResult
 
 
 class URL:
-    def __init__(self, url: str = '', scope: Scope = None):
+    def __init__(self, url: str = "", scope: Scope = None):
         if scope is not None:
             assert not url, 'Cannot set both "url" and "scope".'
             scheme = scope["scheme"]
@@ -12,12 +12,7 @@ class URL:
             path = scope.get("root_path", "") + scope["path"]
             query_string = scope["query_string"]
 
-            default_port = {
-                "http": 80,
-                "https": 443,
-                "ws": 80,
-                "wss": 443,
-            }[scheme]
+            default_port = {"http": 80, "https": 443, "ws": 80, "wss": 443}[scheme]
             if port == default_port:
                 url = "%s://%s%s" % (scheme, host, path)
             else:
@@ -74,13 +69,13 @@ class URL:
         return self.components.port
 
     def replace(self, **kwargs: typing.Any) -> "URL":
-        if 'hostname' in kwargs or 'port' in kwargs:
-            hostname = kwargs.pop('hostname', self.hostname)
-            port = kwargs.pop('port', self.port)
+        if "hostname" in kwargs or "port" in kwargs:
+            hostname = kwargs.pop("hostname", self.hostname)
+            port = kwargs.pop("port", self.port)
             if port is None:
-                kwargs['netloc'] = hostname
+                kwargs["netloc"] = hostname
             else:
-                kwargs['netloc'] = '%s:%d' % (hostname, port)
+                kwargs["netloc"] = "%s:%d" % (hostname, port)
         components = self.components._replace(**kwargs)
         return URL(components.geturl())
 

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -1,12 +1,36 @@
 import typing
-from urllib.parse import parse_qsl, urlparse, ParseResult
+from starlette.types import Scope
+from urllib.parse import parse_qsl, unquote, urlparse, ParseResult
 
 
-class URL(str):
+class URL:
+    def __init__(self, url: str = '', scope: Scope = None):
+        if scope is not None:
+            assert not url, 'Cannot set both "url" and "scope".'
+            scheme = scope["scheme"]
+            host, port = scope["server"]
+            path = scope.get("root_path", "") + scope["path"]
+            query_string = scope["query_string"]
+
+            default_port = {
+                "http": 80,
+                "https": 443,
+                "ws": 80,
+                "wss": 443,
+            }[scheme]
+            if port == default_port:
+                url = "%s://%s%s" % (scheme, host, path)
+            else:
+                url = "%s://%s:%s%s" % (scheme, host, port, path)
+
+            if query_string:
+                url += "?" + unquote(query_string.decode())
+        self._url = url
+
     @property
     def components(self) -> ParseResult:
         if not hasattr(self, "_components"):
-            self._components = urlparse(self)
+            self._components = urlparse(self._url)
         return self._components
 
     @property
@@ -49,9 +73,22 @@ class URL(str):
     def port(self) -> typing.Optional[int]:
         return self.components.port
 
-    def replace_components(self, **kwargs: typing.Any) -> "URL":  # type: ignore
+    def replace(self, **kwargs: typing.Any) -> "URL":
+        if 'hostname' in kwargs or 'port' in kwargs:
+            hostname = kwargs.pop('hostname', self.hostname)
+            port = kwargs.pop('port', self.port)
+            if port is None:
+                kwargs['netloc'] = hostname
+            else:
+                kwargs['netloc'] = '%s:%d' % (hostname, port)
         components = self.components._replace(**kwargs)
         return URL(components.geturl())
+
+    def __eq__(self, other):
+        return str(self) == str(other)
+
+    def __str__(self):
+        return self._url
 
 
 # Type annotations for valid `__init__` values to QueryParams and Headers.

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -34,20 +34,7 @@ class Request(Mapping):
     @property
     def url(self) -> URL:
         if not hasattr(self, "_url"):
-            scheme = self._scope["scheme"]
-            host, port = self._scope["server"]
-            path = self._scope.get("root_path", "") + self._scope["path"]
-            query_string = self._scope["query_string"]
-
-            if (scheme == "http" and port != 80) or (scheme == "https" and port != 443):
-                url = "%s://%s:%s%s" % (scheme, host, port, path)
-            else:
-                url = "%s://%s%s" % (scheme, host, path)
-
-            if query_string:
-                url += "?" + unquote(query_string.decode())
-
-            self._url = URL(url)
+            self._url = URL(scope=self._scope)
         return self._url
 
     @property

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -119,7 +119,9 @@ class JSONResponse(Response):
 
 
 class RedirectResponse(Response):
-    def __init__(self, url: typing.Union[str, URL], status_code: int = 302, headers: dict = None) -> None:
+    def __init__(
+        self, url: typing.Union[str, URL], status_code: int = 302, headers: dict = None
+    ) -> None:
         super().__init__(content=b"", status_code=status_code, headers=headers)
         self.headers["location"] = quote_plus(str(url), safe=":/#?&=@[]!$&'()*+,;")
 

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -1,7 +1,7 @@
 from email.utils import formatdate
 from mimetypes import guess_type
 from starlette.background import BackgroundTask
-from starlette.datastructures import MutableHeaders
+from starlette.datastructures import MutableHeaders, URL
 from starlette.types import Receive, Send
 from urllib.parse import quote_plus
 import json
@@ -119,9 +119,9 @@ class JSONResponse(Response):
 
 
 class RedirectResponse(Response):
-    def __init__(self, url: str, status_code: int = 302, headers: dict = None) -> None:
+    def __init__(self, url: typing.Union[str, URL], status_code: int = 302, headers: dict = None) -> None:
         super().__init__(content=b"", status_code=status_code, headers=headers)
-        self.headers["location"] = quote_plus(url, safe=":/#?&=@[]!$&'()*+,;")
+        self.headers["location"] = quote_plus(str(url), safe=":/#?&=@[]!$&'()*+,;")
 
 
 class StreamingResponse(Response):

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -41,20 +41,7 @@ class WebSocket(Mapping):
     @property
     def url(self) -> URL:
         if not hasattr(self, "_url"):
-            scheme = self._scope["scheme"]
-            host, port = self._scope["server"]
-            path = self._scope.get("root_path", "") + self._scope["path"]
-            query_string = self._scope["query_string"]
-
-            if (scheme == "ws" and port != 80) or (scheme == "wss" and port != 443):
-                url = "%s://%s:%s%s" % (scheme, host, port, path)
-            else:
-                url = "%s://%s%s" % (scheme, host, path)
-
-            if query_string:
-                url += "?" + unquote(query_string.decode())
-
-            self._url = URL(url)
+            self._url = URL(scope=self._scope)
         return self._url
 
     @property

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -13,9 +13,18 @@ def test_url():
     assert u.query == "abc=123"
     assert u.params == ""
     assert u.fragment == "anchor"
-    new = u.replace_components(scheme="http")
+
+    new = u.replace(scheme="http")
     assert new == "http://example.org:123/path/to/somewhere?abc=123#anchor"
     assert new.scheme == "http"
+
+    new = u.replace(port=None)
+    assert new == "https://example.org/path/to/somewhere?abc=123#anchor"
+    assert new.port is None
+
+    new = u.replace(hostname='example.com')
+    assert new == "https://example.com:123/path/to/somewhere?abc=123#anchor"
+    assert new.hostname == 'example.com'
 
 
 def test_headers():

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -22,9 +22,9 @@ def test_url():
     assert new == "https://example.org/path/to/somewhere?abc=123#anchor"
     assert new.port is None
 
-    new = u.replace(hostname='example.com')
+    new = u.replace(hostname="example.com")
     assert new == "https://example.com:123/path/to/somewhere?abc=123#anchor"
-    assert new.hostname == 'example.com'
+    assert new.hostname == "example.com"
 
 
 def test_headers():

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -9,7 +9,7 @@ def test_request_url():
     def app(scope):
         async def asgi(receive, send):
             request = Request(scope, receive)
-            data = {"method": request.method, "url": request.url}
+            data = {"method": request.method, "url": str(request.url)}
             response = JSONResponse(data)
             await response(receive, send)
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -8,7 +8,7 @@ def test_websocket_url():
         async def asgi(receive, send):
             websocket = WebSocket(scope, receive=receive, send=send)
             await websocket.accept()
-            await websocket.send_json({"url": websocket.url})
+            await websocket.send_json({"url": str(websocket.url)})
             await websocket.close()
 
         return asgi


### PR DESCRIPTION
* No longer a `str` subclass.
* Use `.replace()`, not `.replace_components()`
* Support `.replace(hostname=...)` and `.replace(port=...)`
* Support instantiating with `URL(scope=...)`