### PR TITLE
Fix the return value of `url_path_for` 

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -73,7 +73,7 @@ class Starlette:
 
         return decorator
 
-    def url_path_for(self, name: str, **path_params: str) -> URL:
+    def url_path_for(self, name: str, **path_params: str) -> str:
         url = self.router.url_path_for(name, **path_params)
         return url.path
 

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -74,7 +74,8 @@ class Starlette:
         return decorator
 
     def url_path_for(self, name: str, **path_params: str) -> URL:
-        return self.router.url_path_for(name, **path_params)
+        url = self.router.url_path_for(name, **path_params)
+        return url.path
 
     def __call__(self, scope: Scope) -> ASGIInstance:
         scope["app"] = self


### PR DESCRIPTION
Current `Starlette.url_path_for` returns the `URL` instance instead of `path` string. This example:
```python
@app.route("/")
async def homepage(request):
    return JSONResponse({"path": app.url_path_for("func", param="model")})
```
returns `TypeError: Object of type URL is not JSON serializable`.

`url_path_for` will now just return the `path` string

