### PR TITLE
fixed issue 188,trailing spaces not allowed in header

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -107,7 +107,7 @@ class Response:
             cookie[key]["secure"] = True  # type: ignore
         if httponly:
             cookie[key]["httponly"] = True  # type: ignore
-        cookie_val = cookie.output(header="")
+        cookie_val = cookie.output(header="").strip()
         self.raw_headers.append((b"set-cookie", cookie_val.encode("latin-1")))
 
     def delete_cookie(self, key: str, path: str = "/", domain: str = None) -> None:


### PR DESCRIPTION
http.cookies output is created in following way:
```
def output(self, attrs=None, header="Set-Cookie:"):
	return "%s %s" % (header, self.OutputString(attrs)
```

our goal is to get rid standard Set-Cookie header, and create a tuple instead of string, but cookie_val is created with leading space if header is empty ("") by the http lib.

Based on https://tools.ietf.org/html/rfc2616 leading space is not allowed (HTTP/1.1)