### PR TITLE
Add support for empty `request.json()`.

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -103,6 +103,8 @@ class Request(Mapping):
     async def json(self) -> typing.Any:
         if not hasattr(self, "_json"):
             body = await self.body()
+            if not body:
+                body = b"{}"
             self._json = json.loads(body)
         return self._json
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -160,6 +160,10 @@ def test_request_json():
         return asgi
 
     client = TestClient(app)
+
+    response = client.post("/")
+    assert response.json() == {"json": {}}
+
     response = client.post("/", json={"a": "123"})
     assert response.json() == {"json": {"a": "123"}}
 


### PR DESCRIPTION
The app throws a `json.decoder.JSONDecodeError` if I try to access `request.json()` when the request has an empty body.

Hope this is helpful :)