### PR TITLE
WebSockets now default to sending JSON using text dataframes

### DIFF
--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -84,13 +84,13 @@ May raise `starlette.websockets.Disconnect` if the application does not accept t
 
 * `.send_text(data)` - Send the given text to the application.
 * `.send_bytes(data)` - Send the given bytes to the application.
-* `.send_json(data)` - Send the given data to the application.
+* `.send_json(data, mode="text")` - Send the given data to the application. Use `mode="binary"` to send JSON over binary data frames.
 
 #### Receiving data
 
 * `.receive_text()` - Wait for incoming text sent by the application and return it.
 * `.receive_bytes()` - Wait for incoming bytestring sent by the application and return it.
-* `.receive_json()` - Wait for incoming json data sent by the application and return it.
+* `.receive_json(mode="text")` - Wait for incoming json data sent by the application and return it. Use `mode="binary"` to send JSON over binary data frames.
 
 May raise `starlette.websockets.Disconnect`.
 

--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -64,6 +64,9 @@ For example: `request.path_params['username']`
 * `await websocket.send_bytes(data)`
 * `await websocket.send_json(data)`
 
+JSON messages default to being sent over text data frames, from version 0.10.0 onwards.
+Use `websocket.send_json(data, mode="binary")` to send JSON over binary data frames.
+
 ### Receiving data
 
 * `await websocket.receive_text()`
@@ -71,6 +74,9 @@ For example: `request.path_params['username']`
 * `await websocket.receive_json()`
 
 May raise `starlette.websockets.Disconnect()`.
+
+JSON messages default to being received over text data frames, from version 0.10.0 onwards.
+Use `websocket.receive_json(data, mode="binary")` to receive JSON over binary data frames.
 
 ### Closing the connection
 

--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -84,21 +84,21 @@ class WebSocketEndpoint:
             return message["bytes"]
 
         elif self.encoding == "json":
+            if message.get("text") is not None:
+                text = message["text"]
+            else:
+                text = message["bytes"].decode("utf-8")
+
             try:
-                if "text" in message:
-                    message_json = json.loads(message["text"])
-                elif message["bytes"]:
-                    message_json = json.loads(message["bytes"].decode("utf-8"))
+                return json.loads(text)
             except json.decoder.JSONDecodeError:
                 await websocket.close(code=status.WS_1003_UNSUPPORTED_DATA)
                 raise RuntimeError("Malformed JSON data received.")
-            else:
-                return message_json
 
         assert (
             self.encoding is None
         ), f"Unsupported 'encoding' attribute {self.encoding}"
-        return message["text"] if "text" in message else message["bytes"]
+        return message["text"] if message.get("text") else message["bytes"]
 
     async def on_connect(self, websocket: WebSocket) -> None:
         """Override to handle an incoming websocket connection"""

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -286,9 +286,13 @@ class WebSocketTestSession:
     def send_bytes(self, data: bytes) -> None:
         self.send({"type": "websocket.receive", "bytes": data})
 
-    def send_json(self, data: typing.Any) -> None:
-        encoded = json.dumps(data).encode("utf-8")
-        self.send({"type": "websocket.receive", "bytes": encoded})
+    def send_json(self, data: typing.Any, mode: str = "text") -> None:
+        assert mode in ["text", "binary"]
+        text = json.dumps(data)
+        if mode == "text":
+            self.send({"type": "websocket.receive", "text": text})
+        else:
+            self.send({"type": "websocket.receive", "bytes": text.encode("utf-8")})
 
     def close(self, code: int = 1000) -> None:
         self.send({"type": "websocket.disconnect", "code": code})
@@ -309,11 +313,15 @@ class WebSocketTestSession:
         self._raise_on_close(message)
         return message["bytes"]
 
-    def receive_json(self) -> typing.Any:
+    def receive_json(self, mode: str = "text") -> typing.Any:
+        assert mode in ["text", "binary"]
         message = self.receive()
         self._raise_on_close(message)
-        encoded = message["bytes"]
-        return json.loads(encoded.decode("utf-8"))
+        if mode == "text":
+            text = message["text"]
+        else:
+            text = message["bytes"].decode("utf-8")
+        return json.loads(text)
 
 
 class TestClient(requests.Session):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -86,6 +86,20 @@ def test_websocket_endpoint_on_receive_json():
             websocket.send_text("Hello world")
 
 
+def test_websocket_endpoint_on_receive_json_binary():
+    class WebSocketApp(WebSocketEndpoint):
+        encoding = "json"
+
+        async def on_receive(self, websocket, data):
+            await websocket.send_json({"message": data}, mode="binary")
+
+    client = TestClient(WebSocketApp)
+    with client.websocket_connect("/ws") as websocket:
+        websocket.send_json({"hello": "world"}, mode="binary")
+        data = websocket.receive_json(mode="binary")
+        assert data == {"message": {"hello": "world"}}
+
+
 def test_websocket_endpoint_on_receive_text():
     class WebSocketApp(WebSocketEndpoint):
         encoding = "text"

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -21,6 +21,24 @@ def test_websocket_url():
         assert data == {"url": "ws://testserver/123?a=abc"}
 
 
+def test_websocket_binary_json():
+    def app(scope):
+        async def asgi(receive, send):
+            websocket = WebSocket(scope, receive=receive, send=send)
+            await websocket.accept()
+            message = await websocket.receive_json(mode="binary")
+            await websocket.send_json(message, mode="binary")
+            await websocket.close()
+
+        return asgi
+
+    client = TestClient(app)
+    with client.websocket_connect("/123?a=abc") as websocket:
+        websocket.send_json({"test": "data"}, mode="binary")
+        data = websocket.receive_json(mode="binary")
+        assert data == {"test": "data"}
+
+
 def test_websocket_query_params():
     def app(scope):
         async def asgi(receive, send):


### PR DESCRIPTION
Closes #332
Closes #316

This will need to be version 0.10.0, since it's a backwards incompatible change.
For binary-framed JSON we have:

`await websocket.send_json(data, mode="binary")`
`data = await websocket.receive_json(mode="binary")`

Nominally this is actually less "correct" than sending over binary frames, but practically it's more pragmatic given eg. JavaScript and Python's JavaScript implementations both expect text types.