### PR TITLE
Minor doc fix for `AsyncioExecutor`

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -51,5 +51,5 @@ class Query(graphene.ObjectType):
 app = Starlette()
 
 # We're using `executor=AsyncioExecutor()` here.
-app.add_route('/', GraphQLApp(schema=graphene.Schema(query=Query, executor=AsyncioExecutor())))
+app.add_route('/', GraphQLApp(schema=graphene.Schema(query=Query), executor=AsyncioExecutor()))
 ```


### PR DESCRIPTION
The `executor` argument in the GraphQL doc example needs to be in the `GraphQLApp` args.