### PR TITLE
Allow handler-like objects within routing

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -84,7 +84,7 @@ class Route(BaseRoute):
         self.endpoint = endpoint
         self.name = get_name(endpoint)
 
-        if inspect.isfunction(endpoint):
+        if inspect.isfunction(endpoint) or inspect.ismethod(endpoint):
             self.app = request_response(endpoint)
             if methods is None:
                 methods = ["GET"]

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -135,7 +135,7 @@ class WebSocketRoute(BaseRoute):
         self.endpoint = endpoint
         self.name = get_name(endpoint)
 
-        if inspect.isfunction(endpoint):
+        if inspect.isfunction(endpoint) or inspect.ismethod(endpoint):
             self.app = websocket_session(endpoint)
         else:
             self.app = endpoint


### PR DESCRIPTION
Small change to allow to use class methods or object methods as proper endpoints for Routes.

Example:

```python

test_uuid = "(?P<test_uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"

app = Starlette()


class TestHandler:
    def __init__(self):
        # dependencies for handling request
        pass

    async def get(self, request: Request):
        return UJSONResponse(request.path_params)


test_handler = TestHandler()


app.add_route(f'/test/{test_uuid}', test_handler.get)
```

Closes #159