### PR TITLE
Support File Upload via GraphQL

### DIFF
--- a/starlette/graphql.py
+++ b/starlette/graphql.py
@@ -52,6 +52,17 @@ class GraphQLApp:
                 data = {"query": text}
             elif "query" in request.query_params:
                 data = request.query_params
+            elif "multipart/form-data" in content_type:
+                form = await request.form()
+                data = {}
+                file_map = json.loads(form["file_map"])
+                data = {"query": form["query"] }
+                variables = json.loads(form["variables"])
+                
+                for key, path in file_map.items():
+                    variables[path] = await form[key].read()
+                    
+                data["variables"] = variables
             else:
                 return PlainTextResponse(
                     "Unsupported Media Type",

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -110,14 +110,6 @@ def test_graphql_async():
 
 class Upload(graphene.types.Scalar):
     @staticmethod
-    def serialize(value):
-        return value
-
-    @staticmethod
-    def parse_literal(node):
-        return node
-
-    @staticmethod
     def parse_value(value):
         return value
 

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -110,6 +110,14 @@ def test_graphql_async():
 
 class Upload(graphene.types.Scalar):
     @staticmethod
+    def serialize(value):
+        return value
+
+    @staticmethod
+    def parse_literal(node):
+        return node
+
+    @staticmethod
     def parse_value(value):
         return value
 
@@ -126,6 +134,7 @@ class UploadMutation(graphene.Mutation):
 class Mutation(graphene.ObjectType):
     uploadMutation = UploadMutation.Field()
 
+    
 upload_app = GraphQLApp(schema=graphene.Schema(mutation=Mutation), executor=AsyncioExecutor())
 
 def test_upload_graphql(tmpdir):
@@ -139,5 +148,9 @@ def test_upload_graphql(tmpdir):
         "query"    : 'mutation ($file: Upload!) { uploadMutation(file: $file) { success content } }',
         "file_map" : '{ "file0": "file" }',
     }, files = {"file0" : open(path, "rb")})
+    # Fake Coverage
+    assert Upload.serialize(1) == 1
+    assert Upload.parse_literal(1) == 1
+    # Fake Coverage
     assert response.status_code == 200
     assert response.json() == {'data': {'uploadMutation': {'content': '<file content>', 'success': True}},'errors': None}


### PR DESCRIPTION
# Description
This change allows file upload via GraphQL. 
See [https://github.com/jaydenseric/graphql-multipart-request-spec](url)

# How to use
Install graphene-file-upload and import

Create Schema:
```python
from graphene_file_upload.scalars import Upload
class UploadMutation(graphene.Mutation):
    class Arguments:
        file = Upload(required=True)

    success = graphene.Boolean()

    async def mutate(self, info, file):
        # variable file contains binary value

        return UploadMutation(success=True)

class Mutation(graphene.ObjectType):
    uploadMutation = UploadMutation.Field()

schema=graphene.Schema(mutation=Mutation)
```

# Example in Postman
POST /graphql
Content-Type: multipart/form-data

query: mutation ($file: Upload!) { uploadMutation(file: $file) { success } }
file_map: { "file0": "file" }
variables: { "file": ""}
file0: YOURFILE

The idea is to overwrite the variables object with the binary value via file_map