### PR TITLE
Example ASGI apps now ensure scope['type'] is expected type.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,7 @@ from starlette.responses import PlainTextResponse
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -13,6 +13,7 @@ from starlette.response import Response
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):
@@ -95,6 +96,7 @@ from starlette.responses import Response
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -24,6 +24,7 @@ from starlette.responses import Response
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):
@@ -62,6 +63,7 @@ from starlette.responses import HTMLResponse
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):
@@ -79,6 +81,7 @@ from starlette.responses import PlainTextResponse
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):
@@ -107,6 +110,7 @@ env = Environment(loader=FileSystemLoader('templates'))
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):
@@ -141,6 +145,7 @@ from starlette.responses import JSONResponse
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):
@@ -164,6 +169,7 @@ from starlette.responses import UJSONResponse
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):
@@ -181,6 +187,7 @@ from starlette.responses import PlainTextResponse, RedirectResponse
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):
@@ -210,6 +217,7 @@ async def slow_numbers(minimum, maximum):
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):
@@ -237,6 +245,7 @@ from starlette.responses import FileResponse
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -9,6 +9,7 @@ from starlette.testclient import TestClient
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'http'
         self.scope = scope
 
     async def __call__(self, receive, send):
@@ -49,6 +50,7 @@ from starlette.websockets import WebSocket
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'websocket'
         self.scope = scope
 
     async def __call__(self, receive, send):

--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -12,6 +12,7 @@ from starlette.websockets import WebSocket
 
 class App:
     def __init__(self, scope):
+        assert scope['type'] == 'websocket'
         self.scope = scope
 
     async def __call__(self, receive, send):


### PR DESCRIPTION
Closes #330.

If writing plain ASGI apps, it's always good practice to assert that the scope matches the expected type. This eg. means that websocket connections to an HTTP app will fail immediately and vice-versa. It also ensures that applications that do not handle lifespan messages raise an error immediately, and servers can auto-detect not to send lifespan messages to the application.