### PR TITLE
Support serving `index.html` for StaticFiles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
             'aiofiles',
             'graphene',
             'itsdangerous',
+            'jinja2',
             'python-multipart',
             'pyyaml',
             'requests',

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -55,6 +55,18 @@ def test_staticfiles_with_missing_file_returns_404(tmpdir):
     assert response.text == "Not Found"
 
 
+def test_staticfiles_with_serve_index_html_and_missing_file(tmpdir):
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("<h1>Success</h1>")
+
+    app = StaticFiles(directory=tmpdir, serve_index_html=True)
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.text == "<h1>Success</h1>"
+
+
 def test_staticfiles_instantiated_with_missing_directory(tmpdir):
     with pytest.raises(RuntimeError) as exc:
         path = os.path.join(tmpdir, "no_such_directory")


### PR DESCRIPTION
See #146 

`StaticFiles` now takes an optional `serve_index_html` parameter which will attempt to serve `index.html` from the static directory if no file is provided in the request, otherwise serve the regular "Not Found" response.

(Also I apparently screwed something up in my repo and my previous commit is tagging along, so just ignore it :wink:)