### PR TITLE
Fixes to static files documentation.

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -16,6 +16,6 @@ class App:
 app = DebugMiddleware(App)
 ```
 
-For a mode complete handling of exception cases you may wish to use Starlette's
+For a more complete handling of exception cases you may wish to use Starlette's
 [`ExceptionMiddleware`](../exceptions/) class instead, which also includes
 optional debug handling.

--- a/docs/staticfiles.md
+++ b/docs/staticfiles.md
@@ -1,5 +1,5 @@
 
-Starlette also includes an `StaticFiles` class for serving a specific directory:
+Starlette also includes a `StaticFiles` class for serving a specific directory:
 
 * `StaticFiles(directory)` - Serve any files in the given `directory`.
 
@@ -7,12 +7,12 @@ You can combine this ASGI application with Starlette's routing to provide
 comprehensive static file serving.
 
 ```python
-from starlette.routing import Router, Path, PathPrefix
+from starlette.routing import Router, Mount
 from starlette.staticfiles import StaticFiles
 
 
 app = Router(routes=[
-    PathPrefix('/static', app=StaticFiles(directory='static')),
+    Mount('/static', app=StaticFiles(directory='static')),
 ])
 ```
 


### PR DESCRIPTION
I fixed a grammar error. The example code did not work, since there are no Path and PathPrefix classes in starlette.routing. I replaced PathPrefix with Mount to get it to work.