### PR TITLE
Add `scope=...` arguments to Headers, QueryParams, URL

### DIFF
--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -223,7 +223,7 @@ class MultiPartParser:
                     header_field = b""
                     header_value = b""
                 elif message_type == MultiPartMessage.HEADERS_FINISHED:
-                    headers = Headers(raw_headers)
+                    headers = Headers(raw=raw_headers)
                     content_disposition = headers.get("Content-Disposition")
                     disposition, options = parse_options_header(content_disposition)
                     field_name = options[b"name"].decode("latin-1")

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -66,7 +66,7 @@ class CORSMiddleware:
     def __call__(self, scope: Scope) -> ASGIInstance:
         if scope["type"] == "http":
             method = scope["method"]
-            headers = Headers(scope["headers"])
+            headers = Headers(scope=scope)
             origin = headers.get("origin")
 
             if origin is not None:
@@ -145,7 +145,7 @@ class CORSMiddleware:
             return
 
         message.setdefault("headers", [])
-        headers = MutableHeaders(message["headers"])
+        headers = MutableHeaders(scope=message)
         origin = request_headers["Origin"]
         has_cookie = "cookie" in request_headers
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -12,7 +12,7 @@ class GZipMiddleware:
 
     def __call__(self, scope: Scope) -> ASGIInstance:
         if scope["type"] == "http":
-            headers = Headers(scope["headers"])
+            headers = Headers(scope=scope)
             if "gzip" in headers.get("Accept-Encoding", ""):
                 return GZipResponder(self.app, scope, self.minimum_size)
         return self.app(scope)
@@ -52,7 +52,7 @@ class GZipResponder:
                 self.gzip_file.close()
                 body = self.gzip_buffer.getvalue()
 
-                headers = MutableHeaders(self.initial_message["headers"])
+                headers = MutableHeaders(raw=self.initial_message["headers"])
                 headers["Content-Encoding"] = "gzip"
                 headers["Content-Length"] = str(len(body))
                 headers.add_vary_header("Accept-Encoding")
@@ -62,7 +62,7 @@ class GZipResponder:
                 await self.send(message)
             else:
                 # Initial body in streaming GZip response.
-                headers = MutableHeaders(self.initial_message["headers"])
+                headers = MutableHeaders(raw=self.initial_message["headers"])
                 headers["Content-Encoding"] = "gzip"
                 headers.add_vary_header("Accept-Encoding")
                 del headers["Content-Length"]

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -14,7 +14,7 @@ class TrustedHostMiddleware:
 
     def __call__(self, scope: Scope) -> ASGIInstance:
         if scope["type"] in ("http", "websocket") and not self.allow_any:
-            headers = Headers(scope["headers"])
+            headers = Headers(scope=scope)
             host = headers.get("host")
             if host not in self.allowed_hosts:
                 return PlainTextResponse("Invalid host header", status_code=400)

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -46,14 +46,13 @@ class Request(Mapping):
     @property
     def headers(self) -> Headers:
         if not hasattr(self, "_headers"):
-            self._headers = Headers(self._scope["headers"])
+            self._headers = Headers(scope=self._scope)
         return self._headers
 
     @property
     def query_params(self) -> QueryParams:
         if not hasattr(self, "_query_params"):
-            query_string = self._scope["query_string"].decode()
-            self._query_params = QueryParams(query_string)
+            self._query_params = QueryParams(scope=self._scope)
         return self._query_params
 
     @property

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -78,7 +78,7 @@ class Response:
     @property
     def headers(self) -> MutableHeaders:
         if not hasattr(self, "_headers"):
