### PR TITLE
Initial support for MySQL database

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -1,7 +1,10 @@
 Starlette includes optional database support. There is currently only a driver
-for Postgres databases, but MySQL and SQLite support is planned.
+for Postgres and MySQL databases, but SQLite support is planned.
 
-Enabling the built-in database support requires `sqlalchemy`, and an appropriate database driver. Currently this means `asyncpg` is a requirement.
+Enabling the built-in database support requires `sqlalchemy`, and an appropriate database driver. 
+
+PostgreSQL: requires `asyncpg`
+MySQL: requires `aiomysql`
 
 The database support is completely optional - you can either include the middleware or not, or you can build alternative kinds of backends instead. It does not
 include support for an ORM, but it does support using queries built using

--- a/starlette/database/mysql.py
+++ b/starlette/database/mysql.py
@@ -1,0 +1,151 @@
+import typing
+from types import TracebackType
+
+import asyncio
+
+import aiomysql
+from sqlalchemy.dialects.mysql import pymysql
+from sqlalchemy.engine.interfaces import Dialect
+from sqlalchemy.sql import ClauseElement
+
+from starlette.database.core import (
+    DatabaseBackend,
+    DatabaseSession,
+    DatabaseTransaction,
+    compile,
+)
+from starlette.datastructures import DatabaseURL
+
+
+class MysqlBackend(DatabaseBackend):
+    def __init__(self, database_url: typing.Union[str, DatabaseURL]) -> None:
+        self.database_url = database_url
+        self.dialect = self.get_dialect()
+        self.pool = None
+
+    def get_dialect(self) -> Dialect:
+        return pymysql.dialect(paramstyle="pyformat")
+
+    async def startup(self) -> None:
+        db = self.database_url
+        self.pool = await aiomysql.create_pool(host=db.hostname,
+                                               port=db.port,
+                                               user=db.username,
+                                               password=db.password,
+                                               db=db.database)
+
+    async def shutdown(self) -> None:
+        assert self.pool is not None, "DatabaseBackend is not running"
+        self.pool.close()
+        self.pool = None
+
+    def session(self) -> "MysqlSession":
+        assert self.pool is not None, "DatabaseBackend is not running"
+        return MysqlSession(self.pool, self.dialect)
+
+
+class MysqlSession(DatabaseSession):
+    def __init__(self, pool: aiomysql.pool.Pool, dialect: Dialect):
+        self.pool = pool
+        self.dialect = dialect
+        self.conn = None
+        self.connection_holders = 0
+
+    async def fetchall(self, query: ClauseElement) -> typing.Any:
+        query, args = compile(query, dialect=self.dialect)
+
+        conn = await self.acquire_connection()
+        cursor = await conn.cursor()
+        try:
+            await cursor.execute(query, *args)
+            return await cursor.fetchall()
+        finally:
+            await cursor.close()
+            await self.release_connection()
+
+    async def fetchone(self, query: ClauseElement) -> typing.Any:
+        query, args = compile(query, dialect=self.dialect)
+
+        conn = await self.acquire_connection()
+        cursor = await conn.cursor()
+        try:
+            await cursor.execute(query, *args)
+            return await conn.fetchrow(query, *args)
+        finally:
+            await cursor.close()
+            await self.release_connection()
+
+    async def execute(self, query: ClauseElement) -> None:
+        query, args = compile(query, dialect=self.dialect)
+
+        conn = await self.acquire_connection()
+        cursor = await conn.cursor()
+        try:
+            await cursor.execute(query, *args)
+        finally:
+            await cursor.close()
+            await self.release_connection()
+
+    async def executemany(self, query: ClauseElement, values: list) -> None:
+        conn = await self.acquire_connection()
+        cursor = await conn.cursor()
+        try:
+            for item in values:
+                single_query = query.values(item)
+                single_query, args = compile(single_query, dialect=self.dialect)
+                await cursor.execute(single_query, *args)
+        finally:
+            await cursor.close()
+            await self.release_connection()
+
+    def transaction(self) -> DatabaseTransaction:
+        return MysqlTransaction(self)
+
+    async def acquire_connection(self) -> aiomysql.Connection:
+        """
+        Either acquire a connection from the pool, or return the
+        existing connection. Must be followed by a corresponding
+        call to `release_connection`.
+        """
+        self.connection_holders += 1
+        if self.conn is None:
+            self.conn = await self.pool.acquire()
+        return self.conn
+
+    async def release_connection(self) -> None:
+        self.connection_holders -= 1
+        if self.connection_holders == 0:
+            await self.pool.release(self.conn)
+            self.conn = None
+
+
+class MysqlTransaction(DatabaseTransaction):
+    def __init__(self, session: MysqlSession):
+        self.session = session
+        self.conn = None
+
+    async def __aenter__(self) -> None:
+        await self.start()
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        if exc_type is not None:
+            await self.rollback()
+        else:
+            await self.commit()
+
+    async def start(self) -> None:
+        self.conn = await self.session.acquire_connection()
+        await self.conn.begin()
+
+    async def commit(self) -> None:
+        await self.conn.commit()
+        await self.session.release_connection()
+
+    async def rollback(self) -> None:
+        await self.conn.rollback()
+        await self.session.release_connection()

--- a/starlette/middleware/database.py
+++ b/starlette/middleware/database.py
@@ -1,7 +1,5 @@
 import typing
 
-import asyncpg
-
 from starlette.database.core import (
     DatabaseBackend,
     DatabaseSession,
@@ -30,11 +28,18 @@ class DatabaseMiddleware:
         if isinstance(database_url, str):
             database_url = DatabaseURL(database_url)
         assert (
-            database_url.dialect == "postgresql"
-        ), "Currently only postgresql is supported."
-        from starlette.database.postgres import PostgresBackend
+            database_url.dialect in ["postgresql", "mysql"]
+        ), "Currently only postgresql and mysql are supported."
 
-        return PostgresBackend(database_url)
+        if database_url.dialect == "postgresql":
+            from starlette.database.postgres import PostgresBackend
+
+            return PostgresBackend(database_url)
+
+        if database_url.dialect == "mysql":
+            from starlette.database.mysql import MysqlBackend
+
+            return MysqlBackend(database_url)
 
     def __call__(self, scope: Scope) -> ASGIInstance:
         if scope["type"] == "lifespan":


### PR DESCRIPTION
This is a copy of starlette's PostgreSQL driver, with modifications for MySQL. Includes changes to documentation, a mysql module within starlette.database and a minimal change to the Database middleware to accept MySQL DB URLs.