### PR TITLE
Add security flags to session cookie

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -82,8 +82,8 @@ The following arguments are supported:
 * `secret_key` - Should be a random string.
 * `session_cookie` - Defaults to "session".
 * `max_age` - Session expiry time in seconds. Defaults to 2 weeks.
-* `same_site` - SameSite flag prevents the browser from sending session cookie along with cross-site requests. Defaults to "lax".
-* `https_only` - Indicate that Secure flag should be set (can be used with HTTPS only). Defaults to False.
+* `same_site` - SameSite flag prevents the browser from sending session cookie along with cross-site requests. Defaults to `'lax'`.
+* `https_only` - Indicate that Secure flag should be set (can be used with HTTPS only). Defaults to `False`.
 
 ## HTTPSRedirectMiddleware
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -82,6 +82,8 @@ The following arguments are supported:
 * `secret_key` - Should be a random string.
 * `session_cookie` - Defaults to "session".
 * `max_age` - Session expiry time in seconds. Defaults to 2 weeks.
+* `same_site` - SameSite flag prevents the browser from sending session cookie along with cross-site requests. Defaults to "lax".
+* `https_only` - Indicate that Secure flag should be set (can be used with HTTPS only). Defaults to False.
 
 ## HTTPSRedirectMiddleware
 

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -27,7 +27,7 @@ class SessionMiddleware:
         self.max_age = max_age
         self.security_flags = "httponly; samesite=" + same_site
         if https_only: # Secure flag can be used with HTTPS only
-            self.security_flags += "; secure" 
+            self.security_flags += "; secure"
 
     def __call__(self, scope: Scope) -> ASGIInstance:
         if scope["type"] in ("http", "websocket"):

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -5,7 +5,6 @@ from base64 import b64decode, b64encode
 
 import itsdangerous
 from itsdangerous.exc import BadTimeSignature, SignatureExpired
-
 from starlette.datastructures import MutableHeaders, Secret
 from starlette.requests import Request
 from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send
@@ -26,7 +25,7 @@ class SessionMiddleware:
         self.session_cookie = session_cookie
         self.max_age = max_age
         self.security_flags = "httponly; samesite=" + same_site
-        if https_only: # Secure flag can be used with HTTPS only
+        if https_only:  # Secure flag can be used with HTTPS only
             self.security_flags += "; secure"
 
     def __call__(self, scope: Scope) -> ASGIInstance:
@@ -58,7 +57,7 @@ class SessionMiddleware:
                     header_value = "%s=%s; path=/; %s" % (
                         self.session_cookie,
                         data.decode("utf-8"),
-                        self.security_flags
+                        self.security_flags,
                     )
                     headers.append("Set-Cookie", header_value)
                 elif not was_empty_session:
@@ -67,7 +66,7 @@ class SessionMiddleware:
                     header_value = "%s=%s; %s" % (
                         self.session_cookie,
                         "null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT;",
-                        self.security_flags
+                        self.security_flags,
                     )
                     headers.append("Set-Cookie", header_value)
             await send(message)

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -50,7 +50,7 @@ class SessionMiddleware:
                     data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
                     data = self.signer.sign(data)
                     headers = MutableHeaders(scope=message)
