### PR TITLE
Routing for Hosts and Subdomains

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -67,6 +67,9 @@ class Starlette:
     def mount(self, path: str, app: ASGIApp, name: str = None) -> None:
         self.router.mount(path, app=app, name=name)
 
+    def host(self, host: str, app: ASGIApp, name: str = None) -> None:
+        self.router.host(host, app=app, name=name)
+
     def add_middleware(self, middleware_class: type, **kwargs: typing.Any) -> None:
         self.error_middleware.app = middleware_class(
             self.error_middleware.app, **kwargs

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -157,26 +157,35 @@ class DatabaseURL(URL):
 
 class URLPath(str):
     """
-    A URL path string that also holds an associated protocol.
+    A URL path string that may also hold an associated protocol and/or host.
     Used by the routing to return `url_path_for` matches.
     """
 
-    def __new__(cls, path: str, protocol: str) -> str:
-        assert protocol in ("http", "websocket")
+    def __new__(cls, path: str, protocol: str = "", host: str = "") -> str:
+        assert protocol in ("http", "websocket", "")
         return str.__new__(cls, path)  # type: ignore
 
-    def __init__(self, path: str, protocol: str) -> None:
+    def __init__(self, path: str, protocol: str = "", host: str = "") -> None:
         self.protocol = protocol
+        self.host = host
 
     def make_absolute_url(self, base_url: typing.Union[str, URL]) -> str:
         if isinstance(base_url, str):
             base_url = URL(base_url)
-        scheme = {
-            "http": {True: "https", False: "http"},
-            "websocket": {True: "wss", False: "ws"},
-        }[self.protocol][base_url.is_secure]
-        netloc = base_url.netloc
-        return str(URL(scheme=scheme, netloc=base_url.netloc, path=str(self)))
+        if self.protocol:
+            scheme = {
+                "http": {True: "https", False: "http"},
+                "websocket": {True: "wss", False: "ws"},
+            }[self.protocol][base_url.is_secure]
+        else:
+            scheme = base_url.scheme
+
+        if self.host:
+            netloc = self.host
+        else:
+            netloc = base_url.netloc
+
+        return str(URL(scheme=scheme, netloc=netloc, path=str(self)))
 
 
 class Secret:

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -6,7 +6,7 @@ from enum import Enum
 
 from starlette.concurrency import run_in_threadpool
 from starlette.convertors import CONVERTOR_TYPES, Convertor
-from starlette.datastructures import URL, URLPath
+from starlette.datastructures import URL, Headers, URLPath
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, RedirectResponse
@@ -84,6 +84,10 @@ def replace_params(
     return path, path_params
 
 
+# Match parameters in URL paths, eg. '{param}', and '{param:int}'
+PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?}")
+
+
 def compile_path(
     path: str
 ) -> typing.Tuple[typing.Pattern, str, typing.Dict[str, Convertor]]:
@@ -122,9 +126,6 @@ def compile_path(
     path_format += path[idx:]
 
     return re.compile(path_regex), path_format, param_convertors
-
-
-PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?}")
 
 
 class BaseRoute:
@@ -275,7 +276,7 @@ class WebSocketRoute(BaseRoute):
 
 
 class Mount(BaseRoute):
-    def __init__(self, path: str, app: ASGIApp, name: str = None) -> None:
+    def __init__(self, path, app: ASGIApp = None, name: str = None) -> None:
         assert path == "" or path.startswith("/"), "Routed paths must start with '/'"
         self.path = path.rstrip("/")
         self.app = app
@@ -316,7 +317,7 @@ class Mount(BaseRoute):
                 self.path_format, self.param_convertors, path_params
             )
             if not remaining_params:
-                return URLPath(path=path, protocol="http")
+                return URLPath(path=path)
         elif self.name is None or name.startswith(self.name + ":"):
             if self.name is None:
                 # No mount name.
@@ -349,6 +350,83 @@ class Mount(BaseRoute):
         )
 
 
