### PR TITLE
Add ImmutableMultiDict

### DIFF
--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -102,7 +102,7 @@ class FormParser:
                 elif message_type == FormMessage.END:
                     pass
 
-        return FormData(items=items)
+        return FormData(items)
 
 
 class MultiPartParser:
@@ -218,4 +218,4 @@ class MultiPartParser:
                     pass
 
         parser.finalize()
-        return FormData(items=items)
+        return FormData(items)

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -170,7 +170,7 @@ def test_headers_mutablecopy():
 
 
 def test_queryparams():
-    q = QueryParams(query_string="a=123&a=456&b=789")
+    q = QueryParams("a=123&a=456&b=789")
     assert "a" in q
     assert "A" not in q
     assert "c" not in q
@@ -178,36 +178,32 @@ def test_queryparams():
     assert q.get("a") == "456"
     assert q.get("nope", default=None) is None
     assert q.getlist("a") == ["123", "456"]
-    assert q.keys() == ["a", "b"]
-    assert q.values() == ["456", "789"]
-    assert q.items() == [("a", "456"), ("b", "789")]
+    assert list(q.keys()) == ["a", "b"]
+    assert list(q.values()) == ["456", "789"]
+    assert list(q.items()) == [("a", "456"), ("b", "789")]
     assert len(q) == 2
     assert list(q) == ["a", "b"]
     assert dict(q) == {"a": "456", "b": "789"}
     assert str(q) == "a=123&a=456&b=789"
-    assert repr(q) == "QueryParams(query_string='a=123&a=456&b=789')"
+    assert repr(q) == "QueryParams('a=123&a=456&b=789')"
     assert QueryParams({"a": "123", "b": "456"}) == QueryParams(
-        items=[("a", "123"), ("b", "456")]
+        [("a", "123"), ("b", "456")]
     )
-    assert QueryParams({"a": "123", "b": "456"}) == QueryParams(
-        query_string="a=123&b=456"
-    )
+    assert QueryParams({"a": "123", "b": "456"}) == QueryParams("a=123&b=456")
     assert QueryParams({"a": "123", "b": "456"}) == QueryParams(
         {"b": "456", "a": "123"}
     )
     assert QueryParams() == QueryParams({})
-    assert QueryParams(items=[("a", "123"), ("a", "456")]) == QueryParams(
-        query_string="a=123&a=456"
-    )
+    assert QueryParams([("a", "123"), ("a", "456")]) == QueryParams("a=123&a=456")
     assert QueryParams({"a": "123", "b": "456"}) != "invalid"
 
-    q = QueryParams(items=[("a", "123"), ("a", "456")])
+    q = QueryParams([("a", "123"), ("a", "456")])
     assert QueryParams(q) == q
 
 
 def test_formdata():
     upload = io.BytesIO(b"test")
-    form = FormData(items=[("a", "123"), ("a", "456"), ("b", upload)])
+    form = FormData([("a", "123"), ("a", "456"), ("b", upload)])
     assert "a" in form
     assert "A" not in form
     assert "c" not in form
@@ -215,18 +211,16 @@ def test_formdata():
     assert form.get("a") == "456"
     assert form.get("nope", default=None) is None
     assert form.getlist("a") == ["123", "456"]
-    assert form.keys() == ["a", "b"]
-    assert form.values() == ["456", upload]
-    assert form.items() == [("a", "456"), ("b", upload)]
+    assert list(form.keys()) == ["a", "b"]
+    assert list(form.values()) == ["456", upload]
+    assert list(form.items()) == [("a", "456"), ("b", upload)]
     assert len(form) == 2
     assert list(form) == ["a", "b"]
     assert dict(form) == {"a": "456", "b": upload}
     assert (
         repr(form)
-        == "FormData(items=[('a', '123'), ('a', '456'), ('b', " + repr(upload) + ")])"
+        == "FormData([('a', '123'), ('a', '456'), ('b', " + repr(upload) + ")])"
     )
     assert FormData(form) == form
-    assert FormData({"a": "123", "b": "789"}) == FormData(
-        items=[("a", "123"), ("b", "789")]
-    )
+    assert FormData({"a": "123", "b": "789"}) == FormData([("a", "123"), ("b", "789")])
     assert FormData({"a": "123", "b": "789"}) != {"a": "123", "b": "789"}


### PR DESCRIPTION
Add `ImmutableMultiDict`.

`QueryParams` and `FormData` move to having a single positional argument for all cases, so eg the following all all equivalent...

`QueryParams("a=1&b=2")`
`QueryParams({"a": "1", "b": "2"})`
`QueryParams([("a", "1"), ("b", "2")])`

We currently retain backwards compat for old-style keyword args, eg. `QueryParams(querystring="a=1&b=2")`, but will presumably drop that in 0.10.x.