### PR TITLE
Session middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Starlette does not have any hard dependencies, but the following are optional:
 * `aiofiles` - Required if you want to use `FileResponse` or `StaticFiles`.
 * `python-multipart` - Required if you want to support form parsing, with `request.form()`.
 * `graphene` - Required for GraphQL support.
+* `itsdangerous` - Required for SessionMiddleware support.
 * `ujson` - Required if you want to use `UJSONResponse`.
 
 You can install all of these with `pip3 install starlette[full]`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ Starlette does not have any hard dependencies, but the following are optional:
 * `aiofiles` - Required if you want to use `FileResponse` or `StaticFiles`.
 * `python-multipart` - Required if you want to support form parsing, with `request.form()`.
 * `graphene` - Required for GraphQL support.
+* `itsdangerous` - Required for SessionMiddleware support.
 * `ujson` - Required if you want to use `UJSONResponse`.
 
 You can install all of these with `pip3 install starlette[full]`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ ujson
 # Testing
 black
 codecov
+isort
 mypy
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Optionals
 aiofiles
 graphene
+itsdangerous
 python-multipart
 requests
 ujson

--- a/scripts/lint
+++ b/scripts/lint
@@ -8,3 +8,4 @@ fi
 set -x
 
 ${PREFIX}black starlette tests
+${PREFIX}isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --apply starlette tests

--- a/scripts/test
+++ b/scripts/test
@@ -17,3 +17,4 @@ if [ "${PYTHON_VERSION}" = '3.7' ]; then
 else
     ${PREFIX}black starlette tests --check
 fi
+${PREFIX}isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --check-only starlette tests

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -1,6 +1,7 @@
 import typing
+from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urlparse
+
 from starlette.types import Scope
-from urllib.parse import parse_qsl, unquote, urlencode, urlparse, ParseResult
 
 
 class URL:

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -335,6 +335,14 @@ class MutableHeaders(Headers):
         for key, val in other.items():
             self[key] = val
 
+    def append(self, key: str, value: str) -> None:
+        """
+        Append a header, preserving any duplicate entries.
+        """
+        append_key = key.lower().encode("latin-1")
+        append_value = value.encode("latin-1")
+        self._list.append((append_key, append_value))
+
     def add_vary_header(self, vary: str) -> None:
         existing = self.get("vary")
         if existing is not None:

--- a/starlette/debug.py
+++ b/starlette/debug.py
@@ -4,7 +4,7 @@ import typing
 
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, PlainTextResponse, Response
-from starlette.types import Scope, Receive, Send, Message, ASGIApp, ASGIInstance
+from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send
 
 
 def get_debug_response(request: Request, exc: Exception) -> Response:

--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -1,12 +1,13 @@
 import asyncio
-import typing
 import json
+import typing
+
 from starlette import status
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.types import Message, Receive, Scope, Send
 from starlette.websockets import WebSocket
-from starlette.responses import Response, PlainTextResponse
-from starlette.types import Message, Receive, Send, Scope
 
 
 class HTTPEndpoint:

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -1,10 +1,11 @@
-from starlette.debug import get_debug_response
-from starlette.requests import Request
-from starlette.responses import PlainTextResponse, Response
-from starlette.types import ASGIApp, ASGIInstance, Receive, Message, Send, Scope
 import asyncio
 import http
 import typing
+
+from starlette.debug import get_debug_response
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send
 
 
 class HTTPException(Exception):

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -1,7 +1,7 @@
-import io
-import typing
 import asyncio
+import io
 import tempfile
+import typing
 from enum import Enum
 from urllib.parse import unquote
 

--- a/starlette/graphql.py
+++ b/starlette/graphql.py
@@ -1,11 +1,12 @@
-from starlette import status
-from starlette.responses import PlainTextResponse, Response, JSONResponse, HTMLResponse
-from starlette.requests import Request
-from starlette.types import ASGIInstance, Receive, Scope, Send
 import asyncio
 import functools
 import json
 import typing
+
+from starlette import status
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
+from starlette.types import ASGIInstance, Receive, Scope, Send
 
 try:
     import graphene

--- a/starlette/lifespan.py
+++ b/starlette/lifespan.py
@@ -3,8 +3,8 @@ import logging
 import traceback
 import typing
 from types import TracebackType
-from starlette.types import ASGIApp, ASGIInstance, Receive, Message, Send
 
+from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Send
 
 STATE_TRANSITION_ERROR = "Got invalid state transition on lifespan protocol."
 

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -1,9 +1,10 @@
 import asyncio
 import functools
 import typing
