### PR TITLE
Add note about routes order

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -53,6 +53,12 @@ You can use any of the following to add handled routes to the application:
 * `@app.route(path)` - Add an HTTP route, decorator style.
 * `@app.websocket_route(path)` - Add a WebSocket route, decorator style.
 
+#### Order matters
+
+Routes are evaluated in order.
+
+If you need to declare a route of `/user/me` and another of `/user/{username}`, make sure you declare `/user/me` first.
+
 ### Adding event handlers to the application
 
 There are two ways to add event handlers:


### PR DESCRIPTION
Add explicit note about routes order: `/users/me` before `/users/{user_id}`.

---

This is equivalent to this new (more verbose) section in FastAPI: https://fastapi.tiangolo.com/tutorial/path-params/#order-matters

I tried to make it short as I see the docs style in Starlette is concise, but let me know if you prefer it more verbose (I can copy/adapt more from that section in FastAPI).