### PR TITLE
Push black linting into ./scripts/test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ install:
 
 script:
     - scripts/test
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then scripts/lint; fi
 
 after_script:
     - codecov

--- a/scripts/lint
+++ b/scripts/lint
@@ -7,4 +7,4 @@ fi
 
 set -x
 
-${PREFIX}black starlette tests --check
+${PREFIX}black starlette tests

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,7 @@ export PYTHON_VERSION=`python -c "$VERSION_SCRIPT"`
 set -x
 
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
-if [[ "${PYTHON_VERSION}" == '3.7' ]]; then
+if [ "${PYTHON_VERSION}" = '3.7' ]; then
     echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
 else
     ${PREFIX}black starlette tests --check

--- a/scripts/test
+++ b/scripts/test
@@ -8,3 +8,4 @@ fi
 set -x
 
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
+${PREFIX}black starlette tests --check

--- a/scripts/test
+++ b/scripts/test
@@ -5,7 +5,14 @@ if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
 
+export VERSION_SCRIPT="import sys; print('%s.%s' % sys.version_info[0:2])"
+export PYTHON_VERSION=`python -c "$VERSION_SCRIPT"`
+
 set -x
 
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
-${PREFIX}black starlette tests --check
+if [[ $PYTHON_VERSION == "3.7" ]]; then
+    echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
+else
+    ${PREFIX}black starlette tests --check
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,7 @@ export PYTHON_VERSION=`python -c "$VERSION_SCRIPT"`
 set -x
 
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
-if [[ $PYTHON_VERSION == "3.7" ]]; then
+if [ $PYTHON_VERSION == "3.7" ]; then
     echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
 else
     ${PREFIX}black starlette tests --check

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,7 @@ export PYTHON_VERSION=`python -c "$VERSION_SCRIPT"`
 set -x
 
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
-if [ $PYTHON_VERSION == "3.7" ]; then
+if [[ "${PYTHON_VERSION}" == '3.7' ]]; then
     echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
 else
     ${PREFIX}black starlette tests --check

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -4,7 +4,7 @@ from urllib.parse import parse_qsl, unquote, urlparse, ParseResult
 
 
 class URL:
-    def __init__(self, url: str = "", scope: Scope = None):
+    def __init__(self, url: str = "", scope: Scope = None) -> None:
         if scope is not None:
             assert not url, 'Cannot set both "url" and "scope".'
             scheme = scope["scheme"]

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -16,7 +16,6 @@ class Request(Mapping):
         self._scope = scope
         self._receive = receive
         self._stream_consumed = False
-        self._cookies = None
 
     def __getitem__(self, key: str) -> str:
         return self._scope[key]
@@ -52,14 +51,15 @@ class Request(Mapping):
 
     @property
     def cookies(self) -> typing.Dict[str, str]:
-        if self._cookies is None:
-            self._cookies = {}
+        if not hasattr(self, "_cookies"):
+            cookies = {}
             cookie_header = self.headers.get("cookie")
             if cookie_header:
                 cookie = http.cookies.SimpleCookie()
                 cookie.load(cookie_header)
                 for key, morsel in cookie.items():
-                    self._cookies[key] = morsel.value
+                    cookies[key] = morsel.value
+            self._cookies = cookies
         return self._cookies
 
     async def stream(self) -> typing.AsyncGenerator[bytes, None]:


### PR DESCRIPTION
* Fix some annotations.
* Push black linting into `scripts/test`, and instead use `scripts/lint` to cleanup, rather than check.