### PR TITLE
Plaintext response with status

### DIFF
--- a/starlette/debug.py
+++ b/starlette/debug.py
@@ -2,6 +2,7 @@ import html
 import traceback
 import typing
 
+from starlette import status
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, PlainTextResponse, Response
 from starlette.types import Scope, Receive, Send, Message, ASGIApp, ASGIInstance
@@ -15,9 +16,9 @@ def get_debug_response(request: Request, exc: Exception) -> Response:
         content = (
             f"<html><body><h1>500 Server Error</h1><pre>{exc_html}</pre></body></html>"
         )
-        return HTMLResponse(content, status_code=500)
+        return HTMLResponse(content, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
     content = "".join(traceback.format_tb(exc.__traceback__))
-    return PlainTextResponse(content, status_code=500)
+    return PlainTextResponse(content, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class DebugMiddleware:

--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -34,7 +34,9 @@ class HTTPEndpoint:
         # returning the response. For plain ASGI apps, just return the response.
         if "app" in self.scope:
             raise HTTPException(status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
-        return PlainTextResponse("Method Not Allowed", status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
+        return PlainTextResponse(
+            "Method Not Allowed", status_code=status.HTTP_405_METHOD_NOT_ALLOWED
+        )
 
 
 class WebSocketEndpoint:

--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -33,8 +33,8 @@ class HTTPEndpoint:
         # exception, so that the configurable exception handler can deal with
         # returning the response. For plain ASGI apps, just return the response.
         if "app" in self.scope:
-            raise HTTPException(status_code=405)
-        return PlainTextResponse("Method Not Allowed", status_code=405)
+            raise HTTPException(status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
+        return PlainTextResponse("Method Not Allowed", status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 class WebSocketEndpoint:

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -2,6 +2,7 @@ from starlette.debug import get_debug_response
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.types import ASGIApp, ASGIInstance, Receive, Message, Send, Scope
+from starlette import status
 import asyncio
 import http
 import typing
@@ -106,4 +107,4 @@ class ExceptionMiddleware:
         return PlainTextResponse(exc.detail, status_code=exc.status_code)
 
     def server_error(self, request: Request, exc: HTTPException) -> Response:
-        return PlainTextResponse("Internal Server Error", status_code=500)
+        return PlainTextResponse("Internal Server Error", status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -107,4 +107,6 @@ class ExceptionMiddleware:
         return PlainTextResponse(exc.detail, status_code=exc.status_code)
 
     def server_error(self, request: Request, exc: HTTPException) -> Response:
-        return PlainTextResponse("Internal Server Error", status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return PlainTextResponse(
+            "Internal Server Error", status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+        )

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -1,6 +1,7 @@
 from starlette.datastructures import Headers, MutableHeaders, URL
 from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, ASGIInstance, Receive, Scope, Send, Message
+from starlette import status
 import functools
 import typing
 import re
@@ -126,9 +127,9 @@ class CORSMiddleware:
         # if we do.
         if failures:
             failure_text = "Disallowed CORS " + ", ".join(failures)
-            return PlainTextResponse(failure_text, status_code=400, headers=headers)
+            return PlainTextResponse(failure_text, status_code=status.HTTP_400_BAD_REQUEST, headers=headers)
 
-        return PlainTextResponse("OK", status_code=200, headers=headers)
+        return PlainTextResponse("OK", status_code=status.HTTP_200_OK, headers=headers)
 
     async def simple_response(
         self, receive: Receive, send: Send, scope: Scope, request_headers: Headers

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -127,7 +127,9 @@ class CORSMiddleware:
         # if we do.
         if failures:
             failure_text = "Disallowed CORS " + ", ".join(failures)
-            return PlainTextResponse(failure_text, status_code=status.HTTP_400_BAD_REQUEST, headers=headers)
+            return PlainTextResponse(
+                failure_text, status_code=status.HTTP_400_BAD_REQUEST, headers=headers
+            )
 
         return PlainTextResponse("OK", status_code=status.HTTP_200_OK, headers=headers)
 

--- a/starlette/middleware/httpsredirect.py
+++ b/starlette/middleware/httpsredirect.py
@@ -1,6 +1,7 @@
 from starlette.datastructures import URL
 from starlette.responses import RedirectResponse
 from starlette.types import ASGIApp, ASGIInstance, Scope
+from starlette import status
 
 
 class HTTPSRedirectMiddleware:
@@ -12,6 +13,6 @@ class HTTPSRedirectMiddleware:
             redirect_scheme = {"http": "https", "ws": "wss"}[scope["scheme"]]
             url = URL(scope=scope)
             url = url.replace(scheme=redirect_scheme, netloc=url.hostname)
-            return RedirectResponse(url, status_code=301)
+            return RedirectResponse(url, status_code=status.HTTP_301_MOVED_PERMANENTLY)
 
         return self.app(scope)

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -32,6 +32,8 @@ class TrustedHostMiddleware:
                 ):
                     break
             else:
-                return PlainTextResponse("Invalid host header", status_code=status.HTTP_400_BAD_REQUEST)
+                return PlainTextResponse(
+                    "Invalid host header", status_code=status.HTTP_400_BAD_REQUEST
+                )
 
         return self.app(scope)

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -1,6 +1,7 @@
 from starlette.datastructures import Headers
 from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, ASGIInstance, Scope
+from starlette import status
 import typing
 
 
@@ -31,6 +32,6 @@ class TrustedHostMiddleware:
                 ):
                     break
             else:
-                return PlainTextResponse("Invalid host header", status_code=400)
+                return PlainTextResponse("Invalid host header", status_code=status.HTTP_400_BAD_REQUEST)
 
         return self.app(scope)

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -15,6 +15,7 @@ from starlette import status
 
 from urllib.parse import quote_plus
 import http.cookies
+from http import HTTPStatus
 
 try:
     import aiofiles
@@ -137,6 +138,22 @@ class HTMLResponse(Response):
 
 class PlainTextResponse(Response):
     media_type = "text/plain"
+
+    def __init__(
+        self,
+        content: typing.Any,
+        status_code: int = status.HTTP_200_OK,
+        **kwargs
+    ) -> None:
+        if isinstance(content, int):
+            try:
+                status_code = HTTPStatus(content)
+            except ValueError:
+                content = str(content)
+            else:
+                content = status_code.phrase
+                status_code = status_code.value
+        super().__init__(content, status_code=status_code, **kwargs)
 
 
 class JSONResponse(Response):

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -141,15 +141,15 @@ class PlainTextResponse(Response):
 
     def __init__(
         self,
-        content: typing.Any,
+        content: typing.Any = "",
         status_code: int = status.HTTP_200_OK,
         **kwargs: typing.Any,
     ) -> None:
-        if isinstance(content, int):
+        if status_code and not content:
             try:
-                status_code = HTTPStatus(content)
+                status_code = HTTPStatus(status_code)
             except ValueError:
-                content = str(content)
+                pass
             else:
                 content = status_code.phrase
                 status_code = status_code.value

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -143,7 +143,7 @@ class PlainTextResponse(Response):
         self,
         content: typing.Any,
         status_code: int = status.HTTP_200_OK,
-        **kwargs
+        **kwargs: typing.Any
     ) -> None:
         if isinstance(content, int):
             try:

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -143,7 +143,7 @@ class PlainTextResponse(Response):
         self,
         content: typing.Any,
         status_code: int = status.HTTP_200_OK,
-        **kwargs: typing.Any
+        **kwargs: typing.Any,
     ) -> None:
         if isinstance(content, int):
             try:
@@ -178,7 +178,10 @@ class UJSONResponse(JSONResponse):
 
 class RedirectResponse(Response):
     def __init__(
-        self, url: typing.Union[str, URL], status_code: int = status.HTTP_302_FOUND, headers: dict = None
+        self,
+        url: typing.Union[str, URL],
+        status_code: int = status.HTTP_302_FOUND,
+        headers: dict = None,
     ) -> None:
         super().__init__(content=b"", status_code=status_code, headers=headers)
         self.headers["location"] = quote_plus(str(url), safe=":/#?&=@[]!$&'()*+,;")

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -11,6 +11,10 @@ from urllib.parse import quote_plus
 from starlette.background import BackgroundTask
 from starlette.datastructures import MutableHeaders, URL
 from starlette.types import Receive, Send
+from starlette import status
+
+from urllib.parse import quote_plus
+import http.cookies
 
 try:
     import aiofiles
@@ -32,7 +36,7 @@ class Response:
     def __init__(
         self,
         content: typing.Any,
-        status_code: int = 200,
+        status_code: int = status.HTTP_200_OK,
         headers: dict = None,
         media_type: str = None,
         background: BackgroundTask = None,
@@ -157,7 +161,7 @@ class UJSONResponse(JSONResponse):
 
 class RedirectResponse(Response):
     def __init__(
-        self, url: typing.Union[str, URL], status_code: int = 302, headers: dict = None
+        self, url: typing.Union[str, URL], status_code: int = status.HTTP_302_FOUND, headers: dict = None
     ) -> None:
         super().__init__(content=b"", status_code=status_code, headers=headers)
         self.headers["location"] = quote_plus(str(url), safe=":/#?&=@[]!$&'()*+,;")
@@ -167,7 +171,7 @@ class StreamingResponse(Response):
     def __init__(
         self,
         content: typing.Any,
-        status_code: int = 200,
+        status_code: int = status.HTTP_200_OK,
         headers: dict = None,
         media_type: str = None,
     ) -> None:
@@ -204,7 +208,7 @@ class FileResponse(Response):
     ) -> None:
         assert aiofiles is not None, "'aiofiles' must be installed to use FileResponse"
         self.path = path
-        self.status_code = 200
+        self.status_code = status.HTTP_200_OK
         self.filename = filename
         if media_type is None:
             media_type = guess_type(filename or path)[0] or "text/plain"

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -10,7 +10,11 @@ from starlette.exceptions import HTTPException
 from starlette.responses import PlainTextResponse
 from starlette.types import Scope, ASGIApp, ASGIInstance, Send, Receive
 from starlette.websockets import WebSocket, WebSocketClose
+from starlette import status
 from starlette.graphql import GraphQLApp
+
+import re
+import typing
 
 
 class NoMatchFound(Exception):
@@ -116,8 +120,8 @@ class Route(BaseRoute):
     def __call__(self, scope: Scope) -> ASGIInstance:
         if self.methods and scope["method"] not in self.methods:
             if "app" in scope:
-                raise HTTPException(status_code=405)
-            return PlainTextResponse("Method Not Allowed", status_code=405)
+                raise HTTPException(status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
+            return PlainTextResponse("Method Not Allowed", status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
         return self.app(scope)
 
     def __eq__(self, other: typing.Any) -> bool:
@@ -265,8 +269,8 @@ class Router:
         # exception, so that the configurable exception handler can deal with
         # returning the response. For plain ASGI apps, just return the response.
         if "app" in scope:
-            raise HTTPException(status_code=404)
-        return PlainTextResponse("Not Found", status_code=404)
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+        return PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)
 
     def url_path_for(self, name: str, **path_params: str) -> URL:
         for route in self.routes:

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -121,7 +121,9 @@ class Route(BaseRoute):
         if self.methods and scope["method"] not in self.methods:
             if "app" in scope:
                 raise HTTPException(status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
-            return PlainTextResponse("Method Not Allowed", status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
+            return PlainTextResponse(
+                "Method Not Allowed", status_code=status.HTTP_405_METHOD_NOT_ALLOWED
+            )
         return self.app(scope)
 
     def __eq__(self, other: typing.Any) -> bool:

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -5,6 +5,7 @@ from aiofiles.os import stat as aio_stat
 
 from starlette.responses import PlainTextResponse, FileResponse, Response
 from starlette.types import Send, Receive, Scope, ASGIInstance
+from starlette import status
 
 
 class StaticFiles:
@@ -15,10 +16,10 @@ class StaticFiles:
     def __call__(self, scope: Scope) -> ASGIInstance:
         assert scope["type"] == "http"
         if scope["method"] not in ("GET", "HEAD"):
-            return PlainTextResponse("Method Not Allowed", status_code=405)
+            return PlainTextResponse("Method Not Allowed", status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
         path = os.path.normpath(os.path.join(*scope["path"].split("/")))
         if path.startswith(".."):
-            return PlainTextResponse("Not Found", status_code=404)
+            return PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)
         path = os.path.join(self.directory, path)
         if self.config_checked:
             check_directory = None
@@ -55,11 +56,11 @@ class _StaticFilesResponder:
         try:
             stat_result = await aio_stat(self.path)
         except FileNotFoundError:
-            response = PlainTextResponse("Not Found", status_code=404)  # type: Response
+            response = PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)  # type: Response
         else:
             mode = stat_result.st_mode
             if not stat.S_ISREG(mode):
-                response = PlainTextResponse("Not Found", status_code=404)
+                response = PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)
             else:
                 response = FileResponse(self.path, stat_result=stat_result)
 

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -16,7 +16,9 @@ class StaticFiles:
     def __call__(self, scope: Scope) -> ASGIInstance:
         assert scope["type"] == "http"
         if scope["method"] not in ("GET", "HEAD"):
-            return PlainTextResponse("Method Not Allowed", status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
+            return PlainTextResponse(
+                "Method Not Allowed", status_code=status.HTTP_405_METHOD_NOT_ALLOWED
+            )
         path = os.path.normpath(os.path.join(*scope["path"].split("/")))
         if path.startswith(".."):
             return PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)
@@ -56,11 +58,15 @@ class _StaticFilesResponder:
         try:
             stat_result = await aio_stat(self.path)
         except FileNotFoundError:
-            response = PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)  # type: Response
+            response = PlainTextResponse(
+                "Not Found", status_code=status.HTTP_404_NOT_FOUND
+            )  # type: Response
         else:
             mode = stat_result.st_mode
             if not stat.S_ISREG(mode):
-                response = PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)
+                response = PlainTextResponse(
+                    "Not Found", status_code=status.HTTP_404_NOT_FOUND
+                )
             else:
                 response = FileResponse(self.path, stat_result=stat_result)
 

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -217,7 +217,9 @@ def test_cors_vary_header_is_properly_set():
     @app.route("/")
     def homepage(request):
         return PlainTextResponse(
-            "Homepage", status_code=status.HTTP_200_OK, headers={"Vary": "Accept-Encoding"}
+            "Homepage",
+            status_code=status.HTTP_200_OK,
+            headers={"Vary": "Accept-Encoding"},
         )
 
     client = TestClient(app)

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -2,6 +2,7 @@ from starlette.applications import Starlette
 from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
+from starlette import status
 
 
 def test_cors_allow_all():
@@ -18,7 +19,7 @@ def test_cors_allow_all():
 
     @app.route("/")
     def homepage(request):
-        return PlainTextResponse("Homepage", status_code=200)
+        return PlainTextResponse("Homepage", status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
 
@@ -29,7 +30,7 @@ def test_cors_allow_all():
         "Access-Control-Request-Headers": "X-Example",
     }
     response = client.options("/", headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "OK"
     assert response.headers["access-control-allow-origin"] == "*"
     assert response.headers["access-control-allow-headers"] == "X-Example"
@@ -37,14 +38,14 @@ def test_cors_allow_all():
     # Test standard response
     headers = {"Origin": "https://example.org"}
     response = client.get("/", headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Homepage"
     assert response.headers["access-control-allow-origin"] == "*"
     assert response.headers["access-control-expose-headers"] == "X-Status"
 
     # Test non-CORS response
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Homepage"
     assert "access-control-allow-origin" not in response.headers
 
@@ -60,7 +61,7 @@ def test_cors_allow_specific_origin():
 
     @app.route("/")
     def homepage(request):
-        return PlainTextResponse("Homepage", status_code=200)
+        return PlainTextResponse("Homepage", status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
 
@@ -71,7 +72,7 @@ def test_cors_allow_specific_origin():
         "Access-Control-Request-Headers": "X-Example",
     }
     response = client.options("/", headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "OK"
     assert response.headers["access-control-allow-origin"] == "https://example.org"
     assert response.headers["access-control-allow-headers"] == "X-Example"
@@ -79,13 +80,13 @@ def test_cors_allow_specific_origin():
     # Test standard response
     headers = {"Origin": "https://example.org"}
     response = client.get("/", headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Homepage"
     assert response.headers["access-control-allow-origin"] == "https://example.org"
 
     # Test non-CORS response
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Homepage"
     assert "access-control-allow-origin" not in response.headers
 
@@ -112,7 +113,7 @@ def test_cors_disallowed_preflight():
         "Access-Control-Request-Headers": "X-Nope",
     }
     response = client.options("/", headers=headers)
-    assert response.status_code == 400
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.text == "Disallowed CORS origin, method, headers"
 
 
@@ -125,14 +126,14 @@ def test_cors_allow_origin_regex():
 
     @app.route("/")
     def homepage(request):
-        return PlainTextResponse("Homepage", status_code=200)
+        return PlainTextResponse("Homepage", status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
 
     # Test standard response
     headers = {"Origin": "https://example.org"}
     response = client.get("/", headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Homepage"
     assert response.headers["access-control-allow-origin"] == "https://example.org"
 
@@ -141,7 +142,7 @@ def test_cors_allow_origin_regex():
     # in the lack of an "access-control-allow-origin" header in the response.
     headers = {"Origin": "http://example.org"}
     response = client.get("/", headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Homepage"
     assert "access-control-allow-origin" not in response.headers
 
@@ -152,7 +153,7 @@ def test_cors_allow_origin_regex():
         "Access-Control-Request-Headers": "X-Example",
     }
     response = client.options("/", headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "OK"
     assert response.headers["access-control-allow-origin"] == "https://another.com"
     assert response.headers["access-control-allow-headers"] == "X-Example"
@@ -164,7 +165,7 @@ def test_cors_allow_origin_regex():
         "Access-Control-Request-Headers": "X-Example",
     }
     response = client.options("/", headers=headers)
-    assert response.status_code == 400
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.text == "Disallowed CORS origin"
     assert "access-control-allow-origin" not in response.headers
 
@@ -176,14 +177,14 @@ def test_cors_credentialed_requests_return_specific_origin():
 
     @app.route("/")
     def homepage(request):
-        return PlainTextResponse("Homepage", status_code=200)
+        return PlainTextResponse("Homepage", status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
 
     # Test credentialed request
     headers = {"Origin": "https://example.org", "Cookie": "star_cookie=sugar"}
     response = client.get("/", headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Homepage"
     assert response.headers["access-control-allow-origin"] == "https://example.org"
 
@@ -197,12 +198,12 @@ def test_cors_vary_header_defaults_to_origin():
 
     @app.route("/")
     def homepage(request):
-        return PlainTextResponse("Homepage", status_code=200)
+        return PlainTextResponse("Homepage", status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
 
     response = client.get("/", headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.headers["vary"] == "Origin"
 
 
@@ -216,11 +217,11 @@ def test_cors_vary_header_is_properly_set():
     @app.route("/")
     def homepage(request):
         return PlainTextResponse(
-            "Homepage", status_code=200, headers={"Vary": "Accept-Encoding"}
+            "Homepage", status_code=status.HTTP_200_OK, headers={"Vary": "Accept-Encoding"}
         )
 
     client = TestClient(app)
 
     response = client.get("/", headers=headers)
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.headers["vary"] == "Accept-Encoding, Origin"

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -2,6 +2,7 @@ from starlette.applications import Starlette
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.responses import PlainTextResponse, StreamingResponse
 from starlette.testclient import TestClient
+from starlette import status
 
 
 def test_gzip_responses():
@@ -11,11 +12,11 @@ def test_gzip_responses():
 
     @app.route("/")
     def homepage(request):
-        return PlainTextResponse("x" * 4000, status_code=200)
+        return PlainTextResponse("x" * 4000, status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
     response = client.get("/", headers={"accept-encoding": "gzip"})
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "x" * 4000
     assert response.headers["Content-Encoding"] == "gzip"
     assert int(response.headers["Content-Length"]) < 4000
@@ -28,11 +29,11 @@ def test_gzip_not_in_accept_encoding():
 
     @app.route("/")
     def homepage(request):
-        return PlainTextResponse("x" * 4000, status_code=200)
+        return PlainTextResponse("x" * 4000, status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
     response = client.get("/", headers={"accept-encoding": "identity"})
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "x" * 4000
     assert "Content-Encoding" not in response.headers
     assert int(response.headers["Content-Length"]) == 4000
@@ -45,11 +46,11 @@ def test_gzip_ignored_for_small_responses():
 
     @app.route("/")
     def homepage(request):
-        return PlainTextResponse("OK", status_code=200)
+        return PlainTextResponse("OK", status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
     response = client.get("/", headers={"accept-encoding": "gzip"})
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "OK"
     assert "Content-Encoding" not in response.headers
     assert int(response.headers["Content-Length"]) == 2
@@ -67,11 +68,11 @@ def test_gzip_streaming_response():
                 yield bytes
 
         streaming = generator(bytes=b"x" * 400, count=10)
-        return StreamingResponse(streaming, status_code=200)
+        return StreamingResponse(streaming, status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
     response = client.get("/", headers={"accept-encoding": "gzip"})
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "x" * 4000
     assert response.headers["Content-Encoding"] == "gzip"
     assert "Content-Length" not in response.headers

--- a/tests/middleware/test_https_redirect.py
+++ b/tests/middleware/test_https_redirect.py
@@ -2,6 +2,7 @@ from starlette.applications import Starlette
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
+from starlette import status
 
 
 def test_https_redirect_middleware():
@@ -11,13 +12,13 @@ def test_https_redirect_middleware():
 
     @app.route("/")
     def homepage(request):
-        return PlainTextResponse("OK", status_code=200)
+        return PlainTextResponse("OK", status_code=status.HTTP_200_OK)
 
     client = TestClient(app, base_url="https://testserver")
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
 
     client = TestClient(app)
     response = client.get("/", allow_redirects=False)
-    assert response.status_code == 301
+    assert response.status_code == status.HTTP_301_MOVED_PERMANENTLY
     assert response.headers["location"] == "https://testserver/"

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -2,6 +2,7 @@ from starlette.applications import Starlette
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
+from starlette import status
 
 
 def test_trusted_host_middleware():
@@ -13,11 +14,11 @@ def test_trusted_host_middleware():
 
     @app.route("/")
     def homepage(request):
-        return PlainTextResponse("OK", status_code=200)
+        return PlainTextResponse("OK", status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
 
     client = TestClient(app, base_url="http://subdomain.testserver")
     response = client.get("/")
@@ -25,4 +26,4 @@ def test_trusted_host_middleware():
 
     client = TestClient(app, base_url="http://invalidhost")
     response = client.get("/")
-    assert response.status_code == 400
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -3,6 +3,7 @@ import pytest
 import sys
 from starlette.middleware.wsgi import WSGIMiddleware, build_environ
 from starlette.testclient import TestClient
+from starlette import status
 
 
 def hello_world(environ, start_response):
@@ -49,7 +50,7 @@ def test_wsgi_get():
     app = WSGIMiddleware(hello_world)
     client = TestClient(app)
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Hello World!\n"
 
 
@@ -57,7 +58,7 @@ def test_wsgi_post():
     app = WSGIMiddleware(echo_body)
     client = TestClient(app)
     response = client.post("/", json={"example": 123})
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == '{"example": 123}'
 
 
@@ -81,7 +82,7 @@ def test_wsgi_exc_info():
     app = WSGIMiddleware(return_exc_info)
     client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/")
-    assert response.status_code == 500
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.text == "Internal Server Error"
 
 

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -20,7 +20,9 @@ class TrustedHostMiddleware:
     def __call__(self, scope):
         headers = Headers(scope=scope)
         if headers.get("host") != self.hostname:
-            return PlainTextResponse("Invalid host header", status_code=status.HTTP_400_BAD_REQUEST)
+            return PlainTextResponse(
+                "Invalid host header", status_code=status.HTTP_400_BAD_REQUEST
+            )
         return self.app(scope)
 
 
@@ -32,7 +34,9 @@ app.add_middleware(TrustedHostMiddleware, hostname="testserver")
 
 @app.exception_handler(Exception)
 async def error_500(request, exc):
-    return JSONResponse({"detail": "Server Error"}, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    return JSONResponse(
+        {"detail": "Server Error"}, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+    )
 
 
 @app.exception_handler(HTTPException)

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -122,19 +122,13 @@ def test_mounted_route_path_params():
     assert response.text == "Hello, tomchristie!"
 
 
-def test_route_kwargs():
-    response = client.get("/user/tomchristie")
-    assert response.status_code == status.HTTP_200_OK
-    assert response.text == "Hello, tomchristie!"
-
-
 def test_websocket_route():
     with client.websocket_connect("/ws") as session:
         text = session.receive_text()
         assert text == "Hello, world!"
 
 
-def test_400():
+def test_404():
     response = client.get("/404")
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json() == {"detail": "Not Found"}

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,6 +1,7 @@
 from starlette.responses import Response
 from starlette.testclient import TestClient
 from starlette.debug import DebugMiddleware
+from starlette import status
 import pytest
 
 
@@ -14,7 +15,7 @@ def test_debug_text():
     app = DebugMiddleware(app)
     client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/")
-    assert response.status_code == 500
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.headers["content-type"].startswith("text/plain")
     assert "RuntimeError" in response.text
 
@@ -29,7 +30,7 @@ def test_debug_html():
     app = DebugMiddleware(app)
     client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/", headers={"Accept": "text/html, */*"})
-    assert response.status_code == 500
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.headers["content-type"].startswith("text/html")
     assert "RuntimeError" in response.text
 
@@ -37,7 +38,7 @@ def test_debug_html():
 def test_debug_after_response_sent():
     def app(scope):
         async def asgi(receive, send):
-            response = Response(b"", status_code=204)
+            response = Response(b"", status_code=status.HTTP_204_NO_CONTENT)
             await response(receive, send)
             raise RuntimeError("Something went wrong")
 
@@ -56,7 +57,7 @@ def test_debug_error_during_scope():
     app = DebugMiddleware(app)
     client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/", headers={"Accept": "text/html, */*"})
-    assert response.status_code == 500
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.headers["content-type"].startswith("text/html")
     assert "RuntimeError" in response.text
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -3,6 +3,7 @@ from starlette.responses import PlainTextResponse
 from starlette.routing import Router, Route
 from starlette.testclient import TestClient
 from starlette.endpoints import HTTPEndpoint, WebSocketEndpoint
+from starlette import status
 
 
 class Homepage(HTTPEndpoint):
@@ -22,19 +23,19 @@ client = TestClient(app)
 
 def test_http_endpoint_route():
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Hello, world!"
 
 
 def test_http_endpoint_route_path_params():
     response = client.get("/tomchristie")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Hello, tomchristie!"
 
 
 def test_http_endpoint_route_method():
     response = client.post("/")
-    assert response.status_code == 405
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
     assert response.text == "Method Not Allowed"
 
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -110,7 +110,7 @@ def test_response_headers():
 
 def test_response_phrase():
     def app(scope):
-        return Response(b"", status_code=200)
+        return Response(b"", status_code=status.HTTP_200_OK)
 
     client = TestClient(app)
     response = client.get("/")

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -4,7 +4,7 @@ from starlette.responses import (
     Response,
     StreamingResponse,
     UJSONResponse,
-    PlainTextResponse
+    PlainTextResponse,
 )
 from starlette.requests import Request
 from starlette.testclient import TestClient
@@ -51,7 +51,7 @@ def test_ujson_response():
     client = TestClient(app)
     response = client.get("/")
     assert response.json() == {"hello": "world"}
-    assert response.headers['content-type'] == "application/json"
+    assert response.headers["content-type"] == "application/json"
 
 
 def test_plaintext_response():
@@ -65,7 +65,7 @@ def test_plaintext_response():
     client = TestClient(app)
     response = client.get("/")
     assert response.text == "Hello, world!"
-    assert response.headers['content-type'] == "text/plain; charset=utf-8"
+    assert response.headers["content-type"] == "text/plain; charset=utf-8"
     assert response.status_code == status.HTTP_200_OK
 
 
@@ -80,7 +80,7 @@ def test_plaintext_response_status_as_content():
     client = TestClient(app)
     response = client.get("/")
     assert response.text == "Not Found"
-    assert response.headers['content-type'] == "text/plain; charset=utf-8"
+    assert response.headers["content-type"] == "text/plain; charset=utf-8"
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -95,7 +95,7 @@ def test_plaintext_response_non_status_integer():
     client = TestClient(app)
     response = client.get("/")
     assert response.text == "123456789"
-    assert response.headers['content-type'].startswith("text/plain")
+    assert response.headers["content-type"].startswith("text/plain")
     assert response.status_code == status.HTTP_200_OK
 
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -69,10 +69,10 @@ def test_plaintext_response():
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_plaintext_response_status_as_content():
+def test_plaintext_response_status_only():
     def app(scope):
         async def asgi(receive, send):
-            response = PlainTextResponse(status.HTTP_404_NOT_FOUND)
+            response = PlainTextResponse(status_code=status.HTTP_404_NOT_FOUND)
             await response(receive, send)
 
         return asgi
@@ -84,18 +84,33 @@ def test_plaintext_response_status_as_content():
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_plaintext_response_non_status_integer():
+def test_plaintext_response_nonstandard_status():
     def app(scope):
         async def asgi(receive, send):
-            response = PlainTextResponse(123456789)
+            response = PlainTextResponse(status_code=700)
             await response(receive, send)
 
         return asgi
 
     client = TestClient(app)
     response = client.get("/")
-    assert response.text == "123456789"
-    assert response.headers["content-type"].startswith("text/plain")
+    assert response.text == ""
+    assert response.headers["content-type"] == "text/plain; charset=utf-8"
+    assert response.status_code == 700
+
+
+def test_plaintext_response_no_args():
+    def app(scope):
+        async def asgi(receive, send):
+            response = PlainTextResponse()
+            await response(receive, send)
+
+        return asgi
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.text == "OK"
+    assert response.headers["content-type"] == "text/plain; charset=utf-8"
     assert response.status_code == status.HTTP_200_OK
 
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -140,7 +140,7 @@ def test_protocol_switch():
 
     response = client.get("/")
     assert response.status_code == status.HTTP_200_OK
-    assert response.text == "Hello, world"
+    assert response.text == "URL: http://testserver/"
 
     with client.websocket_connect("/") as session:
         assert session.receive_json() == {"URL": "ws://testserver/"}

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3,6 +3,8 @@ from starlette.testclient import TestClient
 from starlette.exceptions import ExceptionMiddleware
 from starlette.routing import Route, Mount, NoMatchFound, Router, WebSocketRoute
 from starlette.websockets import WebSocket, WebSocketDisconnect
+from starlette import status
+
 import pytest
 
 
@@ -61,27 +63,27 @@ client = TestClient(app)
 
 def test_router():
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Hello, world"
 
     response = client.post("/")
-    assert response.status_code == 405
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
     assert response.text == "Method Not Allowed"
 
     response = client.get("/foo")
-    assert response.status_code == 404
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.text == "Not Found"
 
     response = client.get("/users")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "All users"
 
     response = client.get("/users/tomchristie")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "User tomchristie"
 
     response = client.get("/static/123")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "xxxxx"
 
 
@@ -95,7 +97,7 @@ def test_url_path_for():
 
 def test_router_add_route():
     response = client.get("/func")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "Hello, world!"
 
 
@@ -137,8 +139,8 @@ def test_protocol_switch():
     client = TestClient(mixed_protocol_app)
 
     response = client.get("/")
-    assert response.status_code == 200
-    assert response.text == "URL: http://testserver/"
+    assert response.status_code == status.HTTP_200_OK
+    assert response.text == "Hello, world"
 
     with client.websocket_connect("/") as session:
         assert session.receive_json() == {"URL": "ws://testserver/"}

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -3,6 +3,7 @@ import pytest
 
 from starlette.testclient import TestClient
 from starlette.staticfiles import StaticFiles
+from starlette import status
 
 
 def test_staticfiles(tmpdir):
@@ -13,7 +14,7 @@ def test_staticfiles(tmpdir):
     app = StaticFiles(directory=tmpdir)
     client = TestClient(app)
     response = client.get("/example.txt")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK
     assert response.text == "<file content>"
 
 
@@ -25,7 +26,7 @@ def test_staticfiles_post(tmpdir):
     app = StaticFiles(directory=tmpdir)
     client = TestClient(app)
     response = client.post("/example.txt")
-    assert response.status_code == 405
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
     assert response.text == "Method Not Allowed"
 
 
@@ -37,7 +38,7 @@ def test_staticfiles_with_directory_returns_404(tmpdir):
     app = StaticFiles(directory=tmpdir)
     client = TestClient(app)
     response = client.get("/")
-    assert response.status_code == 404
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.text == "Not Found"
 
 
@@ -49,7 +50,7 @@ def test_staticfiles_with_missing_file_returns_404(tmpdir):
     app = StaticFiles(directory=tmpdir)
     client = TestClient(app)
     response = client.get("/404.txt")
-    assert response.status_code == 404
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.text == "Not Found"
 
 
@@ -95,5 +96,5 @@ def test_staticfiles_prevents_breaking_out_of_directory(tmpdir):
     app = StaticFiles(directory=directory)
     # We can't test this with 'requests', so we call the app directly here.
     response = app({"type": "http", "method": "GET", "path": "/../example.txt"})
-    assert response.status_code == 404
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.body == b"Not Found"


### PR DESCRIPTION
As discussed in #138 I have replaced explicit integer status codes with the `status` consonants, and added the option for `PlainTextResponse` to automatically add content if just the status code is passed (specifically, if the content passed is an integer that exists in `http.HTTPStatus`.