### PR TITLE
StaticFiles will check if directory exists upon instantiation

### DIFF
--- a/docs/staticfiles.md
+++ b/docs/staticfiles.md
@@ -1,5 +1,5 @@
 
-Starlette also includes a `StaticFiles` class for serving files in  a given directory:
+Starlette also includes a `StaticFiles` class for serving files in a given directory:
 
 ### StaticFiles
 

--- a/docs/staticfiles.md
+++ b/docs/staticfiles.md
@@ -1,7 +1,12 @@
 
-Starlette also includes a `StaticFiles` class for serving a specific directory:
+Starlette also includes a `StaticFiles` class for serving files in  a given directory:
 
-* `StaticFiles(directory)` - Serve any files in the given `directory`.
+### StaticFiles
+
+Signature: `StaticFiles(directory, check_dir=True)`
+
+* `directory` - A string denoting the directory path
+* `check_dir` - Ensure that the directory exists upon instantiation. Defaults to `True`
 
 You can combine this ASGI application with Starlette's routing to provide
 comprehensive static file serving.

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -8,7 +8,9 @@ from starlette.types import ASGIInstance, Receive, Scope, Send
 
 
 class StaticFiles:
-    def __init__(self, *, directory: str) -> None:
+    def __init__(self, *, directory: str, check_dir: bool = True) -> None:
+        if check_dir and not os.path.isdir(directory):
+            raise RuntimeError("Directory '%s' does not exist" % directory)
         self.directory = directory
         self.config_checked = False
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -56,7 +56,7 @@ def test_staticfiles_with_missing_file_returns_404(tmpdir):
 
 def test_staticfiles_instantiated_with_missing_directory(tmpdir):
     with pytest.raises(RuntimeError) as exc:
-        path = os.path.join(tmpdir, 'no_such_directory')
+        path = os.path.join(tmpdir, "no_such_directory")
         app = StaticFiles(directory=path)
     assert "does not exist" in str(exc)
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -54,9 +54,16 @@ def test_staticfiles_with_missing_file_returns_404(tmpdir):
     assert response.text == "Not Found"
 
 
+def test_staticfiles_instantiated_with_missing_directory(tmpdir):
+    with pytest.raises(RuntimeError) as exc:
+        path = os.path.join(tmpdir, 'no_such_directory')
+        app = StaticFiles(directory=path)
+    assert "does not exist" in str(exc)
+
+
 def test_staticfiles_configured_with_missing_directory(tmpdir):
     path = os.path.join(tmpdir, "no_such_directory")
-    app = StaticFiles(directory=path)
+    app = StaticFiles(directory=path, check_dir=False)
     client = TestClient(app)
     with pytest.raises(RuntimeError) as exc:
         client.get("/example.txt")
@@ -68,7 +75,7 @@ def test_staticfiles_configured_with_file_instead_of_directory(tmpdir):
     with open(path, "w") as file:
         file.write("<file content>")
 
-    app = StaticFiles(directory=path)
+    app = StaticFiles(directory=path, check_dir=False)
     client = TestClient(app)
     with pytest.raises(RuntimeError) as exc:
         client.get("/example.txt")


### PR DESCRIPTION
Closes #185 

StaticFiles will now preform a runtime check once instantiated and `check_dir` has been added as a switch.