### PR TITLE
Fix leaking Secret values in print and logging statements

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -50,25 +50,27 @@ If none of those match, then `config(...)` will raise an error.
 For sensitive keys, the `Secret` class is useful, since it helps minimize
 occasions where the value it holds could leak out into tracebacks or logging.
 
-To get the value of a `Secret` instance, you must explicitly cast it to a string.
+To get the value of a `Secret` instance, you must access the `value` property.
 You should only do this at the point at which the value is used.
 
 ```python
 >>> from myproject import settings
+>>> settings.SECRET_KEY
+Secret('**********')
 >>> print(settings.SECRET_KEY)
 Secret('**********')
->>> str(settings.SECRET_KEY)
+>>> settings.SECRET_KEY.value
 '98n349$%8b8-7yjn0n8y93T$23r'
 ```
 
 Similarly, the `URL` and `DatabaseURL` class will hide any password component
-in their representations.
+in their representations. Cast to a string to get the underlying value.
 
 ```python
 >>> from myproject import settings
->>> print(settings.DATABASE_URL)
+>>> settings.DATABASE_URL
 DatabaseURL('postgresql://admin:**********@192.168.0.8/my-application')
->>> str(settings.SECRET_KEY)
+>>> str(settings.DATABASE_URL)
 'postgresql://admin:Fkjh348htGee4t3@192.168.0.8/my-application'
 ```
 

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -184,17 +184,20 @@ class URLPath(str):
 class Secret:
     """
     Holds a string value that should not be revealed in tracebacks etc.
-    You should cast the value to `str` at the point it is required.
+    You should access the ``value`` attribute at the point it is required.
     """
 
     def __init__(self, value: str):
         self._value = value
 
+    @property
+    def value(self) -> str:
+        return self._value
+
     def __repr__(self) -> str:
         return "%s('**********')" % self.__class__.__name__
 
-    def __str__(self) -> str:
-        return self._value
+    __str__ = __repr__
 
 
 class CommaSeparatedStrings(Sequence):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,9 @@ def test_config(tmpdir):
     assert REQUEST_TIMEOUT == 10
     assert REQUEST_HOSTNAME == "example.com"
     assert repr(SECRET_KEY) == "Secret('**********')"
-    assert str(SECRET_KEY) == "12345"
+    assert str(SECRET_KEY) == "Secret('**********')"
+    assert format(SECRET_KEY) == "Secret('**********')"
+    assert SECRET_KEY.value == "12345"
 
     with pytest.raises(KeyError):
         config.get("MISSING")


### PR DESCRIPTION
`print(Secret("value"))` will no longer print `"value"`.
To get the underlying value, you must access the
`.value` property.

I didn't bother changing the `URL` implementation to
do the same because it would break a lot of public API.

close #301