+
 from starlette.requests import Request
 from starlette.responses import StreamingResponse
-from starlette.types import ASGIApp, ASGIInstance, Scope, Receive, Send
+from starlette.types import ASGIApp, ASGIInstance, Receive, Scope, Send
 
 
 class BaseHTTPMiddleware:

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -1,10 +1,10 @@
-from starlette.datastructures import Headers, MutableHeaders, URL
-from starlette.responses import PlainTextResponse
-from starlette.types import ASGIApp, ASGIInstance, Receive, Scope, Send, Message
 import functools
-import typing
 import re
+import typing
 
+from starlette.datastructures import URL, Headers, MutableHeaders
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send
 
 ALL_METHODS = ("DELETE", "GET", "OPTIONS", "PATCH", "POST", "PUT")
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -1,8 +1,9 @@
-from starlette.datastructures import Headers, MutableHeaders
-from starlette.types import ASGIApp, ASGIInstance, Scope, Receive, Send, Message
 import gzip
 import io
 import typing
+
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send
 
 
 class GZipMiddleware:

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -1,0 +1,46 @@
+import functools
+import json
+from base64 import b64decode, b64encode
+
+import itsdangerous
+
+from starlette.datastructures import MutableHeaders
+from starlette.requests import Request
+from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send
+
+
+class SessionMiddleware:
+    def __init__(
+        self, app: ASGIApp, secret_key: str, session_cookie: str = "session"
+    ) -> None:
+        self.app = app
+        self.signer = itsdangerous.Signer(secret_key)
+        self.session_cookie = session_cookie
+
+    def __call__(self, scope: Scope) -> ASGIInstance:
+        if scope["type"] in ("http", "websocket"):
+            request = Request(scope)
+            if self.session_cookie in request.cookies:
+                data = request.cookies[self.session_cookie].encode("utf-8")
+                data = self.signer.unsign(data)
+                scope["session"] = json.loads(b64decode(data))
+            else:
+                scope["session"] = {}
+            return functools.partial(self.asgi, scope=scope)
+        return self.app(scope)  # pragma: no cover
+
+    async def asgi(self, receive: Receive, send: Send, scope: Scope) -> None:
+        inner = self.app(scope)
+
+        async def sender(message: Message) -> None:
+            if message["type"] == "http.response.start" and scope["session"]:
+                data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
+                data = self.signer.sign(data)
+                headers = MutableHeaders(scope=message)
+                headers["Set-Cookie"] = "%s=%s" % (
+                    self.session_cookie,
+                    data.decode("utf-8"),
+                )
+            await send(message)
+
+        await inner(receive, sender)

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -37,10 +37,8 @@ class SessionMiddleware:
                 data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
                 data = self.signer.sign(data)
                 headers = MutableHeaders(scope=message)
-                headers["Set-Cookie"] = "%s=%s" % (
-                    self.session_cookie,
-                    data.decode("utf-8"),
-                )
+                header_value = "%s=%s" % (self.session_cookie, data.decode("utf-8"))
+                headers.append("Set-Cookie", header_value)
             await send(message)
 
         await inner(receive, sender)

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -1,8 +1,8 @@
+import typing
+
 from starlette.datastructures import Headers
 from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, ASGIInstance, Scope
-import typing
-
 
 ENFORCE_DOMAIN_WILDCARD = "Domain wildcard patterns must be like '*.example.com'."
 

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -3,6 +3,7 @@ import io
 import sys
 import typing
 from concurrent.futures import ThreadPoolExecutor
+
 from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send
 
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -1,11 +1,12 @@
-import typing
+import http.cookies
 import json
+import typing
 from collections.abc import Mapping
 from urllib.parse import unquote
-import http.cookies
+
 from starlette.datastructures import URL, Headers, QueryParams
 from starlette.formparsers import FormParser, MultiPartParser
-from starlette.types import Scope, Receive, Message
+from starlette.types import Message, Receive, Scope
 
 try:
     from multipart.multipart import parse_options_header

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -78,6 +78,10 @@ class Request(Mapping):
         return self._cookies
 
     @property
+    def session(self) -> dict:
+        return self._scope["session"]
+
+    @property
     def receive(self) -> Receive:
         return self._receive
 

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -1,15 +1,15 @@
-import os
-import json
-import stat
-import typing
 import hashlib
 import http.cookies
+import json
+import os
+import stat
+import typing
 from email.utils import formatdate
 from mimetypes import guess_type
 from urllib.parse import quote_plus
 
 from starlette.background import BackgroundTask
