### PR TITLE
Fix multi field forms parsing after already having read the body

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -132,6 +132,7 @@ class Request(HTTPConnection):
     async def stream(self) -> typing.AsyncGenerator[bytes, None]:
         if hasattr(self, "_body"):
             yield self._body
+            yield b""
             return
 
         if self._stream_consumed:

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -41,11 +41,7 @@ def app_read_body(scope):
         data = await request.form()
         output = {}
         for key, value in data.items():
-            if isinstance(value, UploadFile):
-                content = await value.read()
-                output[key] = {"filename": value.filename, "content": content.decode()}
-            else:
-                output[key] = value
+            output[key] = value
         await request.close()
         response = JSONResponse(output)
         await response(receive, send)

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -33,6 +33,26 @@ def app(scope):
     return asgi
 
 
+def app_read_body(scope):
+    async def asgi(receive, send):
+        request = Request(scope, receive)
+        # Read bytes, to force request.stream() to return the already parsed body
+        body_bytes = await request.body()
+        data = await request.form()
+        output = {}
+        for key, value in data.items():
+            if isinstance(value, UploadFile):
+                content = await value.read()
+                output[key] = {"filename": value.filename, "content": content.decode()}
+            else:
+                output[key] = value
+        await request.close()
+        response = JSONResponse(output)
+        await response(receive, send)
+
+    return asgi
+
+
 def test_multipart_request_data(tmpdir):
     client = TestClient(app)
     response = client.post("/", data={"some": "data"}, files=FORCE_MULTIPART)
@@ -111,3 +131,15 @@ def test_no_request_data(tmpdir):
     client = TestClient(app)
     response = client.post("/")
     assert response.json() == {}
+
+
+def test_urlencoded_multi_field_app_reads_body(tmpdir):
+    client = TestClient(app_read_body)
+    response = client.post("/", data={"some": "data", "second": "key pair"})
+    assert response.json() == {"some": "data", "second": "key pair"}
+
+
+def test_multipart_multi_field_app_reads_body(tmpdir):
+    client = TestClient(app_read_body)
+    response = client.post("/", data={"some": "data", "second": "key pair"}, files=FORCE_MULTIPART)
+    assert response.json() == {"some": "data", "second": "key pair"}

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -141,5 +141,7 @@ def test_urlencoded_multi_field_app_reads_body(tmpdir):
 
 def test_multipart_multi_field_app_reads_body(tmpdir):
     client = TestClient(app_read_body)
-    response = client.post("/", data={"some": "data", "second": "key pair"}, files=FORCE_MULTIPART)
+    response = client.post(
+        "/", data={"some": "data", "second": "key pair"}, files=FORCE_MULTIPART
+    )
     assert response.json() == {"some": "data", "second": "key pair"}


### PR DESCRIPTION
This implements tests and the fix for the following scenario:

* The ASGI app uses a `Request` object and calls the `.body()` method (e.g. to check if there is a body in the request).
* Then it calls the `.form()` method.
* And the form had more than one key-value pairs.

:warning: Currently, it would not get the last key-value pair.

---

After this PR, it also gets the last key-value pair.

I added 2 tests that fail with the current code.

The change is just a `yield b""`.

But, without it, the `FormParser`s don't know that the form contents are finished, and don't add the last key-value pair to the results.