### PR TITLE
fix: jinja annotations when jinja not installed

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -281,7 +281,7 @@ from alembic.config import Config
 
 @pytest.fixture(scope="session", autouse=True)
 def create_test_database():
-    url = str(app.DATABASE_URL)
+    url = str(app.database._url)
     engine = create_engine(url)
     assert not database_exists(url), 'Test database already exists. Aborting tests.'
     create_database(url)             # Create the test database.

--- a/starlette/database/mysql.py
+++ b/starlette/database/mysql.py
@@ -4,11 +4,11 @@ import typing
 import uuid
 from types import TracebackType
 
+import aiomysql
 from sqlalchemy.dialects.mysql import pymysql
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.sql import ClauseElement
 
-import aiomysql
 from starlette.database.core import (
     DatabaseBackend,
     DatabaseSession,

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -51,7 +51,7 @@ class Jinja2Templates:
     def __init__(self, directory: str) -> None:
         self.env = self.get_env(directory)
 
-    def get_env(self, directory: str) -> jinja2.Environment:
+    def get_env(self, directory: str) -> "jinja2.Environment":
         @jinja2.contextfunction
         def url_for(context: dict, name: str, **path_params: typing.Any) -> str:
             request = context["request"]
@@ -62,7 +62,7 @@ class Jinja2Templates:
         env.globals["url_for"] = url_for
         return env
 
-    def get_template(self, name: str) -> jinja2.Template:
+    def get_template(self, name: str) -> "jinja2.Template":
         return self.env.get_template(name)
 
     def TemplateResponse(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,7 +1,7 @@
+import databases
 import pytest
 import sqlalchemy
 
-import databases
 from starlette.applications import Starlette
 from starlette.database import transaction
 from starlette.datastructures import CommaSeparatedStrings, DatabaseURL


### PR DESCRIPTION
+ jinja annotations are now strings.
+ minor fix in docs
+ lint

Error when jinja not installed:

```
venv/lib/python3.6/site-packages/starlette/applications.py:4: in <module>
    from starlette.exceptions import ExceptionMiddleware
venv/lib/python3.6/site-packages/starlette/exceptions.py:7: in <module>
    from starlette.responses import PlainTextResponse, Response
venv/lib/python3.6/site-packages/starlette/responses.py:289: in <module>
    from starlette.templating import _TemplateResponse as TemplateResponse
venv/lib/python3.6/site-packages/starlette/templating.py:44: in <module>
    class Jinja2Templates:
venv/lib/python3.6/site-packages/starlette/templating.py:54: in Jinja2Templates
    def get_env(self, directory: str) -> jinja2.Environment:
E   AttributeError: 'NoneType' object has no attribute 'Environment'
```