### PR TITLE
Schema generation & return strings from `url_path_for`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ aiofiles
 graphene
 itsdangerous
 python-multipart
+pyyaml
 requests
 ujson
 

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -1,9 +1,9 @@
 import typing
 
-from starlette.datastructures import URL
+from starlette.datastructures import URL, URLPath
 from starlette.exceptions import ExceptionMiddleware
 from starlette.lifespan import LifespanHandler
-from starlette.routing import BaseRoute, Router
+from starlette.routing import BaseRoute, Router, URLPath
 from starlette.schemas import SchemaGenerator
 from starlette.types import ASGIApp, ASGIInstance, Scope
 
@@ -79,7 +79,7 @@ class Starlette:
 
         return decorator
 
-    def url_path_for(self, name: str, **path_params: str) -> URL:
+    def url_path_for(self, name: str, **path_params: str) -> URLPath:
         return self.router.url_path_for(name, **path_params)
 
     def __call__(self, scope: Scope) -> ASGIInstance:

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -4,6 +4,7 @@ from starlette.datastructures import URL
 from starlette.exceptions import ExceptionMiddleware
 from starlette.lifespan import LifespanHandler
 from starlette.routing import BaseRoute, Router
+from starlette.schemas import SchemaGenerator
 from starlette.types import ASGIApp, ASGIInstance, Scope
 
 
@@ -25,6 +26,11 @@ class Starlette:
     @debug.setter
     def debug(self, value: bool) -> None:
         self.exception_middleware.debug = value
+
+    @property
+    def schema(self) -> dict:
+        generator = SchemaGenerator()
+        return generator.get_schema(self.routes)
 
     def on_event(self, event_type: str) -> typing.Callable:
         return self.lifespan_handler.on_event(event_type)

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -3,7 +3,7 @@ import typing
 from starlette.datastructures import URL, URLPath
 from starlette.exceptions import ExceptionMiddleware
 from starlette.lifespan import LifespanHandler
-from starlette.routing import BaseRoute, Router, URLPath
+from starlette.routing import BaseRoute, Router
 from starlette.schemas import SchemaGenerator
 from starlette.types import ASGIApp, ASGIInstance, Scope
 

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -4,7 +4,7 @@ from starlette.datastructures import URL, URLPath
 from starlette.exceptions import ExceptionMiddleware
 from starlette.lifespan import LifespanHandler
 from starlette.routing import BaseRoute, Router
-from starlette.schemas import SchemaGenerator
+from starlette.schemas import BaseSchemaGenerator
 from starlette.types import ASGIApp, ASGIInstance, Scope
 
 
@@ -14,6 +14,7 @@ class Starlette:
         self.lifespan_handler = LifespanHandler()
         self.app = self.router
         self.exception_middleware = ExceptionMiddleware(self.router, debug=debug)
+        self.schema_generator = None  # type: typing.Optional[BaseSchemaGenerator]
 
     @property
     def routes(self) -> typing.List[BaseRoute]:
@@ -29,8 +30,8 @@ class Starlette:
 
     @property
     def schema(self) -> dict:
-        generator = SchemaGenerator()
-        return generator.get_schema(self.routes)
+        assert self.schema_generator is not None
+        return self.schema_generator.get_schema(self.routes)
 
     def on_event(self, event_type: str) -> typing.Callable:
         return self.lifespan_handler.on_event(event_type)

--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -15,17 +15,6 @@ class HTTPEndpoint:
         assert scope["type"] == "http"
         self.scope = scope
 
-    @classmethod
-    def methods(cls) -> typing.List[str]:
-        methods = [
-            method
-            for method in ["GET", "POST", "PUT", "PATCH", "DELETE"]
-            if hasattr(cls, method.lower())
-        ]
-        if "GET" in methods:
-            methods += ["HEAD"]
-        return methods
-
     async def __call__(self, receive: Receive, send: Send) -> None:
         request = Request(self.scope, receive=receive)
         response = await self.dispatch(request)

--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -15,6 +15,17 @@ class HTTPEndpoint:
         assert scope["type"] == "http"
         self.scope = scope
 
+    @classmethod
+    def methods(cls) -> typing.List[str]:
+        methods = [
+            method
+            for method in ["GET", "POST", "PUT", "PATCH", "DELETE"]
+            if hasattr(cls, method.lower())
+        ]
+        if "GET" in methods:
+            methods += ["HEAD"]
+        return methods
+
     async def __call__(self, receive: Receive, send: Send) -> None:
         request = Request(self.scope, receive=receive)
         response = await self.dispatch(request)

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -85,10 +85,10 @@ class Request(Mapping):
     def receive(self) -> Receive:
         return self._receive
 