-                    header_value = "%s=%s; path=/; secure; httponly; samesite=lax" % (
+                    header_value = "%s=%s; path=/; httponly; samesite=lax" % (
                         self.session_cookie,
                         data.decode("utf-8"),
                     )
@@ -60,7 +60,7 @@ class SessionMiddleware:
                     headers = MutableHeaders(scope=message)
                     header_value = "%s=%s" % (
                         self.session_cookie,
-                        "null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; httponly; samesite=lax",
+                        "null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly; samesite=lax",
                     )
                     headers.append("Set-Cookie", header_value)
             await send(message)

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -50,7 +50,7 @@ class SessionMiddleware:
                     data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
                     data = self.signer.sign(data)
                     headers = MutableHeaders(scope=message)
-                    header_value = "%s=%s; path=/" % (
+                    header_value = "%s=%s; path=/; secure; httponly; samesite=lax" % (
                         self.session_cookie,
                         data.decode("utf-8"),
                     )
@@ -60,7 +60,7 @@ class SessionMiddleware:
                     headers = MutableHeaders(scope=message)
                     header_value = "%s=%s" % (
                         self.session_cookie,
-                        "null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT",
+                        "null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; httponly; samesite=lax",
                     )
                     headers.append("Set-Cookie", header_value)
             await send(message)

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -5,6 +5,7 @@ from base64 import b64decode, b64encode
 
 import itsdangerous
 from itsdangerous.exc import BadTimeSignature, SignatureExpired
+
 from starlette.datastructures import MutableHeaders, Secret
 from starlette.requests import Request
 from starlette.types import ASGIApp, ASGIInstance, Message, Receive, Scope, Send

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -18,11 +18,16 @@ class SessionMiddleware:
         secret_key: typing.Union[str, Secret],
         session_cookie: str = "session",
         max_age: int = 14 * 24 * 60 * 60,  # 14 days, in seconds
+        same_site: str = "lax",
+        https_only: bool = False,
     ) -> None:
         self.app = app
         self.signer = itsdangerous.TimestampSigner(str(secret_key))
         self.session_cookie = session_cookie
         self.max_age = max_age
+        self.security_flags = "httponly; samesite=" + same_site
+        if https_only: # Secure flag can be used with HTTPS only
+            self.security_flags += "; secure" 
 
     def __call__(self, scope: Scope) -> ASGIInstance:
         if scope["type"] in ("http", "websocket"):
@@ -50,17 +55,19 @@ class SessionMiddleware:
                     data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
                     data = self.signer.sign(data)
                     headers = MutableHeaders(scope=message)
-                    header_value = "%s=%s; path=/; httponly; samesite=lax" % (
+                    header_value = "%s=%s; path=/; %s" % (
                         self.session_cookie,
                         data.decode("utf-8"),
+                        self.security_flags
                     )
                     headers.append("Set-Cookie", header_value)
                 elif not was_empty_session:
                     # The session has been cleared.
                     headers = MutableHeaders(scope=message)
-                    header_value = "%s=%s" % (
+                    header_value = "%s=%s; %s" % (
                         self.session_cookie,
-                        "null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly; samesite=lax",
+                        "null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT;",
+                        self.security_flags
                     )
                     headers.append("Set-Cookie", header_value)
             await send(message)

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -59,6 +59,7 @@ def test_session_expires():
     response = client.get("/view_session")
     assert response.json() == {"session": {}}
 
+
 def test_secure_session():
     app = create_app()
     app.add_middleware(SessionMiddleware, secret_key="example", https_only=True)

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -58,3 +58,33 @@ def test_session_expires():
 
     response = client.get("/view_session")
     assert response.json() == {"session": {}}
+
+def test_secure_session():
+    app = create_app()
+    app.add_middleware(SessionMiddleware, secret_key="example", https_only=True)
+    secure_client = TestClient(app, base_url="https://testserver")
+    unsecure_client = TestClient(app, base_url="http://testserver")
+
+    response = unsecure_client.get("/view_session")
+    assert response.json() == {"session": {}}
+
+    response = unsecure_client.post("/update_session", json={"some": "data"})
+    assert response.json() == {"session": {"some": "data"}}
+
+    response = unsecure_client.get("/view_session")
+    assert response.json() == {"session": {}}
+
+    response = secure_client.get("/view_session")
+    assert response.json() == {"session": {}}
+
+    response = secure_client.post("/update_session", json={"some": "data"})
+    assert response.json() == {"session": {"some": "data"}}
+
+    response = secure_client.get("/view_session")
+    assert response.json() == {"session": {"some": "data"}}
+
+    response = secure_client.post("/clear_session")
+    assert response.json() == {"session": {}}
+
+    response = secure_client.get("/view_session")
+    assert response.json() == {"session": {}}


### PR DESCRIPTION
Flags: Secure, HttpOnly and SameSite=lax

SameSite flag can be set to 2 values:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies

I am making it "lax" by default, but maybe it should be configurable somehow?