+class Host(BaseRoute):
+    def __init__(
+        self,
+        host: str,
+        routes: typing.List[BaseRoute] = None,
+        app: ASGIApp = None,
+        name: str = None,
+    ) -> None:
+        self.host = host
+        if app is None:
+            assert routes is not None, "One of either 'routes' or 'app' is required."
+            self.app = Router(routes=routes)
+        else:
+            assert (
+                routes is None
+            ), "One of either 'routes' or 'app' is required. Not both."
+            self.app = app
+
+        self.name = name
+        self.host_regex, self.host_format, self.param_convertors = compile_path(host)
+
+    @property
+    def routes(self) -> typing.List[BaseRoute]:
+        return getattr(self.app, "routes", None)
+
+    def matches(self, scope: Scope) -> typing.Tuple[Match, Scope]:
+        headers = Headers(scope=scope)
+        host = headers.get("host", "").split(":")[0]
+        match = self.host_regex.match(host)
+        if match:
+            matched_params = match.groupdict()
+            for key, value in matched_params.items():
+                matched_params[key] = self.param_convertors[key].convert(value)
+            path_params = dict(scope.get("path_params", {}))
+            path_params.update(matched_params)
+            child_scope = {"path_params": path_params, "endpoint": self.app}
+            return Match.FULL, child_scope
+        return Match.NONE, {}
+
+    def url_path_for(self, name: str, **path_params: str) -> URLPath:
+        if self.name is not None and name == self.name and "path" in path_params:
+            # 'name' matches "<mount_name>".
+            path = path_params.pop("path")
+            host, remaining_params = replace_params(
+                self.host_format, self.param_convertors, path_params
+            )
+            if not remaining_params:
+                return URLPath(path=path, host=host)
+        elif self.name is None or name.startswith(self.name + ":"):
+            if self.name is None:
+                # No mount name.
+                remaining_name = name
+            else:
+                # 'name' matches "<mount_name>:<child_name>".
+                remaining_name = name[len(self.name) + 1 :]
+            host, remaining_params = replace_params(
+                self.host_format, self.param_convertors, path_params
+            )
+            for route in self.routes or []:
+                try:
+                    url = route.url_path_for(remaining_name, **remaining_params)
+                    return URLPath(path=str(url), protocol=url.protocol, host=host)
+                except NoMatchFound as exc:
+                    pass
+        raise NoMatchFound()
+
+    def __call__(self, scope: Scope) -> ASGIInstance:
+        return self.app(scope)
+
+    def __eq__(self, other: typing.Any) -> bool:
+        return (
+            isinstance(other, Host)
+            and self.host == other.host
+            and self.app == other.app
+        )
+
+
 class Router:
     def __init__(
         self,
@@ -362,6 +440,10 @@ class Router:
 
     def mount(self, path: str, app: ASGIApp, name: str = None) -> None:
         route = Mount(path, app=app, name=name)
+        self.routes.append(route)
+
+    def host(self, host: str, app: ASGIApp, name: str = None) -> None:
+        route = Host(host, app=app, name=name)
         self.routes.append(route)
 
     def add_route(

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -276,7 +276,7 @@ class WebSocketRoute(BaseRoute):
 
 
 class Mount(BaseRoute):
-    def __init__(self, path, app: ASGIApp = None, name: str = None) -> None:
+    def __init__(self, path: str, app: ASGIApp, name: str = None) -> None:
         assert path == "" or path.startswith("/"), "Routed paths must start with '/'"
         self.path = path.rstrip("/")
         self.app = app
@@ -351,23 +351,9 @@ class Mount(BaseRoute):
 
 
 class Host(BaseRoute):
-    def __init__(
-        self,
-        host: str,
-        routes: typing.List[BaseRoute] = None,
-        app: ASGIApp = None,
-        name: str = None,
-    ) -> None:
+    def __init__(self, host: str, app: ASGIApp, name: str = None) -> None:
         self.host = host
-        if app is None:
-            assert routes is not None, "One of either 'routes' or 'app' is required."
-            self.app = Router(routes=routes)
-        else:
-            assert (
-                routes is None
-            ), "One of either 'routes' or 'app' is required. Not both."
-            self.app = app
-
+        self.app = app
         self.name = name
         self.host_regex, self.host_format, self.param_convertors = compile_path(host)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,7 +1,7 @@
 import pytest
 
 from starlette.responses import JSONResponse, PlainTextResponse, Response
-from starlette.routing import Mount, NoMatchFound, Route, Router, WebSocketRoute
+from starlette.routing import Host, Mount, NoMatchFound, Route, Router, WebSocketRoute
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
@@ -270,4 +270,87 @@ def test_reverse_mount_urls():
     )
     assert (
         mounted.url_path_for("users", subpath="test", path="/tom") == "/test/users/tom"
+    )
+
+
+def users_api(request):
+    return JSONResponse({"users": [{"username": "tom"}]})
+
+
+mixed_hosts_app = Router(
+    routes=[
+        Host(
+            "www.example.org",
+            routes=[
+                Route("/", homepage, name="homepage"),
+                Route("/users", users, name="users"),
+            ],
+        ),
+        Host(
+            "api.example.org",
+            name="api",
+            routes=[Route("/users", users_api, name="users")],
+        ),
+    ]
+)
+
+
+def test_host_routing():
+    client = TestClient(mixed_hosts_app, base_url="https://api.example.org/")
+
+    response = client.get("/users")
+    assert response.status_code == 200
+    assert response.json() == {"users": [{"username": "tom"}]}
+
+    response = client.get("/")
+    assert response.status_code == 404
+
+    client = TestClient(mixed_hosts_app, base_url="https://www.example.org/")
+
+    response = client.get("/users")
+    assert response.status_code == 200
+    assert response.text == "All users"
+
+    response = client.get("/")
+    assert response.status_code == 200
+
+
+def test_host_reverse_urls():
+    assert (
+        mixed_hosts_app.url_path_for("homepage").make_absolute_url("https://whatever")
+        == "https://www.example.org/"
+    )
+    assert (
+        mixed_hosts_app.url_path_for("users").make_absolute_url("https://whatever")
+        == "https://www.example.org/users"
+    )
+    assert (
+        mixed_hosts_app.url_path_for("api:users").make_absolute_url("https://whatever")
+        == "https://api.example.org/users"
+    )
+
+
+def subdomain_app(scope):
+    return JSONResponse({"subdomain": scope["path_params"]["subdomain"]})
+
+
+subdomain_app = Router(
+    routes=[Host("{subdomain}.example.org", app=subdomain_app, name="subdomains")]
+)
+
+
+def test_subdomain_routing():
+    client = TestClient(subdomain_app, base_url="https://foo.example.org/")
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"subdomain": "foo"}
+
+
+def test_subdomain_reverse_urls():
+    assert (
+        subdomain_app.url_path_for(
+            "subdomains", subdomain="foo", path="/homepage"
+        ).make_absolute_url("https://whatever")
+        == "https://foo.example.org/homepage"
     )

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -281,15 +281,17 @@ mixed_hosts_app = Router(
     routes=[
         Host(
             "www.example.org",
-            routes=[
-                Route("/", homepage, name="homepage"),
-                Route("/users", users, name="users"),
-            ],
+            app=Router(
+                [
+                    Route("/", homepage, name="homepage"),
+                    Route("/users", users, name="users"),
+                ]
+            ),
         ),
         Host(
             "api.example.org",
             name="api",
-            routes=[Route("/users", users_api, name="users")],
+            app=Router([Route("/users", users_api, name="users")]),
         ),
     ]
 )