-    def url_for(self, name: str, **path_params: typing.Any) -> URL:
+    def url_for(self, name: str, **path_params: typing.Any) -> str:
         router = self._scope["router"]
-        url = router.url_path_for(name, **path_params)
-        return url.replace(secure=self.url.is_secure, netloc=self.url.netloc)
+        url_path = router.url_path_for(name, **path_params)
+        return url_path.make_absolute_url(base_url=self.url)
 
     async def stream(self) -> typing.AsyncGenerator[bytes, None]:
         if hasattr(self, "_body"):

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -101,11 +101,15 @@ class Route(BaseRoute):
         self.name = get_name(endpoint)
 
         if inspect.isfunction(endpoint) or inspect.ismethod(endpoint):
+            # Endpoint is function or method. Treat it as `func(request) -> response`.
             self.app = request_response(endpoint)
             if methods is None:
                 methods = ["GET"]
         else:
+            # Endpoint is a class. Treat it as ASGI.
             self.app = endpoint
+            if methods is None and hasattr(endpoint, "methods"):
+                methods = endpoint.methods()
 
         self.methods = methods
         regex = "^" + path + "$"
@@ -157,8 +161,10 @@ class WebSocketRoute(BaseRoute):
         self.name = get_name(endpoint)
 
         if inspect.isfunction(endpoint) or inspect.ismethod(endpoint):
+            # Endpoint is function or method. Treat it as `func(websocket)`.
             self.app = websocket_session(endpoint)
         else:
+            # Endpoint is a class. Treat it as ASGI.
             self.app = endpoint
 
         regex = "^" + path + "$"

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -108,8 +108,6 @@ class Route(BaseRoute):
         else:
             # Endpoint is a class. Treat it as ASGI.
             self.app = endpoint
-            if methods is None and hasattr(endpoint, "methods"):
-                methods = endpoint.methods()
 
         self.methods = methods
         regex = "^" + path + "$"

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -1,11 +1,14 @@
 import inspect
+import typing
 
-from starlette.routing import Route
+import yaml
+
+from starlette.routing import BaseRoute, Route
 
 
 class SchemaGenerator:
-    def get_schema(self, routes):
-        paths = {}
+    def get_schema(self, routes: typing.List[BaseRoute]) -> dict:
+        paths = {}  # type: dict
 
         for route in routes:
             if not isinstance(route, Route):
@@ -13,19 +16,21 @@ class SchemaGenerator:
 
             if inspect.isfunction(route.endpoint) or inspect.ismethod(route.endpoint):
                 docstring = route.endpoint.__doc__
-                for method in route.methods:
+                for method in route.methods or ["GET"]:
                     if method == "HEAD":
                         continue
                     if route.path not in paths:
                         paths[route.path] = {}
-                    paths[route.path][method.lower()] = docstring
+                    data = yaml.safe_load(docstring) if docstring else {}
+                    paths[route.path][method.lower()] = data
             else:
-                for method in route.methods:
-                    if method == "HEAD":
+                for method in ["get", "post", "put", "patch", "delete", "options"]:
+                    if not hasattr(route.endpoint, method):
                         continue
-                    docstring = getattr(route.endpoint, method.lower()).__doc__
+                    docstring = getattr(route.endpoint, method).__doc__
                     if route.path not in paths:
                         paths[route.path] = {}
-                    paths[route.path][method.lower()] = docstring
+                    data = yaml.safe_load(docstring) if docstring else {}
+                    paths[route.path][method] = data
 
         return paths

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -1,0 +1,31 @@
+import inspect
+
+from starlette.routing import Route
+
+
+class SchemaGenerator:
+    def get_schema(self, routes):
+        paths = {}
+
+        for route in routes:
+            if not isinstance(route, Route):
+                continue
+
+            if inspect.isfunction(route.endpoint) or inspect.ismethod(route.endpoint):
+                docstring = route.endpoint.__doc__
+                for method in route.methods:
+                    if method == "HEAD":
+                        continue
+                    if route.path not in paths:
+                        paths[route.path] = {}
+                    paths[route.path][method.lower()] = docstring
+            else:
+                for method in route.methods:
+                    if method == "HEAD":
+                        continue
+                    docstring = getattr(route.endpoint, method.lower()).__doc__
+                    if route.path not in paths:
+                        paths[route.path] = {}
+                    paths[route.path][method.lower()] = docstring
+
+        return paths

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -1,12 +1,24 @@
 import inspect
 import typing
 
-import yaml
-
 from starlette.routing import BaseRoute, Route
 
+try:
+    import yaml
+except ImportError:  # pragma: nocover
+    yaml = None  # type: ignore
 
