### PR TITLE
Support a routing interface for `Router`

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -1,53 +1,9 @@
-import asyncio
-import inspect
 import typing
-from concurrent.futures import ThreadPoolExecutor
 
 from starlette.exceptions import ExceptionMiddleware
 from starlette.lifespan import LifespanHandler
-from starlette.graphql import GraphQLApp
-from starlette.requests import Request
-from starlette.routing import Path, PathPrefix, Router
-from starlette.types import ASGIApp, ASGIInstance, Receive, Scope, Send
-from starlette.websockets import WebSocket
-
-
-def request_response(func: typing.Callable) -> ASGIApp:
-    """
-    Takes a function or coroutine `func(request, **kwargs) -> response`,
-    and returns an ASGI application.
-    """
-    is_coroutine = asyncio.iscoroutinefunction(func)
-
-    def app(scope: Scope) -> ASGIInstance:
-        async def awaitable(receive: Receive, send: Send) -> None:
-            request = Request(scope, receive=receive)
-            kwargs = scope.get("kwargs", {})
-            if is_coroutine:
-                response = await func(request, **kwargs)
-            else:
-                response = func(request, **kwargs)
-            await response(receive, send)
-
-        return awaitable
-
-    return app
-
-
-def websocket_session(func: typing.Callable) -> ASGIApp:
-    """
-    Takes a coroutine `func(session, **kwargs)`, and returns an ASGI application.
-    """
-
-    def app(scope: Scope) -> ASGIInstance:
-        async def awaitable(receive: Receive, send: Send) -> None:
-            session = WebSocket(scope, receive=receive, send=send)
-            kwargs = scope.get("kwargs", {})
-            await func(session, **kwargs)
-
-        return awaitable
-
-    return app
+from starlette.routing import Router
+from starlette.types import ASGIApp, ASGIInstance, Scope
 
 
 class Starlette:
@@ -56,7 +12,6 @@ class Starlette:
         self.lifespan_handler = LifespanHandler()
         self.app = self.router
         self.exception_middleware = ExceptionMiddleware(self.router, debug=debug)
-        self.executor = ThreadPoolExecutor()
 
     @property
     def debug(self) -> bool:
@@ -72,8 +27,7 @@ class Starlette:
     def mount(
         self, path: str, app: ASGIApp, methods: typing.Sequence[str] = None
     ) -> None:
-        prefix = PathPrefix(path, app=app, methods=methods)
-        self.router.routes.append(prefix)
+        self.router.mount(path, app=app, methods=methods)
 
     def add_middleware(self, middleware_class: type, **kwargs: typing.Any) -> None:
         self.exception_middleware.app = middleware_class(self.app, **kwargs)
@@ -87,26 +41,13 @@ class Starlette:
     def add_route(
         self, path: str, route: typing.Callable, methods: typing.Sequence[str] = None
     ) -> None:
-        if not inspect.isclass(route):
-            route = request_response(route)
-            if methods is None:
-                methods = ("GET",)
+        self.router.add_route(path, route, methods=methods)
 
-        instance = Path(path, route, protocol="http", methods=methods)
-        self.router.routes.append(instance)
-
-    def add_graphql_route(
-        self, path: str, schema: typing.Any, executor: typing.Any = None
-    ) -> None:
-        route = GraphQLApp(schema=schema, executor=executor)
-        self.add_route(path, route, methods=["GET", "POST"])
+    def add_graphql_route(self, path: str, schema: typing.Any) -> None:
+        self.router.add_graphql_route(path, schema)
 
     def add_websocket_route(self, path: str, route: typing.Callable) -> None:
-        if not inspect.isclass(route):
-            route = websocket_session(route)
-
-        instance = Path(path, route, protocol="websocket")
-        self.router.routes.append(instance)
+        self.router.add_websocket_route(path, route)
 
     def exception_handler(self, exc_class: type) -> typing.Callable:
         def decorator(func: typing.Callable) -> typing.Callable:
@@ -117,21 +58,20 @@ class Starlette:
 
     def route(self, path: str, methods: typing.Sequence[str] = None) -> typing.Callable:
         def decorator(func: typing.Callable) -> typing.Callable:
-            self.add_route(path, func, methods=methods)
+            self.router.add_route(path, func, methods=methods)
             return func
 
         return decorator
 
     def websocket_route(self, path: str) -> typing.Callable:
         def decorator(func: typing.Callable) -> typing.Callable:
-            self.add_websocket_route(path, func)
+            self.router.add_websocket_route(path, func)
             return func
 
         return decorator
 
     def __call__(self, scope: Scope) -> ASGIInstance:
         scope["app"] = self
-        scope["executor"] = self.executor
         if scope["type"] == "lifespan":
             return self.lifespan_handler(scope)
         return self.exception_middleware(scope)

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -8,7 +8,7 @@ from starlette.types import ASGIApp, ASGIInstance, Scope
 
 class Starlette:
     def __init__(self, debug: bool = False) -> None:
-        self.router = Router(routes=[])
+        self.router = Router()
         self.lifespan_handler = LifespanHandler()
         self.app = self.router
         self.exception_middleware = ExceptionMiddleware(self.router, debug=debug)

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -173,7 +173,7 @@ def test_app_add_route():
     async def homepage(request):
         return PlainTextResponse("Hello, World!")
 
-    app.add_route('/', homepage)
+    app.add_route("/", homepage)
     client = TestClient(app)
     response = client.get("/")
     assert response.status_code == 200
@@ -188,7 +188,7 @@ def test_app_add_websocket_route():
         await session.send_text("Hello, world!")
         await session.close()
 
-    app.add_websocket_route('/ws', websocket_endpoint)
+    app.add_websocket_route("/ws", websocket_endpoint)
     client = TestClient(app)
 
     with client.websocket_connect("/ws") as session:

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -167,6 +167,35 @@ def test_app_debug():
     assert app.debug
 
 
+def test_app_add_route():
+    app = Starlette()
+
+    async def homepage(request):
+        return PlainTextResponse("Hello, World!")
+
+    app.add_route('/', homepage)
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.text == "Hello, World!"
+
+
+def test_app_add_websocket_route():
+    app = Starlette()
+
+    async def websocket_endpoint(session):
+        await session.accept()
+        await session.send_text("Hello, world!")
+        await session.close()
+
+    app.add_websocket_route('/ws', websocket_endpoint)
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws") as session:
+        text = session.receive_text()
+        assert text == "Hello, world!"
+
+
 def test_app_add_event_handler():
     startup_complete = False
     cleanup_complete = False


### PR DESCRIPTION
Closes #125 

`Router` class now has functionality for:
* `add_route`
* `add_graphql_route`
* `add_websocket_route`
* `mount`
* `route` decorator
* `websocket_route` decorator

Essentially, all function logic now resides inside `Router` and `Starlette`'s interface simply wraps what the `Router` provides.