### PR TITLE
Routing tweaks

### DIFF
--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -26,7 +26,8 @@ class HTTPEndpoint:
         if asyncio.iscoroutinefunction(handler):
             response = await handler(request)
         else:
-            response = handler(request)
+            loop = asyncio.get_event_loop()
+            response = await loop.run_in_executor(None, handler, request)
         return response
 
     async def method_not_allowed(self, request: Request) -> Response:

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -293,7 +293,7 @@ class Router:
             matched, child_scope = route.matches(scope)
             if matched:
                 return route(child_scope)
-        return self.not_found(scope)
+        return self.default(scope)
 
     def __eq__(self, other: typing.Any) -> bool:
         return isinstance(other, Router) and self.routes == other.routes

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -42,7 +42,8 @@ def request_response(func: typing.Callable) -> ASGIApp:
             if is_coroutine:
                 response = await func(request)
             else:
-                response = func(request)
+                loop = asyncio.get_event_loop()
+                response = await loop.run_in_executor(None, func, request)
             await response(receive, send)
 
         return awaitable
@@ -54,6 +55,7 @@ def websocket_session(func: typing.Callable) -> ASGIApp:
     """
     Takes a coroutine `func(session)`, and returns an ASGI application.
     """
+    # assert asyncio.iscoroutinefunction(func), "WebSocket endpoints must be async"
 
     def app(scope: Scope) -> ASGIInstance:
         async def awaitable(receive: Receive, send: Send) -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -43,6 +43,11 @@ def func_homepage(request):
     return Response("Hello, world!", media_type="text/plain")
 
 
+@app.route("/func", methods=["POST"])
+def contact(request):
+    return Response("Hello, POST!", media_type="text/plain")
+
+
 @app.websocket_route("/ws")
 async def websocket_endpoint(session):
     await session.accept()
@@ -98,6 +103,12 @@ def test_router_add_route():
     response = client.get("/func")
     assert response.status_code == 200
     assert response.text == "Hello, world!"
+
+
+def test_router_duplicate_path():
+    response = client.post("/func")
+    assert response.status_code == 200
+    assert response.text == "Hello, POST!"
 
 
 def test_router_add_websocket_route():


### PR DESCRIPTION
* Ensure url_path_for works with Mount('/{some_path_params}')
* Fix Router(default=) argument
* Support repeated paths, like: `@app.route("/", methods=["GET"])`, `@app.route("/", methods=["POST"])`
* Use the default ThreadPoolExecutor for all sync endpoints.