### PR TITLE
Support a function-based interface for adding events on LifespanHandler

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -80,6 +80,9 @@ class Starlette:
     def add_exception_handler(self, exc_class: type, handler: typing.Callable) -> None:
         self.exception_middleware.add_exception_handler(exc_class, handler)
 
+    def add_event_handler(self, event_type: str, func: typing.Callable) -> None:
+        self.lifespan_handler.add_event_handler(event_type, func)
+
     def add_route(
         self, path: str, route: typing.Callable, methods: typing.Sequence[str] = None
     ) -> None:

--- a/starlette/lifespan.py
+++ b/starlette/lifespan.py
@@ -15,16 +15,19 @@ class LifespanHandler:
         self.cleanup_handlers = []  # type: typing.List[typing.Callable]
 
     def on_event(self, event_type: str) -> typing.Callable:
-        assert event_type in ("startup", "cleanup")
-
         def decorator(func: typing.Callable) -> typing.Callable:
-            if event_type == "startup":
-                self.startup_handlers.append(func)
-            else:
-                self.cleanup_handlers.append(func)
+            self.add_event_handler(event_type, func)
             return func
 
         return decorator
+
+    def add_event_handler(self, event_type: str, func: typing.Callable) -> None:
+        assert event_type in ("startup", "cleanup")
+
+        if event_type == "startup":
+            self.startup_handlers.append(func)
+        else:
+            self.cleanup_handlers.append(func)
 
     async def run_startup(self) -> None:
         for handler in self.startup_handlers:


### PR DESCRIPTION
For example:
```python
app = Starlette()

async def open_database_connections():
    ...
async def close_database_connections():
    ...

# Use as a function interface
app.add_event_handler("startup", open_database_connections)
app.add_event_handler("cleanup", close_database_connections)
```