### PR TITLE
Return an iterator over keys for Headers and QueryParams

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -149,7 +149,7 @@ class QueryParams(typing.Mapping[str, str]):
         return key in self._dict
 
     def __iter__(self) -> typing.Iterator[typing.Any]:
-        return iter(self._list)
+        return iter(self.keys())
 
     def __len__(self) -> int:
         return len(self._list)
@@ -239,7 +239,7 @@ class Headers(typing.Mapping[str, str]):
         return False
 
     def __iter__(self) -> typing.Iterator[typing.Any]:
-        return iter(self.items())
+        return iter(self.keys())
 
     def __len__(self) -> int:
         return len(self._list)

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -58,7 +58,7 @@ def test_headers():
     assert h.keys() == ["a", "a", "b"]
     assert h.values() == ["123", "456", "789"]
     assert h.items() == [("a", "123"), ("a", "456"), ("b", "789")]
-    assert list(h) == [("a", "123"), ("a", "456"), ("b", "789")]
+    assert list(h) == ["a", "a", "b"]
     assert dict(h) == {"a": "123", "b": "789"}
     assert repr(h) == "Headers(raw=[(b'a', b'123'), (b'a', b'456'), (b'b', b'789')])"
     assert h == Headers(raw=[(b"a", b"123"), (b"b", b"789"), (b"a", b"456")])
@@ -107,7 +107,7 @@ def test_queryparams():
     assert q.keys() == ["a", "a", "b"]
     assert q.values() == ["123", "456", "789"]
     assert q.items() == [("a", "123"), ("a", "456"), ("b", "789")]
-    assert list(q) == [("a", "123"), ("a", "456"), ("b", "789")]
+    assert list(q) == ["a", "a", "b"]
     assert dict(q) == {"a": "123", "b": "789"}
     assert str(q) == "a=123&a=456&b=789"
     assert repr(q) == "QueryParams(query_string='a=123&a=456&b=789')"


### PR DESCRIPTION
The mapping data structures (`QueryParams` and `Headers`) now return an iterable over keys instead of items.

This addresses the first part of the solution mentioned in #139.