### PR TITLE
Add tests for fixed path handling and docs

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -17,6 +17,10 @@ app.mount('/static', StaticFiles(directory="static"))
 def homepage(request):
     return PlainTextResponse('Hello, world!')
 
+@app.route('/user/me')
+def user_me(request):
+    username = "John Doe"
+    return PlainTextResponse('Hello, %s!' % username)
 
 @app.route('/user/{username}')
 def user(request):

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -59,11 +59,7 @@ You should add that route for `/users/me` before the one for `/users/{username}`
 
 ```python
 app = Router([
-    Route('/', endpoint=Homepage, methods=['GET']),
-    Mount('/users', app=Router([
-        Route('/', endpoint=Users, methods=['GET', 'POST']),
-        Route('/users/me', endpoint=UserMe, methods=['GET'])
-        Route('/{username}', endpoint=User, methods=['GET']),
-    ]))
+    Route('/users/me', endpoint=UserMe, methods=['GET']),
+    Route('/{username}', endpoint=User, methods=['GET']),
 ])
 ```

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -43,3 +43,27 @@ app = Router([
 
 The router will respond with "404 Not found" or "405 Method not allowed"
 responses for requests which do not match.
+
+Incoming paths are matched against each `Route` in order.
+
+If you need to have a `Route` with a fixed path that would also match a
+`Route` with parameters you should add the `Route` with the fixed path first.
+
+For example, with an additional `Route` like:
+
+```python
+Route('/users/me', endpoint=UserMe, methods=['GET'])
+```
+
+You should add that route for `/users/me` before the one for `/users/{username}`:
+
+```python
+app = Router([
+    Route('/', endpoint=Homepage, methods=['GET']),
+    Mount('/users', app=Router([
+        Route('/', endpoint=Users, methods=['GET', 'POST']),
+        Route('/users/me', endpoint=UserMe, methods=['GET'])
+        Route('/{username}', endpoint=User, methods=['GET']),
+    ]))
+])
+```

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -24,7 +24,7 @@ def user_me(request):
     return Response(content, media_type="text/plain")
 
 
-def user_no_match(request):
+def user_no_match(request):  # pragma: no cover
     content = "User fixed no match"
     return Response(content, media_type="text/plain")
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -19,6 +19,16 @@ def user(request):
     return Response(content, media_type="text/plain")
 
 
+def user_me(request):
+    content = "User fixed me"
+    return Response(content, media_type="text/plain")
+
+
+def user_no_match(request):
+    content = "User fixed no match"
+    return Response(content, media_type="text/plain")
+
+
 def staticfiles(request):
     return Response("xxxxx", media_type="image/png")
 
@@ -29,7 +39,12 @@ app = Router(
         Mount(
             "/users",
             app=Router(
-                [Route("/", endpoint=users), Route("/{username}", endpoint=user)]
+                [
+                    Route("/", endpoint=users),
+                    Route("/me", endpoint=user_me),
+                    Route("/{username}", endpoint=user),
+                    Route("/nomatch", endpoint=user_no_match),
+                ]
             ),
         ),
         Mount("/static", app=staticfiles),
@@ -102,6 +117,14 @@ def test_router():
     response = client.get("/users/tomchristie")
     assert response.status_code == 200
     assert response.text == "User tomchristie"
+
+    response = client.get("/users/me")
+    assert response.status_code == 200
+    assert response.text == "User fixed me"
+
+    response = client.get("/users/nomatch")
+    assert response.status_code == 200
+    assert response.text == "User nomatch"
 
     response = client.get("/static/123")
     assert response.status_code == 200


### PR DESCRIPTION
This PR tests and documents how fixed paths are matched when there are parameterized paths that also match.

---

Having two endpoints, one for:

```
/users/{username}
```

and one with a fixed path for:

```
/users/me
```

It is necessary to add the one for `/users/me` first, as paths are matched in order of addition to the router. And a URL with path `/users/me` would match `/users/{username}` first with a `username` of `me` if it was added before.

This PR adds tests for that and documents the behavior.

I also added a small route in the applications docs section to "hint" how it works.