### PR TITLE
Move to 'databases' instead of built-in 'DatabaseMiddleware'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+test.db
 .coverage
 .pytest_cache/
 .mypy_cache/

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,12 +7,12 @@ python-multipart
 pyyaml
 requests
 ujson
+databases[sqlite]
 
-# Async database drivers
+# Legacy
+sqlalchemy
 asyncpg
 aiomysql
-
-# Sync database drivers for standard tooling around setup/teardown/migrations.
 psycopg2-binary
 pymysql
 
@@ -24,7 +24,6 @@ isort
 mypy
 pytest
 pytest-cov
-sqlalchemy
 
 # Documentation
 mkdocs

--- a/scripts/test
+++ b/scripts/test
@@ -21,8 +21,4 @@ set -x
 PYTHONPATH=. ${PREFIX}pytest --ignore venv ${IGNORE_MODULES} -W ignore::DeprecationWarning --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
 ${PREFIX}mypy starlette --ignore-missing-imports --disallow-untyped-defs
 ${PREFIX}autoflake --recursive starlette tests
-if [ "${PYTHON_VERSION}" = '3.7' ]; then
-    echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
-else
-    ${PREFIX}black starlette tests --check
-fi
+${PREFIX}black starlette tests --check

--- a/starlette/database/__init__.py
+++ b/starlette/database/__init__.py
@@ -1,3 +1,10 @@
+"""
+The built-in database drivers are now pending deprecation.
+
+You can continue using them just fine for now, but you should consider
+moving to the standalone `databases` package instead.
+"""
+
 from starlette.database.core import (
     transaction,
     DatabaseBackend,

--- a/starlette/middleware/database.py
+++ b/starlette/middleware/database.py
@@ -1,3 +1,9 @@
+"""
+DatabaseMiddleware is pending deprecation.
+
+You can continue using it just fine for now, but you should consider
+moving to the standalone `databases` package instead.
+"""
 import typing
 
 from starlette.database.core import (

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -86,6 +86,9 @@ class HTTPConnection(Mapping):
 
     @property
     def database(self) -> typing.Any:  # pragma: no cover
+        # NOTE: Pending deprecation. You probably want to look at the
+        # stand-alone `databases` package instead.
+        # https://github.com/encode/databases
         assert (
             "database" in self._scope
         ), "DatabaseMiddleware must be installed to access request.database"

--- a/tests/middleware/test_https_redirect.py
+++ b/tests/middleware/test_https_redirect.py
@@ -27,6 +27,11 @@ def test_https_redirect_middleware():
     assert response.status_code == 301
     assert response.headers["location"] == "https://testserver/"
 
+    client = TestClient(app, base_url="http://testserver:443")
+    response = client.get("/", allow_redirects=False)
+    assert response.status_code == 301
+    assert response.headers["location"] == "https://testserver/"
+
     client = TestClient(app, base_url="http://testserver:123")
     response = client.get("/", allow_redirects=False)
     assert response.status_code == 301

--- a/tests/test_database_legacy.py
+++ b/tests/test_database_legacy.py
@@ -1,0 +1,184 @@
+import os
+
+import pytest
+import sqlalchemy
+
+from starlette.applications import Starlette
+from starlette.database import transaction
+from starlette.datastructures import CommaSeparatedStrings, DatabaseURL
+from starlette.middleware.database import DatabaseMiddleware
+from starlette.responses import JSONResponse
+from starlette.testclient import TestClient
+
+try:
+    DATABASE_URLS = CommaSeparatedStrings(os.environ["STARLETTE_TEST_DATABASES"])
+except KeyError:  # pragma: no cover
+    pytest.skip("STARLETTE_TEST_DATABASES is not set", allow_module_level=True)
+
+metadata = sqlalchemy.MetaData()
+
+notes = sqlalchemy.Table(
+    "notes",
+    metadata,
+    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column("text", sqlalchemy.String(length=100)),
+    sqlalchemy.Column("completed", sqlalchemy.Boolean),
+)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def create_test_databases():
+    engines = {}
+    for url in DATABASE_URLS:
+        db_url = DatabaseURL(url)
+        if db_url.dialect == "mysql":
+            #  Use the 'pymysql' driver for creating the database & tables.
+            url = str(db_url.replace(scheme="mysql+pymysql"))
+            db_name = db_url.database
+            db_url = db_url.replace(scheme="mysql+pymysql", database="")
+            engine = sqlalchemy.create_engine(str(db_url))
+            engine.execute("CREATE DATABASE IF NOT EXISTS " + db_name)
+
+        engines[url] = sqlalchemy.create_engine(url)
+        metadata.create_all(engines[url])
+
+    yield
+
+    for engine in engines.values():
+        engine.execute("DROP TABLE notes")
+
+
+def get_app(database_url):
+    app = Starlette()
+    app.add_middleware(
+        DatabaseMiddleware, database_url=database_url, rollback_on_shutdown=True
+    )
+
+    @app.route("/notes", methods=["GET"])
+    async def list_notes(request):
+        query = notes.select()
+        results = await request.database.fetchall(query)
+        content = [
+            {"text": result["text"], "completed": result["completed"]}
+            for result in results
+        ]
+        return JSONResponse(content)
+
+    @app.route("/notes", methods=["POST"])
+    @transaction
+    async def add_note(request):
+        data = await request.json()
+        query = notes.insert().values(text=data["text"], completed=data["completed"])
+        await request.database.execute(query)
+        if "raise_exc" in request.query_params:
+            raise RuntimeError()
+        return JSONResponse({"text": data["text"], "completed": data["completed"]})
+
+    @app.route("/notes/bulk_create", methods=["POST"])
+    async def bulk_create_notes(request):
+        data = await request.json()
+        query = notes.insert()
+        await request.database.executemany(query, data)
+        return JSONResponse({"notes": data})
+
+    @app.route("/notes/{note_id:int}", methods=["GET"])
+    async def read_note(request):
+        note_id = request.path_params["note_id"]
+        query = notes.select().where(notes.c.id == note_id)
+        result = await request.database.fetchone(query)
+        content = {"text": result["text"], "completed": result["completed"]}
+        return JSONResponse(content)
+
+    @app.route("/notes/{note_id:int}/text", methods=["GET"])
+    async def read_note_text(request):
+        note_id = request.path_params["note_id"]
+        query = sqlalchemy.select([notes.c.text]).where(notes.c.id == note_id)
+        text = await request.database.fetchval(query)
+        return JSONResponse(text)
+
+    return app
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+def test_database(database_url):
+    app = get_app(database_url)
+    with TestClient(app) as client:
+        response = client.post(
+            "/notes", json={"text": "buy the milk", "completed": True}
+        )
+        assert response.status_code == 200
+
+        with pytest.raises(RuntimeError):
+            response = client.post(
+                "/notes",
+                json={"text": "you wont see me", "completed": False},
+                params={"raise_exc": "true"},
+            )
+
+        response = client.post(
+            "/notes", json={"text": "walk the dog", "completed": False}
+        )
+        assert response.status_code == 200
+
+        response = client.get("/notes")
+        assert response.status_code == 200
+        assert response.json() == [
+            {"text": "buy the milk", "completed": True},
+            {"text": "walk the dog", "completed": False},
+        ]
+
+        response = client.get("/notes/1")
+        assert response.status_code == 200
+        assert response.json() == {"text": "buy the milk", "completed": True}
+
+        response = client.get("/notes/1/text")
+        assert response.status_code == 200
+        assert response.json() == "buy the milk"
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+def test_database_executemany(database_url):
+    app = get_app(database_url)
+    with TestClient(app) as client:
+        response = client.get("/notes")
+
+        data = [
+            {"text": "buy the milk", "completed": True},
+            {"text": "walk the dog", "completed": False},
+        ]
+        response = client.post("/notes/bulk_create", json=data)
+        assert response.status_code == 200
+
+        response = client.get("/notes")
+        assert response.status_code == 200
+        assert response.json() == [
+            {"text": "buy the milk", "completed": True},
+            {"text": "walk the dog", "completed": False},
+        ]
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+def test_database_isolated_during_test_cases(database_url):
+    """
+    Using `TestClient` as a context manager
+    """
+    app = get_app(database_url)
+    with TestClient(app) as client:
+        response = client.post(
+            "/notes", json={"text": "just one note", "completed": True}
+        )
+        assert response.status_code == 200
+
+        response = client.get("/notes")
+        assert response.status_code == 200
+        assert response.json() == [{"text": "just one note", "completed": True}]
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/notes", json={"text": "just one note", "completed": True}
+        )
+        assert response.status_code == 200
+
+        response = client.get("/notes")
+        assert response.status_code == 200
+        assert response.json() == [{"text": "just one note", "completed": True}]


### PR DESCRIPTION
Move to recommending the stand-alone package https://github.com/encode/databases rather than the built-in `DatabaseMiddleware`.

You no longer need to pass the `request` around everywhere you want database access.

This moves `DatabaseMiddleware` into a pending deprecation state, but does not remove it. It'll currently still continue to work just fine. We'll only drop it once we make a proper version bump.

Not much to change if you're moving to using it...

**1. Create a `database` instance, rather than installing a middleware.**

Remove:

`app.add_middleware(DatabaseMiddleware, database_url=DATABASE_URL)`

Add:

```python
database = databases.Database(DATABASE_URL)

@app.on_event("startup")
async def startup():
    await database.connect()

@app.on_event("shutdown")
async def shutdown():
    await database.disconnect()
```

**2. Use `database.<...>` instead of `request.database.<...>`**

* `request.database.fetchone(...)` -> `database.fetch_one()`
* `request.database.fetchall(...)` -> `database.fetch_all()`
* `request.database.execute(...)` -> `database.execute()`
* New: `database.execute_many()`
* New: `database.iterate()`
* Not yet ported: `request.database.fetchval(...)` (Use `fetchone()['coilumn_name']`)

**3. Use `@database.transaction()` instead of Starlette's built-in `@transaction` decorator.**

Remove:

```python
from starlette.databases import transaction

@transaction
async def my_endpoint(request):
   ...
```

Add:

```python
@database.transaction()
async def my_endpoint(request):
   ...
```