### PR TITLE
Handle auth error responses at the auth backend level

### DIFF
--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -4,7 +4,7 @@ import typing
 
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.responses import RedirectResponse, Response
+from starlette.responses import PlainTextResponse, RedirectResponse, Response
 
 
 def has_required_scope(request: Request, scopes: typing.Sequence[str]) -> bool:
@@ -56,6 +56,9 @@ class AuthenticationBackend:
         self, request: Request
     ) -> typing.Optional[typing.Tuple["AuthCredentials", "BaseUser"]]:
         raise NotImplemented()  # pragma: no cover
+
+    def error_response(self, request: Request, exc: Exception) -> Response:
+        return PlainTextResponse(str(exc), status_code=400)
 
 
 class AuthCredentials:

--- a/starlette/middleware/authentication.py
+++ b/starlette/middleware/authentication.py
@@ -7,7 +7,6 @@ from starlette.authentication import (
     UnauthenticatedUser,
 )
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse
 from starlette.types import ASGIApp, ASGIInstance, Receive, Scope, Send
 
 
@@ -26,7 +25,7 @@ class AuthenticationMiddleware:
         try:
             auth_result = await self.backend.authenticate(request)
         except AuthenticationError as exc:
-            response = PlainTextResponse(str(exc), status_code=400)
+            response = self.backend.error_response(request, exc)
             await response(receive, send)
             return
 


### PR DESCRIPTION
Use case: allow more flexible authentication errors response generation.

Examples:
* JSON error response
* 401 error code

Usage:
```python
class BasicAuth(AuthenticationBackend):
    async def authenticate(self, request):
        try:
            some_auth_logic()
        except (AnException) as exc:
            raise AuthenticationError("Auth error message")

        return AuthCredentials(["authenticated"]), SimpleUser(username)

    def error_response(self, request: Request, exc: Exception) -> Response:
        return JSONResponse({"error": str(exc)}, status_code=401)
```