### PR TITLE
Extra guardrails for ensuring correct responses with TestClient

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -117,7 +117,9 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
             nonlocal raw_kwargs, response_started, response_complete
 
             if message["type"] == "http.response.start":
-                assert not response_started, 'Received multiple "http.response.start" messages.'
+                assert (
+                    not response_started
+                ), 'Received multiple "http.response.start" messages.'
                 raw_kwargs["version"] = 11
                 raw_kwargs["status"] = message["status"]
                 raw_kwargs["reason"] = _get_reason_phrase(message["status"])
@@ -130,8 +132,12 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
                 )
                 response_started = True
             elif message["type"] == "http.response.body":
-                assert response_started, 'Received "http.response.body" without "http.response.start".'
-                assert not response_complete, 'Received "http.response.body" after response completed.'
+                assert (
+                    response_started
+                ), 'Received "http.response.body" without "http.response.start".'
+                assert (
+                    not response_complete
+                ), 'Received "http.response.body" after response completed.'
                 body = message.get("body", b"")
                 more_body = message.get("more_body", False)
                 raw_kwargs["body"].write(body)
@@ -153,7 +159,7 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
                 raise exc from None
 
         if self.raise_server_exceptions:
-            assert response_started, 'TestClient did not receive any response.'
+            assert response_started, "TestClient did not receive any response."
         elif not response_started:
             raw_kwargs = {
                 "version": 11,

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -114,9 +114,10 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
             return {"type": "http.request", "body": body_bytes}
 
         async def send(message):
-            nonlocal raw_kwargs, response_started
+            nonlocal raw_kwargs, response_started, response_complete
 
             if message["type"] == "http.response.start":
+                assert not response_started, 'Received multiple "http.response.start" messages.'
                 raw_kwargs["version"] = 11
                 raw_kwargs["status"] = message["status"]
                 raw_kwargs["reason"] = _get_reason_phrase(message["status"])
@@ -129,13 +130,17 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
                 )
                 response_started = True
             elif message["type"] == "http.response.body":
+                assert response_started, 'Received "http.response.body" without "http.response.start".'
+                assert not response_complete, 'Received "http.response.body" after response completed.'
                 body = message.get("body", b"")
                 more_body = message.get("more_body", False)
                 raw_kwargs["body"].write(body)
                 if not more_body:
                     raw_kwargs["body"].seek(0)
+                    response_complete = True
 
         response_started = False
+        response_complete = False
         raw_kwargs = {"body": io.BytesIO()}
 
         loop = asyncio.get_event_loop()
@@ -146,16 +151,19 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
         except BaseException as exc:
             if self.raise_server_exceptions:
                 raise exc from None
-            if not response_started:
-                raw_kwargs = {
-                    "version": 11,
-                    "status": 500,
-                    "reason": "Internal Server Error",
-                    "headers": [],
-                    "preload_content": False,
-                    "original_response": _MockOriginalResponse([]),
-                    "body": io.BytesIO(),
-                }
+
+        if self.raise_server_exceptions:
+            assert response_started, 'TestClient did not receive any response.'
+        elif not response_started:
+            raw_kwargs = {
+                "version": 11,
+                "status": 500,
+                "reason": "Internal Server Error",
+                "headers": [],
+                "preload_content": False,
+                "original_response": _MockOriginalResponse([]),
+                "body": io.BytesIO(),
+            }
 
         raw = requests.packages.urllib3.HTTPResponse(**raw_kwargs)
         return self.build_response(request, raw)


### PR DESCRIPTION
Catch failure cases when incorrect ASGI messages are sent.