### PR TITLE
Don't partially enforce CORS server-side

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -176,6 +176,8 @@ def test_cors_allow_origin_regex():
     assert response.headers["access-control-allow-origin"] == "https://example.org"
 
     # Test diallowed standard response
+    # Note that enforcement is a browser concern. The disallowed-ness is reflected
+    # in the lack of an "access-control-allow-origin" header in the response.
     headers = {"Origin": "http://example.org"}
     response = client.get("/", headers=headers)
     assert response.status_code == 200

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -175,11 +175,12 @@ def test_cors_allow_origin_regex():
     assert response.text == "Homepage"
     assert response.headers["access-control-allow-origin"] == "https://example.org"
 
-    # Test disallowed origin
+    # Test diallowed standard response
     headers = {"Origin": "http://example.org"}
     response = client.get("/", headers=headers)
-    assert response.status_code == 400
-    assert response.text == "Disallowed CORS origin"
+    assert response.status_code == 200
+    assert response.text == "Homepage"
+    assert "access-control-allow-origin" not in response.headers
 
     # Test pre-flight response
     headers = {
@@ -192,3 +193,14 @@ def test_cors_allow_origin_regex():
     assert response.text == "OK"
     assert response.headers["access-control-allow-origin"] == "https://another.com"
     assert response.headers["access-control-allow-headers"] == "X-Example"
+
+    # Test disallowed pre-flight response
+    headers = {
+        "Origin": "http://another.com",
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "X-Example",
+    }
+    response = client.options("/", headers=headers)
+    assert response.status_code == 400
+    assert response.text == "Disallowed CORS origin"
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
Refs #92

* Use `compiled_allow_origin_regex` variable, for consistent typing.
* Ensure the `allowed_origin_regex` does not strictly override `allow_origins` - both may be used.
* Don't partial enforce CORS server-side. (If we want to do enforcement then we'll want to also check headers, credentials, etc...)