-from starlette.datastructures import MutableHeaders, URL
+from starlette.datastructures import URL, MutableHeaders
 from starlette.types import Receive, Send
 
 try:

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -1,16 +1,16 @@
+import asyncio
+import inspect
 import re
 import typing
-import inspect
-import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
-from starlette.requests import Request
 from starlette.datastructures import URL
 from starlette.exceptions import HTTPException
-from starlette.responses import PlainTextResponse
-from starlette.types import Scope, ASGIApp, ASGIInstance, Send, Receive
-from starlette.websockets import WebSocket, WebSocketClose
 from starlette.graphql import GraphQLApp
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp, ASGIInstance, Receive, Scope, Send
+from starlette.websockets import WebSocket, WebSocketClose
 
 
 class NoMatchFound(Exception):

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -3,8 +3,8 @@ import stat
 
 from aiofiles.os import stat as aio_stat
 
-from starlette.responses import PlainTextResponse, FileResponse, Response
-from starlette.types import Send, Receive, Scope, ASGIInstance
+from starlette.responses import FileResponse, PlainTextResponse, Response
+from starlette.types import ASGIInstance, Receive, Scope, Send
 
 
 class StaticFiles:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -2,15 +2,15 @@ import asyncio
 import http
 import io
 import json
+import queue
 import threading
 import typing
+from urllib.parse import unquote, urljoin, urlparse
+
 import requests
-import queue
-from urllib.parse import unquote, urlparse, urljoin
 
+from starlette.types import ASGIApp, Message, Scope
 from starlette.websockets import WebSocketDisconnect