-class SchemaGenerator:
+
+class BaseSchemaGenerator:
+    def get_schema(self, routes: typing.List[BaseRoute]) -> dict:
+        raise NotImplementedError()  # pragma: no cover
+
+
+class SchemaGenerator(BaseSchemaGenerator):
+    def __init__(self, base_schema: dict) -> None:
+        assert yaml is not None, "`pyyaml` must be installed to use SchemaGenerator."
+        self.base_schema = base_schema
+
     def get_schema(self, routes: typing.List[BaseRoute]) -> dict:
         paths = {}  # type: dict
 
@@ -33,4 +45,6 @@ class SchemaGenerator:
                     data = yaml.safe_load(docstring) if docstring else {}
                     paths[route.path][method] = data
 
-        return paths
+        schema = dict(self.base_schema)
+        schema["paths"] = paths
+        return schema

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -59,10 +59,10 @@ class WebSocket(Mapping):
     def path_params(self) -> dict:
         return self._scope.get("path_params", {})
 
-    def url_for(self, name: str, **path_params: typing.Any) -> URL:
+    def url_for(self, name: str, **path_params: typing.Any) -> str:
         router = self._scope["router"]
-        url = router.url_path_for(name, **path_params)
-        return url.replace(secure=self.url.is_secure, netloc=self.url.netloc)
+        url_path = router.url_path_for(name, **path_params)
+        return url_path.make_absolute_url(base_url=self.url)
 
     async def receive(self) -> Message:
         """

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -99,6 +99,25 @@ def test_url_path_for():
         assert app.url_path_for("broken")
 
 
+def test_url_for():
+    assert (
+        app.url_path_for("homepage").make_absolute_url(base_url="https://example.org")
+        == "https://example.org/"
+    )
+    assert (
+        app.url_path_for("user", username="tomchristie").make_absolute_url(
+            base_url="https://example.org"
+        )
+        == "https://example.org/users/tomchristie"
+    )
+    assert (
+        app.url_path_for("websocket_endpoint").make_absolute_url(
+            base_url="https://example.org"
+        )
+        == "wss://example.org/ws"
+    )
+
+
 def test_router_add_route():
     response = client.get("/func")
     assert response.status_code == 200

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -13,31 +13,84 @@ def ws(session):
 
 @app.route("/users", methods=["GET", "HEAD"])
 def list_users(request):
-    """list_users"""
+    """
+    responses:
+      200:
+        description: A list of users.
+        examples:
+          [{"username": "tom"}, {"username": "lucy"}]
+    """
     pass  # pragma: no cover
 
 
 @app.route("/users", methods=["POST"])
 def create_user(request):
-    """create_user"""
+    """
+    responses:
+      200:
+        description: A user.
+        examples:
+          {"username": "tom"}
+    """
     pass  # pragma: no cover
 
 
 @app.route("/orgs")
 class OrganisationsEndpoint(HTTPEndpoint):
     def get(self, request):
-        """list_orgs"""
+        """
+        responses:
+          200:
+            description: A list of organisations.
+            examples:
+              [{"name": "Foo Corp."}, {"name": "Acme Ltd."}]
+        """
         pass  # pragma: no cover
 
     def post(self, request):
-        """create_org"""
+        """
+        responses:
+          200:
+            description: An organisation.
+            examples:
+              {"name": "Foo Corp."}
+        """
         pass  # pragma: no cover
 
 
 def test_schema_generation():
-    generator = SchemaGenerator()
-    schema = generator.get_schema(app.routes)
-    assert schema == {
-        "/users": {"get": "list_users", "post": "create_user"},
-        "/orgs": {"get": "list_orgs", "post": "create_org"},
+    assert app.schema == {
+        "/orgs": {
+            "get": {
+                "responses": {
+                    200: {
+                        "description": "A list of " "organisations.",
+                        "examples": [{"name": "Foo Corp."}, {"name": "Acme Ltd."}],
+                    }
+                }
+            },
+            "post": {
+                "responses": {
+                    200: {
+                        "description": "An organisation.",
+                        "examples": {"name": "Foo Corp."},
+                    }
+                }
+            },
+        },
+        "/users": {
+            "get": {
+                "responses": {
+                    200: {
+                        "description": "A list of users.",
+                        "examples": [{"username": "tom"}, {"username": "lucy"}],
+                    }
+                }
+            },
+            "post": {
+                "responses": {
+                    200: {"description": "A user.", "examples": {"username": "tom"}}
+                }
+            },
+        },
     }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,43 @@
+from starlette.applications import Starlette
+from starlette.endpoints import HTTPEndpoint
+from starlette.schemas import SchemaGenerator
+
+app = Starlette()
+
+
+@app.websocket_route("/ws")
+def ws(session):
+    """ws"""
+    pass  # pragma: no cover
+
+
+@app.route("/users", methods=["GET", "HEAD"])
+def list_users(request):
+    """list_users"""
+    pass  # pragma: no cover
+
+
+@app.route("/users", methods=["POST"])
+def create_user(request):
+    """create_user"""
+    pass  # pragma: no cover
+
+
+@app.route("/orgs")
+class OrganisationsEndpoint(HTTPEndpoint):
+    def get(self, request):
+        """list_orgs"""
+        pass  # pragma: no cover
+
+    def post(self, request):
+        """create_org"""
+        pass  # pragma: no cover
+
+
+def test_schema_generation():
+    generator = SchemaGenerator()
+    schema = generator.get_schema(app.routes)
+    assert schema == {
+        "/users": {"get": "list_users", "post": "create_user"},
+        "/orgs": {"get": "list_orgs", "post": "create_org"},
+    }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -3,6 +3,9 @@ from starlette.endpoints import HTTPEndpoint
 from starlette.schemas import SchemaGenerator
 
 app = Starlette()
+app.schema_generator = SchemaGenerator(
+    {"openapi": "3.0.0", "info": {"title": "Example API", "version": "1.0"}}
+)
 
 
 @app.websocket_route("/ws")
@@ -60,37 +63,41 @@ class OrganisationsEndpoint(HTTPEndpoint):
 
 def test_schema_generation():
     assert app.schema == {
-        "/orgs": {
-            "get": {
-                "responses": {
-                    200: {
-                        "description": "A list of " "organisations.",
-                        "examples": [{"name": "Foo Corp."}, {"name": "Acme Ltd."}],
+        "openapi": "3.0.0",
+        "info": {"title": "Example API", "version": "1.0"},
+        "paths": {
+            "/orgs": {
+                "get": {
+                    "responses": {
+                        200: {
+                            "description": "A list of " "organisations.",
+                            "examples": [{"name": "Foo Corp."}, {"name": "Acme Ltd."}],
+                        }
                     }
-                }
-            },
-            "post": {
-                "responses": {
-                    200: {
-                        "description": "An organisation.",
-                        "examples": {"name": "Foo Corp."},
+                },
+                "post": {
+                    "responses": {
+                        200: {
+                            "description": "An organisation.",
+                            "examples": {"name": "Foo Corp."},
+                        }
                     }
-                }
+                },
             },
-        },
-        "/users": {
-            "get": {
-                "responses": {
-                    200: {
-                        "description": "A list of users.",
-                        "examples": [{"username": "tom"}, {"username": "lucy"}],
+            "/users": {
+                "get": {
+                    "responses": {
+                        200: {
+                            "description": "A list of users.",
+                            "examples": [{"username": "tom"}, {"username": "lucy"}],
+                        }
                     }
-                }
-            },
-            "post": {
-                "responses": {
-                    200: {"description": "A user.", "examples": {"username": "tom"}}
-                }
+                },
+                "post": {
+                    "responses": {
+                        200: {"description": "A user.", "examples": {"username": "tom"}}
+                    }
+                },
             },
         },
     }


### PR DESCRIPTION
I've accidentally mixed two PRs in here, but may as well push on with it...

* `url_path_for` returns a str-subclass, not `URL()`
* Customizable schema generation support.

```python
from starlette.applications import Starlette
from starlette.schemas import SchemaGenerator

app = Starlette()
app.schema_generator = SchemaGenerator(
    {"openapi": "3.0.0", "info": {"title": "Example API", "version": "1.0"}}
)


@app.route("/users", methods=["GET"])
def list_users(request):
    """
    responses:
      200:
        description: A list of users.
        examples:
          [{"username": "tom"}, {"username": "lucy"}]
    """
    ...


@app.route("/users", methods=["POST"])
def create_user(request):
    """
    responses:
      200:
        description: A user.
        examples:
          {"username": "tom"}
    """
    ...

assert app.schema == {
    "openapi": "3.0.0",
    "info": {"title": "Example API", "version": "1.0"},
    "paths": {
        "/users": {
            "get": {
                "responses": {
                    200: {
                        "description": "A list of users.",
                        "examples": [{"username": "tom"}, {"username": "lucy"}],
                    }
                }
            },
            "post": {
                "responses": {
                    200: {"description": "A user.", "examples": {"username": "tom"}}
                }
            },
        },
    },
}
```

We'll be able to integrate all sorts of nice API docs, client libs etc. against this.

Not tied to any particular validation or anything like that, can write custom classes that inspect the endpoints in various ways.