### PR TITLE
Return proper error response for an empty json body

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -6,6 +6,7 @@ from urllib.parse import unquote
 
 from starlette.datastructures import URL, Headers, QueryParams
 from starlette.formparsers import FormParser, MultiPartParser
+from starlette.responses import PlainTextResponse
 from starlette.types import Message, Receive, Scope
 
 try:
@@ -125,6 +126,11 @@ class Request(Mapping):
     async def json(self) -> typing.Any:
         if not hasattr(self, "_json"):
             body = await self.body()
+            if body is b'':
+                if "app" in self._scope:
+                    from starlette.exceptions import HTTPException
+                    raise HTTPException(status_code=400)
+                return PlainTextResponse("Bad Request", status_code=400)
             self._json = json.loads(body)
         return self._json
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -126,9 +126,10 @@ class Request(Mapping):
     async def json(self) -> typing.Any:
         if not hasattr(self, "_json"):
             body = await self.body()
-            if body is b'':
+            if body is b"":
                 if "app" in self._scope:
                     from starlette.exceptions import HTTPException
+
                     raise HTTPException(status_code=400)
                 return PlainTextResponse("Bad Request", status_code=400)
             self._json = json.loads(body)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,5 +1,4 @@
 import asyncio
-import inspect
 
 import pytest
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -180,7 +180,7 @@ def test_request_json_empty_inside_starlette_app():
     @app.route("/", methods=["POST"])
     async def get_json(request):
         data = await request.json()
-        return JSONResponse({"data": data})
+        return JSONResponse({"data": data})  # pragma: no cover
 
     client = TestClient(app)
     response = client.post("/")


### PR DESCRIPTION
This implements the idea I suggested in #135.

If the request is running inside a Starlette application, it will then be raised with `HTTPException` and handled by the exception middleware. A normal ASGI app will return a `PlainTextResponse` with a status of 400. However, there is the minor inconvenience of having to import `HTTPException` inside `Request.json` in order to avoid circular dependence errors.

