### PR TITLE
refactor: schemas now have better support for third party packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-import sys
 
 from setuptools import setup
 
@@ -43,7 +42,7 @@ setup(
     author='Tom Christie',
     author_email='tom@tomchristie.com',
     packages=get_packages('starlette'),
-    extras_require = {
+    extras_require={
         'full': [
             'aiofiles',
             'graphene',

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -21,42 +21,73 @@ class OpenAPIResponse(Response):
         return yaml.dump(content, default_flow_style=False).encode("utf-8")
 
 
+class EndpointInfo(typing.NamedTuple):
+    path: str
+    http_method: str
+    func: typing.Callable
+
+
 class BaseSchemaGenerator:
     def get_schema(self, routes: typing.List[BaseRoute]) -> dict:
         raise NotImplementedError()  # pragma: no cover
 
+    def get_endpoints(
+        self, routes: typing.List[BaseRoute]
+    ) -> typing.List[EndpointInfo]:
+        """
+        Given the routes, yields the following information:
 
-class SchemaGenerator(BaseSchemaGenerator):
-    def __init__(self, base_schema: dict) -> None:
-        assert yaml is not None, "`pyyaml` must be installed to use SchemaGenerator."
-        self.base_schema = base_schema
-
-    def get_schema(self, routes: typing.List[BaseRoute]) -> dict:
-        paths = {}  # type: dict
+        - path
+            eg: /users/
+        - http_method
+            one of 'get', 'post', 'put', 'patch', 'delete', 'options'
+        - func
+            method ready to extract the docstring
+        """
+        endpoints_info: list = []
 
         for route in routes:
             if not isinstance(route, Route) or not route.include_in_schema:
                 continue
 
             if inspect.isfunction(route.endpoint) or inspect.ismethod(route.endpoint):
-                docstring = route.endpoint.__doc__
                 for method in route.methods or ["GET"]:
                     if method == "HEAD":
                         continue
-                    if route.path not in paths:
-                        paths[route.path] = {}
-                    data = yaml.safe_load(docstring) if docstring else {}
-                    paths[route.path][method.lower()] = data
+                    endpoints_info.append(
+                        EndpointInfo(route.path, method.lower(), route.endpoint)
+                    )
             else:
                 for method in ["get", "post", "put", "patch", "delete", "options"]:
                     if not hasattr(route.endpoint, method):
                         continue
-                    docstring = getattr(route.endpoint, method).__doc__
-                    if route.path not in paths:
-                        paths[route.path] = {}
-                    data = yaml.safe_load(docstring) if docstring else {}
-                    paths[route.path][method] = data
+                    func = getattr(route.endpoint, method)
+                    endpoints_info.append(
+                        EndpointInfo(route.path, method.lower(), func)
+                    )
+        return endpoints_info
 
+    def parse_docstring(self, func_or_method: typing.Callable) -> dict:
+        """
+        Given a function, parse the docstring as YAML and return a dictionary of info.
+        """
+        docstring = func_or_method.__doc__
+        return yaml.safe_load(docstring) if docstring else {}
+
+
+class SchemaGenerator(BaseSchemaGenerator):
+    def __init__(self, base_schema: dict) -> None:
+        self.base_schema = base_schema
+
+    def get_schema(self, routes: typing.List[BaseRoute]) -> dict:
         schema = dict(self.base_schema)
-        schema["paths"] = paths
+        schema.setdefault("paths", {})
+        endpoints_info = self.get_endpoints(routes)
+
+        for endpoint in endpoints_info:
+            if endpoint.path not in schema["paths"]:
+                schema["paths"][endpoint.path] = {}
+            schema["paths"][endpoint.path][endpoint.http_method] = self.parse_docstring(
+                endpoint.func
+            )
         return schema


### PR DESCRIPTION
Hey @tomchristie this is my initial proposal for apispec support. I want to know what do you think. If you give me the green these are the next steps:

* tests
* docs

Also:

renamed: SchemaGenerator -> DictSchemaGenerator

relates: #189

Current schema generator would be used the same, but the name would change, and for APISpec here's an example:

```python
import pprint
from starlette.applications import Starlette
from starlette.schemas import (
    OpenAPIResponse,
    APISpecSchemaGenerator,
)
from marshmallow import Schema, fields
from apispec.ext.marshmallow import MarshmallowPlugin
from apispec import APISpec

app = Starlette()
app.schema_generator = APISpecSchemaGenerator(APISpec(
    title="Example API",
    version="1.0",
    openapi_version="3.0.0",
    info={"description": "best api every"},
    plugins=[MarshmallowPlugin()],
))


class UserSchema(Schema):
    id = fields.Int(dump_only=True)
    name = fields.Str(description="The user's name")


@app.route("/users", methods=["GET"])
def list_users(request):
    """
    responses:
      200:
        description: A list of users.
        schema:
            schema: User
        examples:
          [{"username": "tom"}, {"username": "lucy"}]
    """
    raise NotImplementedError()


@app.route("/users", methods=["POST"])
def create_user(request):
    """
    responses:
      200:
        description: A user.
        examples:
          {"username": "tom"}
    """
    raise NotImplementedError()


@app.route("/schema", methods=["GET"], include_in_schema=False)
def schema(request):
    return OpenAPIResponse(app.schema)


app.schema_generator.spec.definition("User", schema=UserSchema)
pp = pprint.PrettyPrinter(indent=2)
pp.pprint(app.schema)
```