-            self._headers = MutableHeaders(self.raw_headers)
+            self._headers = MutableHeaders(raw=self.raw_headers)
         return self._headers
 
     def set_cookie(

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -47,14 +47,13 @@ class WebSocket(Mapping):
     @property
     def headers(self) -> Headers:
         if not hasattr(self, "_headers"):
-            self._headers = Headers(self._scope["headers"])
+            self._headers = Headers(scope=self._scope)
         return self._headers
 
     @property
     def query_params(self) -> QueryParams:
         if not hasattr(self, "_query_params"):
-            query_string = self._scope["query_string"].decode()
-            self._query_params = QueryParams(query_string)
+            self._query_params = QueryParams(scope=self._scope)
         return self._query_params
 
     async def receive(self) -> Message:

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -14,7 +14,7 @@ class TrustedHostMiddleware:
         self.hostname = hostname
 
     def __call__(self, scope):
-        headers = Headers(scope["headers"])
+        headers = Headers(scope=scope)
         if headers.get("host") != self.hostname:
             return PlainTextResponse("Invalid host header", status_code=400)
         return self.app(scope)

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -45,7 +45,7 @@ def test_url_from_scope():
 
 
 def test_headers():
-    h = Headers([(b"a", b"123"), (b"a", b"456"), (b"b", b"789")])
+    h = Headers(raw=[(b"a", b"123"), (b"a", b"456"), (b"b", b"789")])
     assert "a" in h
     assert "A" in h
     assert "b" in h
@@ -61,8 +61,13 @@ def test_headers():
     assert list(h) == [("a", "123"), ("a", "456"), ("b", "789")]
     assert dict(h) == {"a": "123", "b": "789"}
     assert repr(h) == "Headers([('a', '123'), ('a', '456'), ('b', '789')])"
-    assert h == Headers([(b"a", b"123"), (b"b", b"789"), (b"a", b"456")])
+    assert h == Headers(raw=[(b"a", b"123"), (b"b", b"789"), (b"a", b"456")])
     assert h != [(b"a", b"123"), (b"A", b"456"), (b"b", b"789")]
+
+    h = Headers({"a": "123", "b": "789"})
+    assert h["A"] == "123"
+    assert h["B"] == "789"
+    assert h.raw == [(b"a", b"123"), (b"b", b"789")]
 
 
 def test_mutable_headers():
@@ -78,10 +83,11 @@ def test_mutable_headers():
     assert dict(h) == {"a": "2", "b": "4"}
     del h["a"]
     assert dict(h) == {"b": "4"}
+    assert h.raw == [(b"b", b"4")]
 
 
 def test_headers_mutablecopy():
-    h = Headers([(b"a", b"123"), (b"a", b"456"), (b"b", b"789")])
+    h = Headers(raw=[(b"a", b"123"), (b"a", b"456"), (b"b", b"789")])
     c = h.mutablecopy()
     assert c.items() == [("a", "123"), ("a", "456"), ("b", "789")]
     c["a"] = "abc"
@@ -89,7 +95,7 @@ def test_headers_mutablecopy():
 
 
 def test_queryparams():
-    q = QueryParams([("a", "123"), ("a", "456"), ("b", "789")])
+    q = QueryParams(query_string="a=123&a=456&b=789")
     assert "a" in q
     assert "A" not in q
     assert "c" not in q
@@ -102,12 +108,13 @@ def test_queryparams():
     assert q.items() == [("a", "123"), ("a", "456"), ("b", "789")]
     assert list(q) == [("a", "123"), ("a", "456"), ("b", "789")]
     assert dict(q) == {"a": "123", "b": "789"}
-    assert repr(q) == "QueryParams([('a', '123'), ('a', '456'), ('b', '789')])"
+    assert str(q) == "a=123&a=456&b=789"
+    assert repr(q) == "QueryParams(query_string='a=123&a=456&b=789')"
     assert QueryParams({"a": "123", "b": "456"}) == QueryParams(
-        [("a", "123"), ("b", "456")]
+        query_string="a=123&b=456"
     )
-    assert QueryParams({"a": "123", "b": "456"}) == {"b": "456", "a": "123"}
-    assert QueryParams({"a": "123", "b": "456"}) == [("b", "456"), ("a", "123")]
-    assert {"b": "456", "a": "123"} == QueryParams({"a": "123", "b": "456"})
-    assert [("b", "456"), ("a", "123")] == QueryParams({"a": "123", "b": "456"})
-    assert QueryParams() == {}
+    assert QueryParams({"a": "123", "b": "456"}) != {"b": "456", "a": "123"}
+    assert QueryParams({"a": "123", "b": "456"}) == QueryParams(
+        {"b": "456", "a": "123"}
+    )
+    assert QueryParams() == QueryParams({})


### PR DESCRIPTION
`URL("https://example.org/")`
`URL(scope=scope)`

`Headers({"accept": "application/json"})`
`Headers(raw=[(b'accept', 'application/json'])`
`Headers(scope=scope)`

`QueryParams({"a": "123", "b": "456})`
`QueryParams(query_string="a=123&b=456")`
`QueryParams(scope=scope)`
