### PR TITLE
Doc: Fix FileResponse path argument

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -195,6 +195,6 @@ class App:
         self.scope = scope
 
     async def __call__(self, receive, send):
-        response = FileResponse('/statics/favicon.ico')
+        response = FileResponse('statics/favicon.ico')
         await response(receive, send)
 ```


### PR DESCRIPTION
I'm not sure what causes this but when I first tested the FileResponse with path argument leading / throws `file doesn't exist error`. 

```
response = FileResponse('/statics/favicor.ico') # Not Working
response = FileResponse('statics/favicon.ico') # Working
```
I'm using Python 3.7.1 and also I tested with Python 3.6.5 ( Linux ). 