### PR TITLE
Request.ujson() for parity with UJSONResponse

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -13,7 +13,12 @@ try:
 except ImportError:  # pragma: nocover
     parse_options_header = None  # type: ignore
 
+try:
+    import ujson
+except ImportError:  # pragma: nocover
+    ujson = None  # type: ignore
 
+    
 class ClientDisconnect(Exception):
     pass
 
@@ -168,6 +173,12 @@ class Request(HTTPConnection):
             self._json = json.loads(body)
         return self._json
 
+    async def ujson(self) -> typing.Any:
+        if not hasattr(self, "_json"):
+            body = await self.body()
+            self._json = ujson.loads(body)
+        return self._json
+    
     async def form(self) -> FormData:
         if not hasattr(self, "_form"):
             assert (

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -197,6 +197,21 @@ def test_request_json():
     assert response.json() == {"json": {"a": "123"}}
 
 
+def test_request_ujson():
+    def app(scope):
+        async def asgi(receive, send):
+            request = Request(scope, receive)
+            data = await request.ujson()
+            response = JSONResponse({"json": data})
+            await response(receive, send)
+
+        return asgi
+
+    client = TestClient(app)
+    response = client.post("/", json={"a": "123"})
+    assert response.json() == {"json": {"a": "123"}}
+
+
 def test_request_scope_interface():
     """
     A Request can be instantiated with a scope, and presents a `Mapping`


### PR DESCRIPTION
Proper solution should be some setting - e.g. `app = Starlette("app", json="ujson")` - will you accept PR with this approach?