### PR TITLE
doc: exceptions: keep original status_code

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -16,11 +16,11 @@ app = Starlette()
 
 @app.exception_handler(404)
 async def not_found(request, exc):
-    return HTMLResponse(content=HTML_404_PAGE)
+    return HTMLResponse(content=HTML_404_PAGE, status_code=exc.status_code)
 
 @app.exception_handler(500)
 async def server_error(request, exc):
-    return HTMLResponse(content=HTML_500_PAGE)
+    return HTMLResponse(content=HTML_500_PAGE, status_code=exc.status_code)
 ```
 
 If `debug` is enabled and an error occurs, then instead of using the installed


### PR DESCRIPTION
It is considered to be best practice for a not-found page to also use
status code 404.

This changes the examples for the 404 and 500 pages to keep the
exceptions status code.