### PR TITLE
Implement session expiry with configurable maximum age

### DIFF
--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -3,6 +3,7 @@ import json
 from base64 import b64decode, b64encode
 
 import itsdangerous
+from itsdangerous.exc import SignatureExpired
 
 from starlette.datastructures import MutableHeaders
 from starlette.requests import Request
@@ -30,7 +31,7 @@ class SessionMiddleware:
                 try:
                     data = self.signer.unsign(data, max_age=self.max_age)
                     scope["session"] = json.loads(b64decode(data))
-                except itsdangerous.exc.SignatureExpired:
+                except SignatureExpired:
                     scope["session"] = {}
             else:
                 scope["session"] = {}

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -3,7 +3,7 @@ import json
 from base64 import b64decode, b64encode
 
 import itsdangerous
-from itsdangerous.exc import SignatureExpired
+from itsdangerous.exc import BadTimeSignature, SignatureExpired
 
 from starlette.datastructures import MutableHeaders
 from starlette.requests import Request
@@ -31,7 +31,7 @@ class SessionMiddleware:
                 try:
                     data = self.signer.unsign(data, max_age=self.max_age)
                     scope["session"] = json.loads(b64decode(data))
-                except SignatureExpired:
+                except (BadTimeSignature, SignatureExpired):
                     scope["session"] = {}
             else:
                 scope["session"] = {}

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -3,29 +3,33 @@ from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import JSONResponse
 from starlette.testclient import TestClient
 
-app = Starlette()
-app.add_middleware(SessionMiddleware, secret_key="example")
 
-
-@app.route("/view_session")
 def view_session(request):
     return JSONResponse({"session": request.session})
 
 
-@app.route("/update_session", methods=["POST"])
 async def update_session(request):
     data = await request.json()
     request.session.update(data)
     return JSONResponse({"session": request.session})
 
 
-@app.route("/clear_session", methods=["POST"])
 async def clear_session(request):
     request.session.clear()
     return JSONResponse({"session": request.session})
 
 
+def create_app():
+    app = Starlette()
+    app.add_route("/view_session", view_session)
+    app.add_route("/update_session", update_session, methods=["POST"])
+    app.add_route("/clear_session", clear_session, methods=["POST"])
+    return app
+
+
 def test_session():
+    app = create_app()
+    app.add_middleware(SessionMiddleware, secret_key="example")
     client = TestClient(app)
 
     response = client.get("/view_session")
@@ -39,6 +43,18 @@ def test_session():
 
     response = client.post("/clear_session")
     assert response.json() == {"session": {}}
+
+    response = client.get("/view_session")
+    assert response.json() == {"session": {}}
+
+
+def test_session_expires():
+    app = create_app()
+    app.add_middleware(SessionMiddleware, secret_key="example", max_age=-1)
+    client = TestClient(app)
+
+    response = client.post("/update_session", json={"some": "data"})
+    assert response.json() == {"session": {"some": "data"}}
 
     response = client.get("/view_session")
     assert response.json() == {"session": {}}


### PR DESCRIPTION
Resolves #178 

This involved minimal changes; it should all be straight forward. Essentially I just swapped out the `Signer` instance for one of type `TimestampSigner` and added an optional `max_age` argument to the `SessionMiddleware` constructor. Then when we attempt to unsign the session, a `SignatureExpired` exception is raised if the age of the session exceeds `max_age`, and the scope's `session` attribute is cleared. I'm not thrilled about how I specified the default `max_age` value, but also can't really think of any reasonable alternatives.

I also had to refactor the tests a bit. To avoid interfering the the existing session-related tests, I created a simple app factory function to allow us to configure the middleware separately.

Let me know if you'd like any changes made :)