### PR TITLE
Include Jinja2 in the [full] optional package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
             'aiofiles',
             'graphene',
             'itsdangerous',
+            'jinja2',
             'python-multipart',
             'pyyaml',
             'requests',


### PR DESCRIPTION
Under **Dependencies** in the documentation, it states that Jinja2 is installed when using the `starlette[full]` optional package. Jinja2 will now be installed.