### PR TITLE
Add content_type attribute to UploadFile

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -422,8 +422,9 @@ class UploadFile:
     An uploaded file included as part of the request data.
     """
 
-    def __init__(self, filename: str, file: typing.IO = None) -> None:
+    def __init__(self, filename: str, content_type: str, file: typing.IO = None) -> None:
         self.filename = filename
+        self.content_type = content_type
         if file is None:
             file = tempfile.SpooledTemporaryFile()
         self.file = file

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -423,7 +423,7 @@ class UploadFile:
     """
 
     def __init__(
-        self, filename: str, content_type: str, file: typing.IO = None
+        self, filename: str, file: typing.IO = None, content_type: str = ""
     ) -> None:
         self.filename = filename
         self.content_type = content_type

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -422,7 +422,9 @@ class UploadFile:
     An uploaded file included as part of the request data.
     """
 
-    def __init__(self, filename: str, content_type: str, file: typing.IO = None) -> None:
+    def __init__(
+        self, filename: str, content_type: str, file: typing.IO = None
+    ) -> None:
         self.filename = filename
         self.content_type = content_type
         if file is None:

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -200,11 +200,12 @@ class MultiPartParser:
                 elif message_type == MultiPartMessage.HEADERS_FINISHED:
                     headers = Headers(raw=raw_headers)
                     content_disposition = headers.get("Content-Disposition")
+                    content_type = headers.get("Content-Type")
                     disposition, options = parse_options_header(content_disposition)
                     field_name = options[b"name"].decode("latin-1")
                     if b"filename" in options:
                         filename = options[b"filename"].decode("latin-1")
-                        file = UploadFile(filename=filename)
+                        file = UploadFile(filename=filename, content_type=content_type)
                     else:
                         file = None
                 elif message_type == MultiPartMessage.PART_DATA:

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -200,7 +200,7 @@ class MultiPartParser:
                 elif message_type == MultiPartMessage.HEADERS_FINISHED:
                     headers = Headers(raw=raw_headers)
                     content_disposition = headers.get("Content-Disposition")
-                    content_type = headers.get("Content-Type")
+                    content_type = headers.get("Content-Type", "")
                     disposition, options = parse_options_header(content_disposition)
                     field_name = options[b"name"].decode("latin-1")
                     if b"filename" in options:

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -23,7 +23,7 @@ def app(scope):
         for key, value in data.items():
             if isinstance(value, UploadFile):
                 content = await value.read()
-                output[key] = {"filename": value.filename, "content": content.decode()}
+                output[key] = {"filename": value.filename, "content": content.decode(), "content_type": value.content_type}
             else:
                 output[key] = value
         await request.close()
@@ -44,7 +44,7 @@ def multi_items_app(scope):
             if isinstance(value, UploadFile):
                 content = await value.read()
                 output[key].append(
-                    {"filename": value.filename, "content": content.decode()}
+                    {"filename": value.filename, "content": content.decode(), "content_type": value.content_type}
                 )
             else:
                 output[key].append(value)
@@ -86,7 +86,19 @@ def test_multipart_request_files(tmpdir):
     with open(path, "rb") as f:
         response = client.post("/", files={"test": f})
         assert response.json() == {
-            "test": {"filename": "test.txt", "content": "<file content>"}
+            "test": {"filename": "test.txt", "content": "<file content>", "content_type": None}
+        }
+
+def test_multipart_request_files_with_content_type(tmpdir):
+    path = os.path.join(tmpdir, "test.txt")
+    with open(path, "wb") as file:
+        file.write(b"<file content>")
+
+    client = TestClient(app)
+    with open(path, "rb") as f:
+        response = client.post("/", files={"test": ("test.txt", f, "text/plain")})
+        assert response.json() == {
+            "test": {"filename": "test.txt", "content": "<file content>", "content_type": "text/plain"}
         }
 
 
@@ -101,10 +113,10 @@ def test_multipart_request_multiple_files(tmpdir):
 
     client = TestClient(app)
     with open(path1, "rb") as f1, open(path2, "rb") as f2:
-        response = client.post("/", files={"test1": f1, "test2": f2})
+        response = client.post("/", files={"test1": f1, "test2": ("test2.txt", f2, "text/plain")})
         assert response.json() == {
-            "test1": {"filename": "test1.txt", "content": "<file1 content>"},
-            "test2": {"filename": "test2.txt", "content": "<file2 content>"},
+            "test1": {"filename": "test1.txt", "content": "<file1 content>", "content_type": None},
+            "test2": {"filename": "test2.txt", "content": "<file2 content>", "content_type": "text/plain"},
         }
 
 
@@ -120,13 +132,13 @@ def test_multi_items(tmpdir):
     client = TestClient(multi_items_app)
     with open(path1, "rb") as f1, open(path2, "rb") as f2:
         response = client.post(
-            "/", data=[("test1", "abc")], files=[("test1", f1), ("test1", f2)]
+            "/", data=[("test1", "abc")], files=[("test1", f1), ("test1", ("test2.txt", f2, "text/plain"))]
         )
         assert response.json() == {
             "test1": [
                 "abc",
-                {"filename": "test1.txt", "content": "<file1 content>"},
-                {"filename": "test2.txt", "content": "<file2 content>"},
+                {"filename": "test1.txt", "content": "<file1 content>", "content_type": None},
+                {"filename": "test2.txt", "content": "<file2 content>", "content_type": "text/plain"},
             ]
         }
 
@@ -156,7 +168,7 @@ def test_multipart_request_mixed_files_and_data(tmpdir):
         },
     )
     assert response.json() == {
-        "file": {"filename": "file.txt", "content": "<file content>"},
+        "file": {"filename": "file.txt", "content": "<file content>", "content_type": "text/plain"},
         "field0": "value0",
         "field1": "value1",
     }

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -23,7 +23,11 @@ def app(scope):
         for key, value in data.items():
             if isinstance(value, UploadFile):
                 content = await value.read()
-                output[key] = {"filename": value.filename, "content": content.decode(), "content_type": value.content_type}
+                output[key] = {
+                    "filename": value.filename,
+                    "content": content.decode(),
+                    "content_type": value.content_type,
+                }
             else:
                 output[key] = value
         await request.close()
@@ -44,7 +48,11 @@ def multi_items_app(scope):
             if isinstance(value, UploadFile):
                 content = await value.read()
                 output[key].append(
-                    {"filename": value.filename, "content": content.decode(), "content_type": value.content_type}
+                    {
+                        "filename": value.filename,
+                        "content": content.decode(),
+                        "content_type": value.content_type,
+                    }
                 )
             else:
                 output[key].append(value)
@@ -86,8 +94,13 @@ def test_multipart_request_files(tmpdir):
     with open(path, "rb") as f:
         response = client.post("/", files={"test": f})
         assert response.json() == {
-            "test": {"filename": "test.txt", "content": "<file content>", "content_type": None}
+            "test": {
+                "filename": "test.txt",
+                "content": "<file content>",
+                "content_type": None,
+            }
         }
+
 
 def test_multipart_request_files_with_content_type(tmpdir):
     path = os.path.join(tmpdir, "test.txt")
@@ -98,7 +111,11 @@ def test_multipart_request_files_with_content_type(tmpdir):
     with open(path, "rb") as f:
         response = client.post("/", files={"test": ("test.txt", f, "text/plain")})
         assert response.json() == {
-            "test": {"filename": "test.txt", "content": "<file content>", "content_type": "text/plain"}
+            "test": {
+                "filename": "test.txt",
+                "content": "<file content>",
+                "content_type": "text/plain",
+            }
         }
 
 
@@ -113,10 +130,20 @@ def test_multipart_request_multiple_files(tmpdir):
 
     client = TestClient(app)
     with open(path1, "rb") as f1, open(path2, "rb") as f2:
-        response = client.post("/", files={"test1": f1, "test2": ("test2.txt", f2, "text/plain")})
+        response = client.post(
+            "/", files={"test1": f1, "test2": ("test2.txt", f2, "text/plain")}
+        )
         assert response.json() == {
-            "test1": {"filename": "test1.txt", "content": "<file1 content>", "content_type": None},
-            "test2": {"filename": "test2.txt", "content": "<file2 content>", "content_type": "text/plain"},
+            "test1": {
+                "filename": "test1.txt",
+                "content": "<file1 content>",
+                "content_type": None,
+            },
+            "test2": {
+                "filename": "test2.txt",
+                "content": "<file2 content>",
+                "content_type": "text/plain",
+            },
         }
 
 
@@ -132,13 +159,23 @@ def test_multi_items(tmpdir):
     client = TestClient(multi_items_app)
     with open(path1, "rb") as f1, open(path2, "rb") as f2:
         response = client.post(
-            "/", data=[("test1", "abc")], files=[("test1", f1), ("test1", ("test2.txt", f2, "text/plain"))]
+            "/",
+            data=[("test1", "abc")],
+            files=[("test1", f1), ("test1", ("test2.txt", f2, "text/plain"))],
         )
         assert response.json() == {
             "test1": [
                 "abc",
-                {"filename": "test1.txt", "content": "<file1 content>", "content_type": None},
-                {"filename": "test2.txt", "content": "<file2 content>", "content_type": "text/plain"},
+                {
+                    "filename": "test1.txt",
+                    "content": "<file1 content>",
+                    "content_type": None,
+                },
+                {
+                    "filename": "test2.txt",
+                    "content": "<file2 content>",
+                    "content_type": "text/plain",
+                },
             ]
         }
 
@@ -168,7 +205,11 @@ def test_multipart_request_mixed_files_and_data(tmpdir):
         },
     )
     assert response.json() == {
-        "file": {"filename": "file.txt", "content": "<file content>", "content_type": "text/plain"},
+        "file": {
+            "filename": "file.txt",
+            "content": "<file content>",
+            "content_type": "text/plain",
+        },
         "field0": "value0",
         "field1": "value1",
     }

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -97,7 +97,7 @@ def test_multipart_request_files(tmpdir):
             "test": {
                 "filename": "test.txt",
                 "content": "<file content>",
-                "content_type": None,
+                "content_type": "",
             }
         }
 
@@ -137,7 +137,7 @@ def test_multipart_request_multiple_files(tmpdir):
             "test1": {
                 "filename": "test1.txt",
                 "content": "<file1 content>",
-                "content_type": None,
+                "content_type": "",
             },
             "test2": {
                 "filename": "test2.txt",
@@ -169,7 +169,7 @@ def test_multi_items(tmpdir):
                 {
                     "filename": "test1.txt",
                     "content": "<file1 content>",
-                    "content_type": None,
+                    "content_type": "",
                 },
                 {
                     "filename": "test2.txt",


### PR DESCRIPTION
Thanks for your awesome project!

I want to look "Content-Type" header in multipart form request in some cases.

* Add `content_type` to UploadFile class
* If no content_type found, `UloadFile.content_type == None`

ref: https://tools.ietf.org/html/rfc7578#section-4.4

I don't know it's good to be `None` as the default behavior. For example, [Flask's `FileStorage.mimetype`returns empty string as default](https://github.com/pallets/werkzeug/blob/c8144ed2bcab242c80b9c5bbfe0a6f2124af0315/werkzeug/http.py#L371), but [`FileStorage.content_type` returns `None` as default](https://github.com/pallets/werkzeug/blob/c8144ed2bcab242c80b9c5bbfe0a6f2124af0315/werkzeug/datastructures.py#L2704).
