### PR TITLE
Improvements to schema generation

### DIFF
--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -81,14 +81,6 @@ class BaseSchemaGenerator:
 
         return endpoints_info
 
-    def _extract_yaml(self, docstring: str) -> str:
-        """
-        We support having regular docstrings before the schema definition.
-
-        Here we return just the schema part from a docstring.
-        """
-        return docstring.split("---")[-1]
-
     def parse_docstring(self, func_or_method: typing.Callable) -> typing.Optional[dict]:
         """
         Given a function, parse the docstring as YAML and return a dictionary of info.
@@ -97,7 +89,10 @@ class BaseSchemaGenerator:
         if not docstring:
             return None
 
-        docstring = self._extract_yaml(docstring)
+        # We support having regular docstrings before the schema
+        # definition. Here we return just the schema part from
+        # the docstring.
+        docstring = docstring.split("---")[-1]
 
         parsed = yaml.safe_load(docstring)
 

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -81,13 +81,13 @@ class BaseSchemaGenerator:
 
         return endpoints_info
 
-    def parse_docstring(self, func_or_method: typing.Callable) -> typing.Optional[dict]:
+    def parse_docstring(self, func_or_method: typing.Callable) -> dict:
         """
         Given a function, parse the docstring as YAML and return a dictionary of info.
         """
         docstring = func_or_method.__doc__
         if not docstring:
-            return None
+            return {}
 
         # We support having regular docstrings before the schema
         # definition. Here we return just the schema part from
@@ -99,7 +99,7 @@ class BaseSchemaGenerator:
         if not isinstance(parsed, dict):
             # A regular docstring (not yaml formatted) can return
             # a simple string here, which wouldn't follow the schema.
-            return None
+            return {}
 
         return parsed
 
@@ -122,10 +122,12 @@ class SchemaGenerator(BaseSchemaGenerator):
 
             parsed = self.parse_docstring(endpoint.func)
 
-            if parsed is not None:
-                if endpoint.path not in schema["paths"]:
-                    schema["paths"][endpoint.path] = {}
+            if not parsed:
+                continue
 
-                schema["paths"][endpoint.path][endpoint.http_method] = parsed
+            if endpoint.path not in schema["paths"]:
+                schema["paths"][endpoint.path] = {}
+
+            schema["paths"][endpoint.path][endpoint.http_method] = parsed
 
         return schema

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -10,6 +10,10 @@ schemas = SchemaGenerator(
 app = Starlette()
 
 
+subapp = Starlette()
+app.mount("/subapp", subapp)
+
+
 @app.websocket_route("/ws")
 def ws(session):
     """ws"""
@@ -63,6 +67,43 @@ class OrganisationsEndpoint(HTTPEndpoint):
         pass  # pragma: no cover
 
 
+@app.route("/regular-docstring-and-schema")
+def regular_docstring_and_schema(request):
+    """
+    This a regular docstring example (not included in schema)
+
+    ---
+
+    responses:
+      200:
+        description: This is included in the schema.
+    """
+    pass  # pragma: no cover
+
+
+@app.route("/regular-docstring")
+def regular_docstring(request):
+    """
+    This a regular docstring example (not included in schema)
+    """
+    pass  # pragma: no cover
+
+
+@app.route("/no-docstring")
+def no_docstring(request):
+    pass  # pragma: no cover
+
+
+@subapp.route("/subapp-endpoint")
+def subapp_endpoint(request):
+    """
+    responses:
+      200:
+        description: This endpoint is part of a subapp.
+    """
+    pass  # pragma: no cover
+
+
 @app.route("/schema", methods=["GET"], include_in_schema=False)
 def schema(request):
     return schemas.OpenAPIResponse(request=request)
@@ -91,6 +132,20 @@ def test_schema_generation():
                         }
                     }
                 },
+            },
+            "/regular-docstring-and-schema": {
+                "get": {
+                    "responses": {
+                        200: {"description": "This is included in the schema."}
+                    }
+                }
+            },
+            "/subapp/subapp-endpoint": {
+                "get": {
+                    "responses": {
+                        200: {"description": "This endpoint is part of a subapp."}
+                    }
+                }
             },
             "/users": {
                 "get": {
@@ -136,6 +191,16 @@ paths:
           description: An organisation.
           examples:
             name: Foo Corp.
+  /regular-docstring-and-schema:
+    get:
+      responses:
+        200:
+          description: This is included in the schema.
+  /subapp/subapp-endpoint:
+    get:
+      responses:
+        200:
+          description: This endpoint is part of a subapp.
   /users:
     get:
       responses:


### PR DESCRIPTION
Three changes here:

-  Include mounted paths in schemas (part of #172) 
- Allow regular docstrings before schema definitions 
- Don't include empty definitions in the schemas

Second one is to support something like this:

```python
@app.route("/regular-docstring")
def regular_docstring(request):
    """
    This a regular docstring example (not included in schema)

    ---

    responses:
      200:
        description: This is included in the schema.
    """
    pass  # pragma: no cover
```

Which splits regular docstring from the schema definition using the yaml start marker: `---`.

Third one is to avoid errors in swagger-ui when an endpoint doesn't have any docstrings.

Happy to split / amend if needed 