### PR DESCRIPTION
* Adds `app.host(host, app)`, which mirrors the existing `app.mount(path, app)`.
* Adds a `Host(...)` routing class, which mirrors the existing `Mount` routing class.

Closes #360

Examples:

Website and API, with separate routing rules:

```python
app = Starlette()
site = Router()  # Use eg. `@site.route()` to configure this.
api = Router()  # Use eg. `@api.route()` to configure this.

app.host('www.example.org', site)
app.host('api.example.org', api)
```

A custom subdomain:

```python
app = Starlette()

site = Router()  # Use eg. `@site.route()` to configure this.
subdomains = Router()  # Use eg. `@subdomains.route()` to configure this.

app.host('www.example.org', site)
app.host('{subdomain}.example.org', api)
```

Features:

* Subdomain components are available in URL reversing, eg. `request.url_for("users_list", subdomain=...)`
* Namespaces route naming is supported. eg. `app.host('api.example.org', api, name="api')` will then require reverse lookups like eg. `request.url_for("api:users_list")`
* Matched subdomain parts are available on the existing `request.path_params`.

Considerations:

* The name of `request.path_params` isn't exactly correct anymore. Should we move to `request.route_params` or something?
* For testing purposes users will need an easy way to mock up the host for requests, rather than eg. 127.0.0.1. Do we want that available in Starlette or in Uvicorn? Or do we just point folks at how to edit their `hosts` file?
* ~We might like subdomain parameters to be optional. If they're not included then `request.url_for` should default to current domain. (Assuming it matches the pattern?)~ Actually probably forget about that - we don't expect it with submounted paths, we shouldn't expect it here.
* We need to document this.
* I'm also becoming less convinced with the benefits of the decorator style routing, vs. composing route instances.
