### PR TITLE
Add context with request when executing GraphQL query

### DIFF
--- a/starlette/graphql.py
+++ b/starlette/graphql.py
@@ -85,7 +85,9 @@ class GraphQLApp:
         )
         return JSONResponse(response_data, status_code=status_code)
 
-    async def execute(self, request, query, variables=None, operation_name=None):  # type: ignore
+    async def execute(
+        self, request, query, variables=None, operation_name=None
+    ):  # type: ignore
         context = dict(request=request)
 
         if self.is_async:
@@ -95,7 +97,7 @@ class GraphQLApp:
                 operation_name=operation_name,
                 executor=self.executor,
                 return_promise=True,
-                context=context
+                context=context,
             )
         else:
             return await run_in_threadpool(
@@ -103,7 +105,7 @@ class GraphQLApp:
                 query,
                 variables=variables,
                 operation_name=operation_name,
-                context=context
+                context=context,
             )
 
     async def handle_graphiql(self, request: Request) -> Response:

--- a/starlette/graphql.py
+++ b/starlette/graphql.py
@@ -85,9 +85,9 @@ class GraphQLApp:
         )
         return JSONResponse(response_data, status_code=status_code)
 
-    async def execute(
+    async def execute(  # type: ignore
         self, request, query, variables=None, operation_name=None
-    ):  # type: ignore
+    ):
         context = dict(request=request)
 
         if self.is_async:

--- a/starlette/graphql.py
+++ b/starlette/graphql.py
@@ -73,7 +73,7 @@ class GraphQLApp:
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
 
-        result = await self.execute(query, variables)
+        result = await self.execute(request, query, variables)
         error_data = (
             [format_graphql_error(err) for err in result.errors]
             if result.errors
@@ -85,7 +85,9 @@ class GraphQLApp:
         )
         return JSONResponse(response_data, status_code=status_code)
 
-    async def execute(self, query, variables=None, operation_name=None):  # type: ignore
+    async def execute(self, request, query, variables=None, operation_name=None):  # type: ignore
+        context = dict(request=request)
+
         if self.is_async:
             return await self.schema.execute(
                 query,
@@ -93,6 +95,7 @@ class GraphQLApp:
                 operation_name=operation_name,
                 executor=self.executor,
                 return_promise=True,
+                context=context
             )
         else:
             return await run_in_threadpool(
@@ -100,6 +103,7 @@ class GraphQLApp:
                 query,
                 variables=variables,
                 operation_name=operation_name,
+                context=context
             )
 
     async def handle_graphiql(self, request: Request) -> Response:

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -25,7 +25,11 @@ class Query(graphene.ObjectType):
         return "Hello " + name
 
     def resolve_whoami(self, info):
-        return "a mystery" if info.context["request"]["user"] is None else info.context["request"]["user"]
+        return (
+            "a mystery"
+            if info.context["request"]["user"] is None
+            else info.context["request"]["user"]
+        )
 
 
 schema = graphene.Schema(query=Query)
@@ -111,7 +115,9 @@ def test_graphql_context():
     app.add_middleware(FakeAuthMiddleware)
     app.add_route("/", GraphQLApp(schema=schema))
     client = TestClient(app)
-    response = client.post("/", json={"query": "{ whoami }"}, headers={'Authorization': 'Bearer 123'})
+    response = client.post(
+        "/", json={"query": "{ whoami }"}, headers={"Authorization": "Bearer 123"}
+    )
     assert response.status_code == 200
     assert response.json() == {"data": {"whoami": "Jane"}, "errors": None}
 

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,16 +1,40 @@
+import functools
+
 import graphene
 from graphql.execution.executors.asyncio import AsyncioExecutor
 
+from starlette.datastructures import Headers
 from starlette.applications import Starlette
 from starlette.graphql import GraphQLApp
 from starlette.testclient import TestClient
 
 
+class FakeAuthMiddleware:
+    def __init__(self, app) -> None:
+        self.app = app
+
+    def __call__(self, scope):
+        return functools.partial(self.asgi, scope=scope)
+
+    async def asgi(self, receive, send, scope) -> None:
+        headers = Headers(scope=scope)
+        if headers.get('Authorization') == 'Bearer 123':
+            scope["user"] = "Jane"
+        else:
+            scope["user"] = None
+        inner = self.app(scope)
+        await inner(receive, send)
+
+
 class Query(graphene.ObjectType):
     hello = graphene.String(name=graphene.String(default_value="stranger"))
+    whoami = graphene.String()
 
     def resolve_hello(self, info, name):
         return "Hello " + name
+
+    def resolve_whoami(self, info):
+        return "a mystery" if info.context["request"]["user"] is None else info.context["request"]["user"]
 
 
 schema = graphene.Schema(query=Query)
@@ -89,6 +113,16 @@ def test_add_graphql_route():
     response = client.get("/?query={ hello }")
     assert response.status_code == 200
     assert response.json() == {"data": {"hello": "Hello stranger"}, "errors": None}
+
+
+def test_graphql_context():
+    app = Starlette()
+    app.add_middleware(FakeAuthMiddleware)
+    app.add_route("/", GraphQLApp(schema=schema))
+    client = TestClient(app)
+    response = client.post("/", json={"query": "{ whoami }"}, headers={'Authorization': 'Bearer 123'})
+    assert response.status_code == 200
+    assert response.json() == {"data": {"whoami": "Jane"}, "errors": None}
 
 
 class ASyncQuery(graphene.ObjectType):

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,10 +1,8 @@
-import functools
-
 import graphene
 from graphql.execution.executors.asyncio import AsyncioExecutor
 
-from starlette.datastructures import Headers
 from starlette.applications import Starlette
+from starlette.datastructures import Headers
 from starlette.graphql import GraphQLApp
 from starlette.testclient import TestClient
 
@@ -14,16 +12,9 @@ class FakeAuthMiddleware:
         self.app = app
 
     def __call__(self, scope):
-        return functools.partial(self.asgi, scope=scope)
-
-    async def asgi(self, receive, send, scope) -> None:
         headers = Headers(scope=scope)
-        if headers.get('Authorization') == 'Bearer 123':
-            scope["user"] = "Jane"
-        else:
-            scope["user"] = None
-        inner = self.app(scope)
-        await inner(receive, send)
+        scope["user"] = "Jane" if headers.get("Authorization") == "Bearer 123" else None
+        return self.app(scope)
 
 
 class Query(graphene.ObjectType):


### PR DESCRIPTION
Currently, there is no way to access the `request` object within a GraphQL resolver or mutation. I think this is problematic because it makes some middlewares useless in a GraphQL context:

1. If I want to authenticate my users, I will probably have to store the logged in user in the scope
2. The database middleware presented in #243 adds a `@db` property on the request object

I suggest to pass a simple dict context containing the request when executing GraphQL stuff.

What do you think?