### PR TITLE
Drop `add_graphql_route`, in favor of more consistent API style

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -46,7 +46,6 @@ You can use any of the following to add handled routes to the application:
 
 * `app.add_route(path, func, methods=["GET"])` - Add an HTTP route. The function may be either a coroutine or a regular function, with a signature like `func(request, **kwargs) -> response`.
 * `app.add_websocket_route(path, func)` - Add a websocket session route. The function must be a coroutine, with a signature like `func(session, **kwargs)`.
-* `app.add_graphql_route(path, schema, executor=None)` - Add a GraphQL route.
 * `@app.route(path)` - Add an HTTP route, decorator style.
 * `@app.websocket_route(path)` - Add a WebSocket route, decorator style.
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -5,6 +5,7 @@ Here's an example of integrating the support into your application.
 
 ```python
 from starlette.applications import Starlette
+from starlette.graphql import GraphQLApp
 import graphene
 
 
@@ -16,7 +17,7 @@ class Query(graphene.ObjectType):
 
 
 app = Starlette()
-app.add_graphql_route('/', schema=graphene.Schema(query=Query))
+app.add_route('/', GraphQLApp(schema=graphene.Schema(query=Query)))
 ```
 
 If you load up the page in a browser, you'll be served the GraphiQL tool,
@@ -50,5 +51,5 @@ class Query(graphene.ObjectType):
 app = Starlette()
 
 # We're using `executor=AsyncioExecutor()` here.
-app.add_graphql_route('/', schema=graphene.Schema(query=Query), executor=AsyncioExecutor())
+app.add_route('/', GraphQLApp(schema=graphene.Schema(query=Query, executor=AsyncioExecutor())))
 ```

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -53,9 +53,6 @@ class Starlette:
     ) -> None:
         self.router.add_route(path, route, methods=methods)
 
-    def add_graphql_route(self, path: str, schema: typing.Any) -> None:
-        self.router.add_graphql_route(path, schema)
-
     def add_websocket_route(self, path: str, route: typing.Callable) -> None:
         self.router.add_websocket_route(path, route)
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -7,7 +7,6 @@ from enum import Enum
 
 from starlette.datastructures import URL, URLPath
 from starlette.exceptions import HTTPException
-from starlette.graphql import GraphQLApp
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, ASGIInstance, Receive, Scope, Send
@@ -260,12 +259,6 @@ class Router:
     ) -> None:
         route = Route(path, endpoint=endpoint, methods=methods)
         self.routes.append(route)
-
-    def add_graphql_route(
-        self, path: str, schema: typing.Any, executor: typing.Any = None
-    ) -> None:
-        app = GraphQLApp(schema=schema, executor=executor)
-        self.add_route(path, endpoint=app)
 
     def add_websocket_route(self, path: str, endpoint: typing.Callable) -> None:
         route = WebSocketRoute(path, endpoint=endpoint)

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -84,7 +84,7 @@ def test_graphiql_get():
 
 def test_add_graphql_route():
     app = Starlette()
-    app.add_graphql_route("/", schema)
+    app.add_route("/", GraphQLApp(schema=schema))
     client = TestClient(app)
     response = client.get("/?query={ hello }")
     assert response.status_code == 200


### PR DESCRIPTION
Drop `app.add_graphql_route(...)` in favor of just using a standard `app.add_route(...)`