### PR TITLE
Customisable debug generator

### DIFF
--- a/tests/middleware/test_errors.py
+++ b/tests/middleware/test_errors.py
@@ -1,6 +1,6 @@
 import pytest
 
-from starlette.middleware.errors import ServerErrorMiddleware
+from starlette.middleware.errors import ServerErrorMiddleware, DebugGenerator
 from starlette.responses import JSONResponse, Response
 from starlette.testclient import TestClient
 
@@ -91,3 +91,17 @@ def test_debug_not_http():
 
     with pytest.raises(RuntimeError):
         app({"type": "websocket"})
+
+
+def test_customized_debug_generator():
+    exc = RuntimeError("Something went wrong")
+
+    class CustomDebugGenerator(DebugGenerator):
+        title = "My debugger"
+        styles = "p{color: red;}"
+
+    gen = CustomDebugGenerator(exc)
+    html = gen.generate_html()
+    assert "p{color: red;}" in html
+    assert "Something went wrong" in html
+    assert "My debugger" in html

--- a/tests/middleware/test_errors.py
+++ b/tests/middleware/test_errors.py
@@ -1,6 +1,6 @@
 import pytest
 
-from starlette.middleware.errors import ServerErrorMiddleware, DebugGenerator
+from starlette.middleware.errors import DebugGenerator, ServerErrorMiddleware
 from starlette.responses import JSONResponse, Response
 from starlette.testclient import TestClient
 


### PR DESCRIPTION
This PR generalises the `DebugGenerator`: instead of using hard-coded HTML templates and CSS, they are now defined as class attributes. The debug generator class is also made customisable in the same fashion on `ServerErrorMiddleware`.

The idea is that, from an ASGI toolkit perspective, the `ServerErrorMiddleware` and the `DebugGenerator` are useful (although undocumented) components that help with implementing traceback responses in debug mode.

Let me know if this fits Starlette's scope at all.