### PR TITLE
add tests for chunked requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .coverage
 .pytest_cache/
+.mypy_cache/
 starlette.egg-info/
 venv/


### PR DESCRIPTION
Was doing some research on ASGI and found the `testclient` from `starlette` extremely helpful, but it was missing the functionality of passing a generator as body, which is supported by `requests`. So I added that to `_TestClient` and because there's no existing tests for chunked encoding requests, I also added that.