### PR TITLE
Invoke mounted apps to handle lifespan message

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -565,7 +565,7 @@ class MountedAppLifespanHandler:
                 self.instance = instance
                 self.startup_event = asyncio.Event()
                 self.shutdown_event = asyncio.Event()
-                self.receive_queue = asyncio.Queue()
+                self.receive_queue = asyncio.Queue()  # type: asyncio.Queue
 
             async def receive(self) -> Message:
                 return await self.receive_queue.get()
@@ -608,10 +608,8 @@ class MountedAppLifespanHandler:
 
         class MountedAppLifespan:
             def __init__(self, app: ASGIApp, scope: Scope) -> None:
-                self.lifespans = []
-                if not hasattr(app, "routes"):
-                    return
-                for route in app.routes:
+                self.lifespans = []  # type: typing.List[Lifespan]
+                for route in getattr(app, "routes", []):
                     try:
                         if not isinstance(route, Route):
                             self.lifespans.append(Lifespan(route(scope)))


### PR DESCRIPTION
Submounting other applications is very powerful.

Right now, only the root app process the lifespan message. So the event handlers registered on the root app can be called when the server startup/shutdown.  It is proper and reasonable. But sometime it is useful to invoke the submounted apps to process lifespan message in the meantime. 

I write a ``MountedAppLifespanHandler`` to invoke the submounted apps when the lifespan is coming. But I do not think it is proper to replace the recent ``LifespanHandler`` for the following compatible and design reasons:
1. It change the recent startup/shutdown behavior.
1. The ``__init__`` method is not compatible, need a ``ASGIApp``  as the first param.
2. I think it is optional not required.

There is no direct way to initialize my handler, because the lifespan handler creation is hard coded:

```
class Router:
    ......
    def __call__(self, scope: Scope) -> ASGIInstance:
        assert scope["type"] in ("http", "websocket", "lifespan")

        if scope["type"] == "lifespan":
            return LifespanHandler(scope)
    ......
```

I need to initialize my handler like this:

```
class Router:
    ......
    def __call__(self, scope: Scope) -> ASGIInstance:
        assert scope["type"] in ("http", "websocket", "lifespan")

        if scope["type"] == "lifespan":
            return MountedAppLifespanHandler(self, scope)
    ......
```

So, maybe my handler can be a future feature when the framework support custom lifespan handler initialization.