### PR TITLE
Add support for `app.on_event("startup")` and `app.on_event("cleanup")`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ install:
 
 script:
     - scripts/test
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then scripts/lint; fi
 
 after_script:
     - codecov

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -28,6 +28,11 @@ async def websocket_endpoint(websocket):
     await websocket.accept()
     await websocket.send_text('Hello, websocket!')
     await websocket.close()
+
+
+@app.on_event('startup')
+def startup():
+    print('Ready to go')
 ```
 
 ### Instantiating the application

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,61 @@
+
+Starlette applications can register multiple event handlers for dealing with
+code than needs to run before the application starts up, or when the application
+is shutting down.
+
+## Registering events
+
+These event handlers can either be `async` coroutines, or regular syncronous
+functions.
+
+The event handlers are registered with a decorator syntax, like so:
+
+```python
+from starlette.applications import Starlette
+
+
+app = Starlette()
+
+@app.on_event('startup')
+async def open_database_connection_pool():
+    ...
+
+@app.on_event('cleanup')
+async def close_database_connection_pool():
+    ...
+
+```
+
+Starlette will not start serving any incoming requests until all of the
+registered startup handlers have completed.
+
+The cleanup handlers will run once all connections have been closed, and
+any in-process background tasks have completed.
+
+**Note**: The ASGI lifespan protocol has only recently been added to the spec,
+and is only currently supported by the `uvicorn` server. Make sure to use the
+latest `uvicorn` release if you need startup/cleanup support.
+
+## Running event handers in tests
+
+You might want to explicitly call into your event handlers in any test setup
+or test teardown code.
+
+Alternatively, Starlette provides a context manager that ensures the
+lifespan events are called.
+
+```python
+from example import app
+from starlette.lifespan import LifespanContext
+from starlette.testclient import TestClient
+
+
+def test_homepage():
+    with LifespanContext(app):
+        # Application 'startup' handlers are called on entering the block.
+        client = TestClient(app)
+        response = client.get("/")
+        assert response.status_code == 200
+
+    # Application 'cleanup' handlers are called on exiting the block.
+```

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -41,6 +41,7 @@ app.add_middleware(CORSMiddleware, allow_origins=['*'])
 The following arguments are supported:
 
 * `allow_origins` - A list of origins that should be permitted to make cross-origin requests. eg. `['https://example.org', 'https://www.example.org']`. You can use `['*']` to allow any origin.
+* `allow_origin_regex` - A regex string to match against origins that should be permitted to make cross-origin requests. eg. `'https://.*\.example\.org'`.
 * `allow_methods` - A list of HTTP methods that should be allowed for cross-origin requests. Defaults to `['GET']`. You can use `['*']` to allow all standard methods.
 * `allow_headers` - A list of HTTP request headers that should be supported for cross-origin requests. Defaults to `[]`. You can use `['*']` to allow all headers. The `Accept`, `Accept-Language`, `Content-Language` and `Content-Type` headers are always allowed for CORS requests.
 * `allow_credentials` - Indicate that cookies should be supported for cross-origin requests. Defaults to `False`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
     - Endpoints: 'endpoints.md'
     - Middleware: 'middleware.md'
     - Static Files: 'staticfiles.md'
+    - Events: 'events.md'
     - Background Tasks: 'background.md'
     - Exceptions: 'exceptions.md'
     - Debug: 'debug.md'

--- a/scripts/lint
+++ b/scripts/lint
@@ -7,4 +7,4 @@ fi
 
 set -x
 
-${PREFIX}black starlette tests --check
+${PREFIX}black starlette tests

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,7 @@ export PYTHON_VERSION=`python -c "$VERSION_SCRIPT"`
 set -x
 
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
-if [[ "${PYTHON_VERSION}" == '3.7' ]]; then
+if [ "${PYTHON_VERSION}" = '3.7' ]; then
     echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
 else
     ${PREFIX}black starlette tests --check

--- a/scripts/test
+++ b/scripts/test
@@ -8,3 +8,4 @@ fi
 set -x
 
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
+${PREFIX}black starlette tests --check

--- a/scripts/test
+++ b/scripts/test
@@ -5,7 +5,14 @@ if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
 
+export VERSION_SCRIPT="import sys; print('%s.%s' % sys.version_info[0:2])"
+export PYTHON_VERSION=`python -c "$VERSION_SCRIPT"`
+
 set -x
 
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
-${PREFIX}black starlette tests --check
+if [[ $PYTHON_VERSION == "3.7" ]]; then
+    echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
+else
+    ${PREFIX}black starlette tests --check
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,7 @@ export PYTHON_VERSION=`python -c "$VERSION_SCRIPT"`
 set -x
 
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
-if [[ $PYTHON_VERSION == "3.7" ]]; then
+if [ $PYTHON_VERSION == "3.7" ]; then
     echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
 else
     ${PREFIX}black starlette tests --check

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,7 @@ export PYTHON_VERSION=`python -c "$VERSION_SCRIPT"`
 set -x
 
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
-if [ $PYTHON_VERSION == "3.7" ]; then
+if [[ "${PYTHON_VERSION}" == '3.7' ]]; then
     echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
 else
     ${PREFIX}black starlette tests --check

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -4,7 +4,7 @@ from urllib.parse import parse_qsl, unquote, urlparse, ParseResult
 
 
 class URL:
-    def __init__(self, url: str = "", scope: Scope = None):
+    def __init__(self, url: str = "", scope: Scope = None) -> None:
         if scope is not None:
             assert not url, 'Cannot set both "url" and "scope".'
             scheme = scope["scheme"]

--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -10,6 +10,7 @@ from starlette.types import Receive, Send, Scope
 
 class HTTPEndpoint:
     def __init__(self, scope: Scope) -> None:
+        assert scope["type"] == "http"
         self.scope = scope
 
     async def __call__(self, receive: Receive, send: Send) -> None:
@@ -43,6 +44,7 @@ class WebSocketEndpoint:
     encoding = None  # May be "text", "bytes", or "json".
 
     def __init__(self, scope: Scope) -> None:
+        assert scope["type"] == "websocket"
         self.scope = scope
 
     async def __call__(self, receive: Receive, send: Send) -> None:

--- a/starlette/lifespan.py
+++ b/starlette/lifespan.py
@@ -14,13 +14,14 @@ class LifespanHandler:
     def on_event(self, event_type: str):
         assert event_type in ("startup", "cleanup")
 
-        def func(handler):
+        def decorator(func):
             if event_type == "startup":
-                self.startup_handlers.append(handler)
+                self.startup_handlers.append(func)
             else:
-                self.cleanup_handlers.append(handler)
+                self.cleanup_handlers.append(func)
+            return func
 
-        return func
+        return decorator
 
     async def run_startup(self) -> None:
         for handler in self.startup_handlers:

--- a/starlette/lifespan.py
+++ b/starlette/lifespan.py
@@ -1,0 +1,99 @@
+import asyncio
+import logging
+import traceback
+
+
+STATE_TRANSITION_ERROR = "Got invalid state transition on lifespan protocol."
+
+
+class LifespanHandler:
+    def __init__(self):
+        self.startup_handlers = []
+        self.cleanup_handlers = []
+
+    def on_event(self, event_type: str):
+        assert event_type in ("startup", "cleanup")
+
+        def func(handler):
+            if event_type == "startup":
+                self.startup_handlers.append(handler)
+            else:
+                self.cleanup_handlers.append(handler)
+
+        return func
+
+    async def run_startup(self) -> None:
+        for handler in self.startup_handlers:
+            if asyncio.iscoroutinefunction(handler):
+                await handler()
+            else:
+                handler()
+
+    async def run_cleanup(self) -> None:
+        for handler in self.cleanup_handlers:
+            if asyncio.iscoroutinefunction(handler):
+                await handler()
+            else:
+                handler()
+
+    def __call__(self, scope):
+        assert scope["type"] == "lifespan"
+        return self.run_lifespan
+
+    async def run_lifespan(self, receive, send):
+        message = await receive()
+        assert message["type"] == "lifespan.startup"
+        await self.run_startup()
+        await send({"type": "lifespan.startup.complete"})
+        message = await receive()
+        assert message["type"] == "lifespan.cleanup"
+        await self.run_cleanup()
+        await send({"type": "lifespan.cleanup.complete"})
+
+
+class LifespanContext:
+    def __init__(self, app, startup_timeout=10, cleanup_timeout=10):
+        self.startup_timeout = startup_timeout
+        self.cleanup_timeout = cleanup_timeout
+        self.startup_event = asyncio.Event()
+        self.cleanup_event = asyncio.Event()
+        self.receive_queue = asyncio.Queue()
+        self.asgi = app({"type": "lifespan"})
+
+    def __enter__(self):
+        loop = asyncio.get_event_loop()
+        loop.create_task(self.run_lifespan())
+        loop.run_until_complete(self.wait_startup())
+
+    def __exit__(self, exc_type, exc, tb):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.wait_cleanup())
+
+    async def run_lifespan(self):
+        try:
+            await self.asgi(self.receive, self.send)
+        finally:
+            self.startup_event.set()
+            self.cleanup_event.set()
+
+    async def send(self, message):
+        if message["type"] == "lifespan.startup.complete":
+            assert not self.startup_event.is_set(), STATE_TRANSITION_ERROR
+            assert not self.cleanup_event.is_set(), STATE_TRANSITION_ERROR
+            self.startup_event.set()
+        else:
+            assert message["type"] == "lifespan.cleanup.complete"
+            assert self.startup_event.is_set(), STATE_TRANSITION_ERROR
+            assert not self.cleanup_event.is_set(), STATE_TRANSITION_ERROR
+            self.cleanup_event.set()
+
+    async def receive(self):
+        return await self.receive_queue.get()
+
+    async def wait_startup(self):
+        await self.receive_queue.put({"type": "lifespan.startup"})
+        await asyncio.wait_for(self.startup_event.wait(), timeout=self.startup_timeout)
+
+    async def wait_cleanup(self):
+        await self.receive_queue.put({"type": "lifespan.cleanup"})
+        await asyncio.wait_for(self.cleanup_event.wait(), timeout=self.cleanup_timeout)

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -16,7 +16,6 @@ class Request(Mapping):
         self._scope = scope
         self._receive = receive
         self._stream_consumed = False
-        self._cookies = None
 
     def __getitem__(self, key: str) -> str:
         return self._scope[key]
@@ -52,14 +51,15 @@ class Request(Mapping):
 
     @property
     def cookies(self) -> typing.Dict[str, str]:
-        if self._cookies is None:
-            self._cookies = {}
+        if not hasattr(self, "_cookies"):
+            cookies = {}
             cookie_header = self.headers.get("cookie")
             if cookie_header:
                 cookie = http.cookies.SimpleCookie()
                 cookie.load(cookie_header)
                 for key, morsel in cookie.items():
-                    self._cookies[key] = morsel.value
+                    cookies[key] = morsel.value
+            self._cookies = cookies
         return self._cookies
 
     async def stream(self) -> typing.AsyncGenerator[bytes, None]:

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -86,6 +86,8 @@ class Router:
         self.default = self.not_found if default is None else default
 
     def __call__(self, scope: Scope) -> ASGIInstance:
+        assert scope["type"] in ("http", "websocket")
+
         for route in self.routes:
             matched, child_scope = route.matches(scope)
             if matched:

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -12,6 +12,7 @@ class StaticFile:
         self.path = path
 
     def __call__(self, scope: Scope) -> ASGIInstance:
+        assert scope["type"] == "http"
         if scope["method"] not in ("GET", "HEAD"):
             return PlainTextResponse("Method Not Allowed", status_code=405)
         return _StaticFileResponder(scope, path=self.path)
@@ -23,6 +24,7 @@ class StaticFiles:
         self.config_checked = False
 
     def __call__(self, scope: Scope) -> ASGIInstance:
+        assert scope["type"] == "http"
         if scope["method"] not in ("GET", "HEAD"):
             return PlainTextResponse("Method Not Allowed", status_code=405)
         path = os.path.normpath(os.path.join(*scope["path"].split("/")))

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,0 +1,74 @@
+from starlette.applications import Starlette
+from starlette.lifespan import LifespanHandler, LifespanContext
+
+
+def test_lifespan_handler():
+    startup_complete = False
+    cleanup_complete = False
+    handler = LifespanHandler()
+
+    @handler.on_event("startup")
+    def run_startup():
+        nonlocal startup_complete
+        startup_complete = True
+
+    @handler.on_event("cleanup")
+    def run_cleanup():
+        nonlocal cleanup_complete
+        cleanup_complete = True
+
+    assert not startup_complete
+    assert not cleanup_complete
+    with LifespanContext(handler):
+        assert startup_complete
+        assert not cleanup_complete
+    assert startup_complete
+    assert cleanup_complete
+
+
+def test_async_lifespan_handler():
+    startup_complete = False
+    cleanup_complete = False
+    handler = LifespanHandler()
+
+    @handler.on_event("startup")
+    async def run_startup():
+        nonlocal startup_complete
+        startup_complete = True
+
+    @handler.on_event("cleanup")
+    async def run_cleanup():
+        nonlocal cleanup_complete
+        cleanup_complete = True
+
+    assert not startup_complete
+    assert not cleanup_complete
+    with LifespanContext(handler):
+        assert startup_complete
+        assert not cleanup_complete
+    assert startup_complete
+    assert cleanup_complete
+
+
+def test_app_lifespan():
+    startup_complete = False
+    cleanup_complete = False
+    app = Starlette()
+
+    @app.on_event("startup")
+    def run_startup():
+        nonlocal startup_complete
+        startup_complete = True
+
+    @app.on_event("cleanup")
+    def run_cleanup():
+        nonlocal cleanup_complete
+        cleanup_complete = True
+
+    assert not startup_complete
+    assert not cleanup_complete
+    with LifespanContext(app):
+        assert startup_complete
+        assert not cleanup_complete
+    assert startup_complete
+    assert cleanup_complete

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -150,6 +150,6 @@ def test_staticfiles_prevents_breaking_out_of_directory(tmpdir):
 
     app = StaticFiles(directory=directory)
     # We can't test this with 'requests', so we call the app directly here.
-    response = app({"method": "GET", "path": "/../example.txt"})
+    response = app({"type": "http", "method": "GET", "path": "/../example.txt"})
     assert response.status_code == 404
     assert response.body == b"Not Found"


### PR DESCRIPTION
Closes #64.

Example:

```python
from starlette.applications import Starlette
from starlette.responses import JSONResponse
import uvicorn

