### PR TITLE
Resource middlewares

### DIFF
--- a/starlette/middleware/resource.py
+++ b/starlette/middleware/resource.py
@@ -1,0 +1,64 @@
+import functools
+import typing
+
+from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send
+
+
+class ResourceMiddleware:
+    def __init__(self, app: ASGIApp, name: str) -> None:
+        self.app = app
+        self.name = name
+
+    def __call__(self, scope: Scope) -> ASGIInstance:
+        if scope["type"] == "lifespan":
+            return ResourceLifespan(self.app, self, scope)
+        return functools.partial(self.asgi, scope=scope)
+
+    async def asgi(self, receive: Receive, send: Send, scope: Scope) -> None:
+        if "resources" not in scope:
+            scope["resources"] = {}
+        elif self.name in scope["resources"]:
+            raise ValueError(f"Resource {self.name} is already registered")
+
+        resource = await self.get_resource(scope)
+        try:
+            scope["resources"][self.name] = resource
+            inner = self.app(scope)
+            await inner(receive, send)
+        finally:
+            await self.clean_resource(resource)
+
+    async def get_resource(self, scope):  # type: ignore
+        raise NotImplementedError()  # pragma: no cover
+
+    async def clean_resource(self, resource: typing.Any) -> None:
+        pass  # pragma: no cover
+
+    async def startup(self) -> None:
+        pass  # pragma: no cover
+
+    async def shutdown(self) -> None:
+        pass  # pragma: no cover
+
+
+class ResourceLifespan:
+    def __init__(
+        self, app: ASGIApp, middleware: ResourceMiddleware, scope: Scope
+    ) -> None:
+        self.inner = app(scope)
+        self.middleware = middleware
+
+    async def __call__(self, receive: Receive, send: Send) -> None:
+        try:
+
+            async def receiver() -> Message:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    await self.middleware.startup()
+                elif message["type"] == "lifespan.shutdown":
+                    await self.middleware.shutdown()
+                return message
+
+            await self.inner(receiver, send)
+        finally:
+            self.middleware = None  # type: ignore

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -83,6 +83,12 @@ class Request(Mapping):
         ), "SessionMiddleware must be installed to access request.session"
         return self._scope["session"]
 
+    def resource(self, name: str) -> typing.Any:
+        assert "resources" in self._scope and name in self._scope["resources"], (
+            "There is no resource middleware registered for %s" % name
+        )
+        return self._scope["resources"][name]
+
     @property
     def receive(self) -> Receive:
         return self._receive

--- a/tests/middleware/test_resource.py
+++ b/tests/middleware/test_resource.py
@@ -1,0 +1,71 @@
+import pytest
+
+from starlette.applications import Starlette
+from starlette.datastructures import Headers
+from starlette.middleware.resource import ResourceMiddleware
+from starlette.responses import JSONResponse
+from starlette.testclient import TestClient
+
+
+class Store:
+    def get_last_order(self):
+        return "3 apples"
+
+    def close(self):
+        pass
+
+
+class StoreMiddleware(ResourceMiddleware):
+    async def get_resource(self, scope):
+        return Store()
+
+    async def clean_resource(self, resource):
+        resource.close()
+
+    async def startup(self) -> None:
+        pass  # for example, create a connection pool
+
+    async def shutdown(self) -> None:
+        pass  # and close the connection pool
+
+
+class AuthMiddleware(ResourceMiddleware):
+    async def get_resource(self, scope):
+        headers = Headers(scope=scope)
+        return "Jane" if headers.get("Authorization") == "Bearer 123" else None
+
+
+def test_resource_middlewares():
+    app = Starlette()
+    app.add_middleware(StoreMiddleware, name="store")
+    app.add_middleware(AuthMiddleware, name="user")
+
+    @app.route("/last-order")
+    def last_order(request):
+        user = request.resource("user")
+        store = request.resource("store")
+
+        if user is None:
+            return JSONResponse({})
+
+        return JSONResponse({"customer": user, "lastOrder": store.get_last_order()})
+
+    with TestClient(app) as client:
+        response = client.get("/last-order")
+        assert response.json() == {}
+        response = client.get("/last-order", headers={"Authorization": "Bearer 123"})
+        assert response.json() == {"customer": "Jane", "lastOrder": "3 apples"}
+
+
+def test_double_resource_registration():
+    app = Starlette()
+    app.add_middleware(StoreMiddleware, name="store")
+    app.add_middleware(AuthMiddleware, name="store")
+
+    @app.route("/last-order")
+    def last_order(request):
+        return JSONResponse({})  # pragma: no cover
+
+    with TestClient(app) as client:
+        with pytest.raises(ValueError):
+            client.get("/last-order")


### PR DESCRIPTION
I think it would be great to be able to attach "resources" objects to the scope/request. By resources, I mean either service resources (such as a database connection) or data resources (such as the user corresponding to an auth token).

I really like the way you implemented the db property in #243, but I believe other users would enjoy the flexibility of adding their own services or resources to the scope and to the request (other database engines, multiple databases, authentication...). My code here is "just" a generalisation of the code in your PR, so that we can do stuff like:

```python
@app.route("/last-order")
def last_order(request):
    user = request.resource("user")
    store = request.resource("store")
    if user is None:
        return JSONResponse({})
    return JSONResponse({"customer": user, "lastOrder": store.get_last_order()})
```

Ideally, we should be able to access such resources in a websocket endpoint.

What do you think about the general idea here?