### PR TITLE
Clean up all unused imports

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -1,6 +1,6 @@
 import typing
 
-from starlette.datastructures import URL, URLPath
+from starlette.datastructures import URLPath
 from starlette.exceptions import ExceptionMiddleware
 from starlette.lifespan import LifespanHandler
 from starlette.middleware.base import BaseHTTPMiddleware

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -1,5 +1,5 @@
 import typing
-from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urlparse
+from urllib.parse import ParseResult, parse_qsl, urlencode, urlparse
 
 from starlette.types import Scope
 

--- a/starlette/lifespan.py
+++ b/starlette/lifespan.py
@@ -1,6 +1,4 @@
 import asyncio
-import logging
-import traceback
 import typing
 from types import TracebackType
 

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -2,7 +2,7 @@ import functools
 import re
 import typing
 
-from starlette.datastructures import URL, Headers, MutableHeaders
+from starlette.datastructures import Headers, MutableHeaders
 from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -1,6 +1,5 @@
 import gzip
 import io
-import typing
 
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -4,7 +4,7 @@ import sys
 import typing
 
 from starlette.concurrency import run_in_threadpool
-from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send
+from starlette.types import ASGIInstance, Message, Receive, Scope, Send
 
 
 def build_environ(scope: Scope, body: bytes) -> dict:

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -2,7 +2,6 @@ import http.cookies
 import json
 import typing
 from collections.abc import Mapping
-from urllib.parse import unquote
 
 from starlette.datastructures import URL, Headers, QueryParams
 from starlette.formparsers import FormParser, MultiPartParser

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -2,7 +2,6 @@ import asyncio
 import inspect
 import re
 import typing
-from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 
 from starlette.concurrency import run_in_threadpool

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -2,7 +2,6 @@ import enum
 import json
 import typing
 from collections.abc import Mapping
-from urllib.parse import unquote
 
 from starlette.datastructures import URL, Headers, QueryParams
 from starlette.types import Message, Receive, Scope, Send

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -1,4 +1,3 @@
-import io
 import sys
 
 import pytest

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from starlette.background import BackgroundTask
 from starlette.responses import Response
 from starlette.testclient import TestClient

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,6 +1,5 @@
 import pytest
 
-from starlette.exceptions import ExceptionMiddleware
 from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.routing import Mount, NoMatchFound, Route, Router, WebSocketRoute
 from starlette.testclient import TestClient


### PR DESCRIPTION
It would be useful if the linting script could cover this too. `flake8` possibly? However, there's the issue where imports used specifically for commented type defs would be flagged as errors by `flake8`.

For example:
In `starlette/applications`:
```python
from starlette.schemas import BaseSchemaGenerator
...
self.schema_generator = None  # type: typing.Optional[BaseSchemaGenerator]
```