app = Starlette()

@app.route('/')
def homepage(request):
    return JSONResponse({'hello': 'world'})

@app.on_event('startup')
async def startup():
    pass

@app.on_event('cleanup')
async def cleanup():
    print('Cleanup')


if __name__ == '__main__':
    uvicorn.run(app, host='0.0.0.0', port=8000)
```

Requires the latest version of uvicorn (0.3.11), which adds ASGI lifespan support.

---

**Docs**:


Starlette applications can register multiple event handlers for dealing with
code than needs to run before the application starts up, or when the application
is shutting down.

## Registering events

These event handlers can either be `async` coroutines, or regular syncronous
functions.

The event handlers are registered with a decorator syntax, like so:

```python
from starlette.applications import Starlette


app = Starlette()

@app.on_event('startup')
async def open_database_connection_pool():
    ...

@app.on_event('cleanup')
async def close_database_connection_pool():
    ...

```

Starlette will not start serving any incoming requests until all of the
registered startup handlers have completed.

The cleanup handlers will run once all connections have been closed, and
any in-process background tasks have completed.

**Note**: The ASGI lifespan protocol has only recently been added to the spec,
and is only currently supported by the `uvicorn` server. Make sure to use the
latest `uvicorn` release if you need startup/cleanup support.

## Running event handers in tests

You might want to explicitly call into your event handlers in any test setup
or test teardown code.

Alternatively, Starlette provides a context manager that ensures the
lifespan events are called.

```python
from example import app
from starlette.lifespan import LifespanContext
from starlette.testclient import TestClient


def test_homepage():
    with LifespanContext(app):
        # Application 'startup' handlers are called on entering the block.
        client = TestClient(app)
        response = client.get("/")
        assert response.status_code == 200

    # Application 'cleanup' handlers are called on exiting the block.
```