### PR TITLE
routing: fix KeyError with optional group

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -175,6 +175,8 @@ class Route(BaseRoute):
             if match:
                 matched_params = match.groupdict()
                 for key, value in matched_params.items():
+                    if key not in self.param_convertors:
+                        continue
                     matched_params[key] = self.param_convertors[key].convert(value)
                 path_params = dict(scope.get("path_params", {}))
                 path_params.update(matched_params)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -65,6 +65,13 @@ def path_convertor(request):
     return JSONResponse({"path": path})
 
 
+@app.route(r"/optional(?P<optional>\+[^/]+)?/(?P<suffix>.*)")
+def optional(request):
+    optional = request.path_params["optional"]
+    suffix = request.path_params["suffix"]
+    return JSONResponse({"optional": optional, "suffix": suffix})
+
+
 @app.websocket_route("/ws")
 async def websocket_endpoint(session):
     await session.accept()
@@ -106,6 +113,16 @@ def test_router():
     response = client.get("/static/123")
     assert response.status_code == 200
     assert response.text == "xxxxx"
+
+
+def test_router_optional():
+    response = client.get("/optional/suffix")
+    assert response.status_code == 200
+    assert response.json() == {"optional": None, "suffix": "suffix"}
+
+    response = client.get("/optional+provided/suffix")
+    assert response.status_code == 200
+    assert response.json() == {"optional": "+provided", "suffix": "suffix"}
 
 
 def test_route_converters():


### PR DESCRIPTION
14650bf caused a regression when using an optional regexp group
(`(?P<foo>…)?/…`).

Not sure about the fix, but at least there is a test for it included.. :)