### PR TITLE
Session property asserts that SessionMiddleware is installed

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -79,7 +79,7 @@ class Request(Mapping):
 
     @property
     def session(self) -> dict:
-        return self._scope["session"]
+        return self._scope.get("session", {})
 
     @property
     def receive(self) -> Receive:

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -79,7 +79,10 @@ class Request(Mapping):
 
     @property
     def session(self) -> dict:
-        return self._scope.get("session", {})
+        assert (
+            "session" in self._scope
+        ), "SessionMiddleware must be installed to access request.session"
+        return self._scope["session"]
 
     @property
     def receive(self) -> Receive:


### PR DESCRIPTION
This will prevent a server crash in the event that `session` is accessed without `SessionMiddlware` being initialized.