### PR TITLE
Transfer JSON as text over WebSockets

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -277,8 +277,8 @@ class WebSocketTestSession:
         self.send({"type": "websocket.receive", "bytes": data})
 
     def send_json(self, data: typing.Any) -> None:
-        encoded = json.dumps(data).encode("utf-8")
-        self.send({"type": "websocket.receive", "bytes": encoded})
+        text = json.dumps(data)
+        self.send({"type": "websocket.receive", "text": text})
 
     def close(self, code: int = 1000) -> None:
         self.send({"type": "websocket.disconnect", "code": code})
@@ -302,8 +302,8 @@ class WebSocketTestSession:
     def receive_json(self) -> typing.Any:
         message = self.receive()
         self._raise_on_close(message)
-        encoded = message["bytes"]
-        return json.loads(encoded.decode("utf-8"))
+        text = message["text"]
+        return json.loads(text)
 
 
 class TestClient(requests.Session):

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -132,8 +132,8 @@ class WebSocket(HTTPConnection):
         assert self.application_state == WebSocketState.CONNECTED
         message = await self.receive()
         self._raise_on_disconnect(message)
-        encoded = message["bytes"]
-        return json.loads(encoded.decode("utf-8"))
+        text = message["text"]
+        return json.loads(text)
 
     async def send_text(self, data: str) -> None:
         await self.send({"type": "websocket.send", "text": data})
@@ -142,8 +142,8 @@ class WebSocket(HTTPConnection):
         await self.send({"type": "websocket.send", "bytes": data})
 
     async def send_json(self, data: typing.Any) -> None:
-        encoded = json.dumps(data).encode("utf-8")
-        await self.send({"type": "websocket.send", "bytes": encoded})
+        text = json.dumps(data)
+        await self.send({"type": "websocket.send", "text": text})
 
     async def close(self, code: int = 1000) -> None:
         await self.send({"type": "websocket.close", "code": code})

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from starlette.endpoints import HTTPEndpoint, WebSocketEndpoint
@@ -78,6 +80,10 @@ def test_websocket_endpoint_on_receive_json():
     client = TestClient(WebSocketApp)
     with client.websocket_connect("/ws") as websocket:
         websocket.send_json({"hello": "world"})
+        data = websocket.receive_json()
+        assert data == {"message": {"hello": "world"}}
+
+        websocket.send_bytes(json.dumps({"hello": "world"}).encode("utf-8"))
         data = websocket.receive_json()
         assert data == {"message": {"hello": "world"}}
 


### PR DESCRIPTION
I think we usually send JSON data as a text, like `ws.send(JSON.stringify(...))`.