### PR TITLE
Add missing argument to database docs example

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -155,7 +155,8 @@ if TESTING:
   DATABASE_URL = DATABASE_URL.replace(database='test_' + DATABASE_URL.database)
 
 
-# Use 'rollback_on_shutdown' during testing, to ensure we have
+# Use 'rollback_on_shutdown' during testing, to ensure we do not persist
+# database changes
 app = Starlette()
 app.add_middleware(
     DatabaseMiddleware,

--- a/starlette/middleware/database.py
+++ b/starlette/middleware/database.py
@@ -16,7 +16,7 @@ class DatabaseMiddleware:
         self,
         app: ASGIApp,
         database_url: typing.Union[str, DatabaseURL],
-        rollback_on_shutdown: bool,
+        rollback_on_shutdown: bool = False,
     ) -> None:
         self.app = app
         self.backend = self.get_backend(database_url)


### PR DESCRIPTION
This commit adds a missing required argument in the docs example of using the DatabaseMiddleware.

I'm not entirely sure if it's best to set it to false as I've done here, but I assume that's the use-case most people are looking for.

I've also slightly clarified a comment in the test part of the same docs that seemed incomplete.