### PR TITLE
Make it compatible with PEP-561, a.k.a. mypy support for depending packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ setup(
     author='Tom Christie',
     author_email='tom@tomchristie.com',
     packages=get_packages('starlette'),
+    package_data = {
+        'starlette': ['py.typed'],
+    },
     extras_require={
         'full': [
             'aiofiles',


### PR DESCRIPTION
### Make it compatible with PEP-561, a.k.a. mypy support for depending packages

Apparently `mypy` doesn't check types for installed packages that don't have the marker declaring them as such.

I'm following the instructions in `mypy` about [Making PEP 561 compatible packages](https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages)

---

### Use case:

I'm building stuff that depends on Starlette, but when I run `mypy` on my package, I get some errors like: 

```
error: Cannot find module named 'starlette.requests'
```

When I clone Starlette and point `MYPYPATH` to the clonned Starlette directory, as in:

```bash
MYPYPATH=/home/user/code/starlette mypy my-project
```

The errors dissapear.

This is what I expect to solve with the PR.