### PR TITLE
Disable graphiql by default

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -17,11 +17,13 @@ class Query(graphene.ObjectType):
 
 
 app = Starlette()
-app.add_route('/', GraphQLApp(schema=graphene.Schema(query=Query)))
+app.add_route('/', GraphQLApp(schema=graphene.Schema(query=Query), graphiql=True))
 ```
 
 If you load up the page in a browser, you'll be served the GraphiQL tool,
 which you can use to interact with your GraphQL API.
+
+The `graphiql` parameter must be set to `True` for console access.
 
 ![GraphiQL](img/graphiql.png)
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -17,13 +17,12 @@ class Query(graphene.ObjectType):
 
 
 app = Starlette()
-app.add_route('/', GraphQLApp(schema=graphene.Schema(query=Query), graphiql=True))
+app.add_route('/', GraphQLApp(schema=graphene.Schema(query=Query)))
 ```
 
 If you load up the page in a browser, you'll be served the GraphiQL tool,
 which you can use to interact with your GraphQL API.
 
-The `graphiql` parameter must be set to `True` for console access.
 
 ![GraphiQL](img/graphiql.png)
 

--- a/starlette/graphql.py
+++ b/starlette/graphql.py
@@ -27,8 +27,10 @@ class GraphQLApp:
         schema: "graphene.Schema",
         executor: typing.Any = None,
         executor_class: type = None,
+        graphiql: bool = False,
     ) -> None:
         self.schema = schema
+        self.graphiql = graphiql
         if executor is None:
             # New style in 0.10.0. Use 'executor_class'.
             # See issue https://github.com/encode/starlette/issues/242
@@ -58,6 +60,10 @@ class GraphQLApp:
     async def handle_graphql(self, request: Request) -> Response:
         if request.method in ("GET", "HEAD"):
             if "text/html" in request.headers.get("Accept", ""):
+                if not self.graphiql:
+                    return PlainTextResponse(
+                        "Not Found", status_code=status.HTTP_404_NOT_FOUND
+                    )
                 return await self.handle_graphiql(request)
 
             data = request.query_params  # type: typing.Mapping[str, typing.Any]

--- a/starlette/graphql.py
+++ b/starlette/graphql.py
@@ -27,7 +27,7 @@ class GraphQLApp:
         schema: "graphene.Schema",
         executor: typing.Any = None,
         executor_class: type = None,
-        graphiql: bool = False,
+        graphiql: bool = True,
     ) -> None:
         self.schema = schema
         self.graphiql = graphiql

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -33,7 +33,7 @@ class Query(graphene.ObjectType):
 
 
 schema = graphene.Schema(query=Query)
-app = GraphQLApp(schema=schema)
+app = GraphQLApp(schema=schema, graphiql=True)
 client = TestClient(app)
 
 
@@ -99,6 +99,14 @@ def test_graphiql_get():
     response = client.get("/", headers={"accept": "text/html"})
     assert response.status_code == 200
     assert "<!DOCTYPE html>" in response.text
+
+
+def test_graphiql_not_found():
+    app = GraphQLApp(schema=schema)
+    client = TestClient(app)
+    response = client.get("/", headers={"accept": "text/html"})
+    assert response.status_code == 404
+    assert response.text == "Not Found"
 
 
 def test_add_graphql_route():

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -102,7 +102,7 @@ def test_graphiql_get():
 
 
 def test_graphiql_not_found():
-    app = GraphQLApp(schema=schema)
+    app = GraphQLApp(schema=schema, graphiql=False)
     client = TestClient(app)
     response = client.get("/", headers={"accept": "text/html"})
     assert response.status_code == 404


### PR DESCRIPTION
This allows for GraphIQL to be enabled/disabled (default: disabled) using an additional keyword argument. It is a good security practice to disable this console on production systems.