### PR TITLE
Set Max-Age on Session Cookies

### DIFF
--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -55,9 +55,10 @@ class SessionMiddleware:
                     data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
                     data = self.signer.sign(data)
                     headers = MutableHeaders(scope=message)
-                    header_value = "%s=%s; path=/; %s" % (
+                    header_value = "%s=%s; path=/; Max-Age=%s; %s" % (
                         self.session_cookie,
                         data.decode("utf-8"),
+                        self.max_age,
                         self.security_flags,
                     )
                     headers.append("Set-Cookie", header_value)

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -55,7 +55,7 @@ class SessionMiddleware:
                     data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
                     data = self.signer.sign(data)
                     headers = MutableHeaders(scope=message)
-                    header_value = "%s=%s; path=/; Max-Age=%s; %s" % (
+                    header_value = "%s=%s; path=/; Max-Age=%d; %s" % (
                         self.session_cookie,
                         data.decode("utf-8"),
                         self.max_age,


### PR DESCRIPTION
As of now, no `Max-Age` or `Expires` value is set when sending the session cookie.

I think it makes sense to use `max_age` both for signing session data and for the cookie max age.

WDYT?