### PR TITLE
Add BackgroundTasks for multiple jobs. Support GraphQL background tasks.

### DIFF
--- a/docs/background.md
+++ b/docs/background.md
@@ -6,6 +6,8 @@ the response has been sent.
 
 ### Background Task
 
+Used to add a single background task to a response.
+
 Signature: `BackgroundTask(func, *args, **kwargs)`
 
 ```python
@@ -26,4 +28,36 @@ async def signup(request):
 
 async def send_welcome_email(to_address):
     ...
+```
+
+### BackgroundTasks
+
+Used to add multiple background tasks to a response.
+
+Signature: `BackgroundTasks(tasks=[])`
+
+```python
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.background import BackgroundTasks
+
+app = Starlette()
+
+@app.route('/user/signup', methods=['POST'])
+async def signup(request):
+    data = await request.json()
+    username = data['username']
+    email = data['email']
+    tasks = BackgroundTasks()
+    tasks.add_task(send_welcome_email, to_address=email)
+    tasks.add_task(send_admin_notification, username=username)
+    message = {'status': 'Signup successful'}
+    return JSONResponse(message, background=tasks)
+
+async def send_welcome_email(to_address):
+    ...
+
+async def send_admin_notification(username):
+    ...
+
 ```

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -41,6 +41,27 @@ class Query(graphene.ObjectType):
         return request.headers.get("User-Agent", "<unknown>")
 ```
 
+## Adding background tasks
+
+You can add background tasks to run once the response has been sent.
+
+```python
+class Query(graphene.ObjectType):
+    user_agent = graphene.String()
+
+    def resolve_user_agent(self, info):
+        """
+        Return the User-Agent of the incoming request.
+        """
+        user_agent = request.headers.get("User-Agent", "<unknown>")
+        background = info.context["background"]
+        background.add_task(log_user_agent, user_agent=user_agent)
+        return user_agent
+
+async def log_user_agent(user_agent):
+    ...
+```
+
 ## Sync or Async executors
 
 If you're working with a standard ORM, then just use regular function calls for

--- a/starlette/background.py
+++ b/starlette/background.py
@@ -18,3 +18,18 @@ class BackgroundTask:
             await self.func(*self.args, **self.kwargs)
         else:
             await run_in_threadpool(self.func, *self.args, **self.kwargs)
+
+
+class BackgroundTasks(BackgroundTask):
+    def __init__(self, tasks: typing.Sequence[BackgroundTask] = []):
+        self.tasks = list(tasks)
+
+    def add_task(
+        self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any
+    ) -> None:
+        task = BackgroundTask(func, *args, **kwargs)
+        self.tasks.append(task)
+
+    async def __call__(self) -> None:
+        for task in self.tasks:
+            await task()

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,4 +1,4 @@
-from starlette.background import BackgroundTask
+from starlette.background import BackgroundTask, BackgroundTasks
 from starlette.responses import Response
 from starlette.testclient import TestClient
 
@@ -49,3 +49,29 @@ def test_sync_task():
     response = client.get("/")
     assert response.text == "task initiated"
     assert TASK_COMPLETE
+
+
+def test_multiple_tasks():
+    TASK_COUNTER = 0
+
+    def increment(amount):
+        nonlocal TASK_COUNTER
+        TASK_COUNTER += amount
+
+    def app(scope):
+        async def asgi(receive, send):
+            tasks = BackgroundTasks()
+            tasks.add_task(increment, amount=1)
+            tasks.add_task(increment, amount=2)
+            tasks.add_task(increment, amount=3)
+            response = Response(
+                "tasks initiated", media_type="text/plain", background=tasks
+            )
+            await response(receive, send)
+
+        return asgi
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.text == "tasks initiated"
+    assert TASK_COUNTER == 1 + 2 + 3


### PR DESCRIPTION
Closes #180

Adding background tasks from GraphQL:

```python
class Query(graphene.ObjectType):
    ...

    def resolve_some_field(self, info):
        ...
        background = info.context["background"]
        background.add_task(func, *args, **kwargs)
        ...
```

Adding multiple background tasks to a response:

```python
async def some_endpoint(request):
    tasks = BackgroundTasks()
    tasks.add_task(func, *args, **kwargs)
    tasks.add_task(func, *args, **kwargs)
    return JSONResponse(content, background=tasks)
```