### PR TITLE
Improve authentication.requires() to support class based endpoints

### DIFF
--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -183,11 +183,6 @@ api_app.schema_generator = SchemaGenerator(
 )
 
 
-@api_app.route("/docs", include_in_schema=False)
-def api_docs(request):
-    return OpenAPIResponse(api_app.schema)
-
-
 @api_app.route("/manage", name="manage")
 @requires("authenticated")
 class ManageResources(HTTPEndpoint):
@@ -271,3 +266,7 @@ def test_management_api():
         response = client.delete("/users/1")
         assert response.status_code == 302
         assert response.headers['location'] == 'http://testserver/manage'
+
+        response = client.delete("/users/123", auth=("tomchristie", "example"))
+        assert response.status_code == 200
+        assert response.json()['deleted'] == '123'


### PR DESCRIPTION
I ran into an issue on my API where the OpenAPI docstrings for a class-based endpoint which required authentication weren't appearing in the schema.

Upon investigation I noticed that `starlette.authentication.requires` was returning a wrapper function for the classes, which made the openapi schema generator unable to detect the class and inspect the methods for docstrings.

This was the most simple way I could think of to fix the issue.