### PR TITLE
Add support for route converters

### DIFF
--- a/starlette/converters.py
+++ b/starlette/converters.py
@@ -1,0 +1,32 @@
+import typing
+
+
+class ValidationError(Exception):
+    pass
+
+
+class Converter:
+    def convert(self, value: str) -> typing.Any:
+        raise NotImplementedError()  # pragma: no cover
+
+
+class IntConverter(Converter):
+    def convert(self, value: str) -> int:
+        try:
+            converted_value = int(value)
+        except ValueError:
+            raise ValidationError(
+                "'%s' failed to convert '%s'" % (self.__class__.__name__, value)
+            )
+        return converted_value
+
+
+class FloatConverter(Converter):
+    def convert(self, value: str) -> float:
+        try:
+            converted_value = float(value)
+        except ValueError:
+            raise ValidationError(
+                "'%s' failed to convert '%s'" % (self.__class__.__name__, value)
+            )
+        return converted_value

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -137,9 +137,11 @@ class Route(BaseRoute):
         if ":" in path:
             # If we need to type coerce, find and parse all types out of the path.
             pattern = r"(:[^{}]*)"
-            types = re.findall(pattern, path)
-            self.types = [t.strip(":") for t in types]
-            self.path = re.sub(pattern, "", path)
+            matches = re.findall(pattern, path)
+            types = [match.strip(":") for match in matches]
+            if "" not in types:
+                self.types = types
+                self.path = re.sub(pattern, "", path)
 
         if self.types is not None and "path" in self.types:
             # Type converter is 'path'. Allow slashes to be used in parameter.


### PR DESCRIPTION
Refs #182. Here's what I think route converters could look like in Starlette. If nothing else, it can be used as a base to work against.

Supports:
* `{param:int}`
* `{param:float}`
* `{param:path}`

The `convert_params` interface allows new converters to be added easily.

Example usage:
```python
# Integer
@app.route("/get/{number:int}")
async def func(request):
    number = request.path_params["number"]
    return JSONResponse({"num": number})

response = client.get('/get/25')
number = response.json()["num"]
type(number) == int  # True

# Float
@app.route("/get/{number:float}")
async def func(request):
    number = request.path_params["number"]
    return JSONResponse({"num": number})

response = client.get('/get/25.5')
number = response.json()["num"]
type(number) == float  # True

# Path
@app.route("/get/{param:path}")
async def func(request):
    return PlainTextResponse("Hello, world!")

response = client.get('/get/hello/world/1')
response.text == "Hello, world!"  # True
response.status_code == 200  # True
```