-from starlette.types import Message, Scope, ASGIApp
-
 
 # Annotations for `Session.request()`
 Cookies = typing.Union[

--- a/starlette/types.py
+++ b/starlette/types.py
@@ -1,6 +1,5 @@
 import typing
 
-
 Scope = typing.MutableMapping[str, typing.Any]
 Message = typing.MutableMapping[str, typing.Any]
 

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -1,12 +1,11 @@
 import enum
 import json
 import typing
-
 from collections.abc import Mapping
 from urllib.parse import unquote
 
 from starlette.datastructures import URL, Headers, QueryParams
-from starlette.types import Scope, Receive, Send, Message
+from starlette.types import Message, Receive, Scope, Send
 
 
 class WebSocketState(enum.Enum):

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1,8 +1,9 @@
+import pytest
+
 from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
-import pytest
 
 
 class CustomMiddleware(BaseHTTPMiddleware):

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -1,0 +1,33 @@
+from starlette.applications import Starlette
+from starlette.middleware.sessions import SessionMiddleware
+from starlette.responses import JSONResponse
+from starlette.testclient import TestClient
+
+app = Starlette()
+app.add_middleware(SessionMiddleware, secret_key="example")
+
+
+@app.route("/view_session")
+def view_session(request):
+    return JSONResponse({"session": request.session})
+
+
+@app.route("/update_session", methods=["POST"])
+async def update_session(request):
+    data = await request.json()
+    request.session.update(data)
+    return JSONResponse({"session": request.session})
+
+
+client = TestClient(app)
+
+
+def test_session():
+    response = client.get("/view_session")
+    assert response.json() == {"session": {}}
+
+    response = client.post("/update_session", json={"some": "data"})
+    assert response.json() == {"session": {"some": "data"}}
+
+    response = client.get("/view_session")
+    assert response.json() == {"session": {"some": "data"}}

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -1,6 +1,8 @@
 import io
-import pytest
 import sys
+
+import pytest
+
 from starlette.middleware.wsgi import WSGIMiddleware, build_environ
 from starlette.testclient import TestClient
 

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -1,13 +1,14 @@
+import os
+
 from starlette.applications import Starlette
 from starlette.datastructures import Headers
+from starlette.endpoints import HTTPEndpoint
 from starlette.exceptions import HTTPException
+from starlette.lifespan import LifespanContext
 from starlette.responses import JSONResponse, PlainTextResponse
-from starlette.routing import Router, Route, Mount, WebSocketRoute
+from starlette.routing import Mount, Route, Router, WebSocketRoute
 from starlette.staticfiles import StaticFiles
 from starlette.testclient import TestClient
-from starlette.endpoints import HTTPEndpoint
-from starlette.lifespan import LifespanContext
-import os
 
 
 class TrustedHostMiddleware:

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,7 +1,8 @@
-from starlette.responses import Response
-from starlette.background import BackgroundTask
-from starlette.testclient import TestClient
 import asyncio
+
+from starlette.background import BackgroundTask
+from starlette.responses import Response
+from starlette.testclient import TestClient
 
 
 def test_async_task():

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1,4 +1,4 @@
-from starlette.datastructures import Headers, MutableHeaders, QueryParams, URL
+from starlette.datastructures import URL, Headers, MutableHeaders, QueryParams
 
 
 def test_url():

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,7 +1,8 @@
+import pytest
+
+from starlette.debug import DebugMiddleware
 from starlette.responses import Response
 from starlette.testclient import TestClient
-from starlette.debug import DebugMiddleware
-import pytest
 
 
 def test_debug_text():

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,8 +1,9 @@
 import pytest
-from starlette.responses import PlainTextResponse
-from starlette.routing import Router, Route
-from starlette.testclient import TestClient
+
 from starlette.endpoints import HTTPEndpoint, WebSocketEndpoint
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route, Router
+from starlette.testclient import TestClient
 
 
 class Homepage(HTTPEndpoint):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,8 +1,9 @@
+import pytest
+
 from starlette.exceptions import ExceptionMiddleware, HTTPException
 from starlette.responses import PlainTextResponse
-from starlette.routing import Router, Route, WebSocketRoute
+from starlette.routing import Route, Router, WebSocketRoute
 from starlette.testclient import TestClient
-import pytest
 
 
 def raise_runtime_error(request):

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -1,8 +1,9 @@
-from starlette.formparsers import UploadFile
-from starlette.responses import JSONResponse
-from starlette.requests import Request
-from starlette.testclient import TestClient
 import os
+
+from starlette.formparsers import UploadFile
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.testclient import TestClient
 
 
 class ForceMultipartDict(dict):

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,8 +1,9 @@
+import graphene
 from graphql.execution.executors.asyncio import AsyncioExecutor
+
 from starlette.applications import Starlette
 from starlette.graphql import GraphQLApp
 from starlette.testclient import TestClient
-import graphene
 
 
 class Query(graphene.ObjectType):

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,5 +1,5 @@
 from starlette.applications import Starlette
-from starlette.lifespan import LifespanHandler, LifespanContext
+from starlette.lifespan import LifespanContext, LifespanHandler
 
 
 def test_lifespan_handler():

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,9 +1,10 @@
-from starlette.responses import JSONResponse
-from starlette.testclient import TestClient
-from starlette.requests import Request, ClientDisconnect
-from starlette.responses import Response
 import asyncio
+
 import pytest
+
+from starlette.requests import ClientDisconnect, Request
+from starlette.responses import JSONResponse, Response
+from starlette.testclient import TestClient
 
 
 def test_request_url():

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,3 +1,10 @@
+import asyncio
+import os
+
+import pytest
+
+from starlette import status
+from starlette.requests import Request
 from starlette.responses import (
     FileResponse,
     RedirectResponse,
@@ -5,12 +12,7 @@ from starlette.responses import (
     StreamingResponse,
     UJSONResponse,
 )
-from starlette.requests import Request
 from starlette.testclient import TestClient
-from starlette import status
-import asyncio
-import pytest
-import os
 
 
 def test_text_response():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,9 +1,10 @@
-from starlette.responses import Response
-from starlette.testclient import TestClient
-from starlette.exceptions import ExceptionMiddleware
-from starlette.routing import Route, Mount, NoMatchFound, Router, WebSocketRoute
-from starlette.websockets import WebSocket, WebSocketDisconnect
 import pytest
+
+from starlette.exceptions import ExceptionMiddleware
+from starlette.responses import Response
+from starlette.routing import Mount, NoMatchFound, Route, Router, WebSocketRoute
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocket, WebSocketDisconnect
 
 
 def homepage(request):

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -1,8 +1,9 @@
 import os
+
 import pytest
 
-from starlette.testclient import TestClient
 from starlette.staticfiles import StaticFiles
+from starlette.testclient import TestClient
 
 
 def test_staticfiles(tmpdir):

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,7 +1,8 @@
 import pytest
+
+from starlette import status
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocket, WebSocketDisconnect
-from starlette import status
 
 
 def test_websocket_url():


### PR DESCRIPTION
Adds support for `request.session`, with a signed-cookie session middleware implementation.

* Raise an appropriate error if `request.session` is accessed and `session` does not exist in the scope. eg. "SessionMiddleware must be installed"
* Clean up Cookies low level interfaces eg. support `Cookies(scope=...)`
* Ensure `WebSocket` interface includes cookies and sessions interfaces.
* Support session clearing.