### PR TITLE
Finesse mount routing

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -100,7 +100,7 @@ class Route(BaseRoute):
         methods: typing.List[str] = None,
         include_in_schema: bool = True
     ) -> None:
-        assert path.startswith("/"), "Routed paths must alsways start '/'"
+        assert path.startswith("/"), "Routed paths must always start '/'"
         self.path = path
         self.endpoint = endpoint
         self.name = get_name(endpoint)
@@ -160,7 +160,7 @@ class Route(BaseRoute):
 
 class WebSocketRoute(BaseRoute):
     def __init__(self, path: str, *, endpoint: typing.Callable) -> None:
-        assert path.startswith("/"), "Routed paths must alsways start '/'"
+        assert path.startswith("/"), "Routed paths must always start '/'"
         self.path = path
         self.endpoint = endpoint
         self.name = get_name(endpoint)
@@ -208,6 +208,7 @@ class WebSocketRoute(BaseRoute):
 
 class Mount(BaseRoute):
     def __init__(self, path: str, app: ASGIApp) -> None:
+        assert path == "" or path.startswith("/"), "Routed paths must always start '/'"
         self.path = path.rstrip("/")
         self.app = app
         regex = "^" + self.path + "(?P<path>/.*)$"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -30,7 +30,7 @@ app = Router(
         Mount(
             "/users",
             app=Router(
-                [Route("", endpoint=users), Route("/{username}", endpoint=user)]
+                [Route("/", endpoint=users), Route("/{username}", endpoint=user)]
             ),
         ),
         Mount("/static", app=staticfiles),
@@ -192,7 +192,7 @@ def test_mount_urls():
 
     strictly_mounted = Router([Mount("/users/", ok)])
     client = TestClient(strictly_mounted)
-    assert client.get("/users").status_code == 404
+    assert client.get("/users").url == "http://testserver/users/"
     assert client.get("/users/").status_code == 200
     assert client.get("/users/a").status_code == 200
     assert client.get("/usersa").status_code == 404


### PR DESCRIPTION
Closes #160.

* Mounted routes will now only match if the submount is properly directory separated.
* Adds append slash redirect behaviors when a directory URL would have matched.
* Support `url_path_for('mounted', path=...)`, eg. for use with static files.
* Support `url_path_for('mount_name:sub_name', **params)`