### PR TITLE
Support `@requires` as a method decorator

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -131,9 +131,20 @@ async def dashboard(request):
     ...
 ```
 
+For class-based endpoints, you should wrap the decorator
+around a method on the class.
+
+```python
+@app.route("/dashboard")
+class Dashboard(HTTPEndpoint):
+    @requires("authenticated")
+    async def get(self, request):
+        ...
+```
+
 ## Custom authentication error responses
 
-You can customise the error response sent when a `AuthenticationError` is 
+You can customise the error response sent when a `AuthenticationError` is
 raised by an auth backend:
 
 ```python

--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -24,8 +24,9 @@ def requires(
 
     def decorator(func: typing.Callable) -> typing.Callable:
         if asyncio.iscoroutinefunction(func):
+
             @functools.wraps(func)
-            async def wrapper(*args) -> Response:
+            async def wrapper(*args: typing.Any) -> Response:
                 assert len(args) in (1, 2)  # func(request) or func(self, request)
                 request = args[-1]
                 if not has_required_scope(request, scopes_list):
@@ -37,7 +38,7 @@ def requires(
             return wrapper
 
         @functools.wraps(func)
-        def sync_wrapper(*args) -> Response:
+        def sync_wrapper(*args: typing.Any) -> Response:
             assert len(args) in (1, 2)  # func(request) or func(self, request)
             request = args[-1]
             if not has_required_scope(request, scopes_list):

--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -27,8 +27,11 @@ def requires(
 
             @functools.wraps(func)
             async def wrapper(*args: typing.Any) -> Response:
-                assert len(args) in (1, 2)  # func(request) or func(self, request)
+                # Support either `func(request)`` or `func(self, request)``
+                assert len(args) in (1, 2)
                 request = args[-1]
+                assert isinstance(request, Request)
+
                 if not has_required_scope(request, scopes_list):
                     if redirect is not None:
                         return RedirectResponse(url=request.url_for(redirect))
@@ -39,8 +42,11 @@ def requires(
 
         @functools.wraps(func)
         def sync_wrapper(*args: typing.Any) -> Response:
-            assert len(args) in (1, 2)  # func(request) or func(self, request)
+            # Support either `func(request)`` or `func(self, request)``
+            assert len(args) in (1, 2)
             request = args[-1]
+            assert isinstance(request, Request)
+
             if not has_required_scope(request, scopes_list):
                 if redirect is not None:
                     return RedirectResponse(url=request.url_for(redirect))


### PR DESCRIPTION
Allows this...

```python
@app.route("/dashboard")
class Dashboard(HTTPEndpoint):
    @requires("authenticated")
    async def get(self, request):
        ...
```

Or this...

```python
@app.route("/dashboard")
class Dashboard(HTTPEndpoint):
    @requires("authenticated")
    async def dispatch(self, request):
        await super(Dashboard, self).dispatch(request)
```