### PR TITLE
Add SQLAlchemy ORM example to databases, using request.state

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -385,7 +385,7 @@ def read_user(request):
 
 
 @app.middleware("http")
-async def close_db(request, call_next):
+async def db_session_middleware(request, call_next):
     request.state.db = Session()
     response = await call_next(request)
     request.state.db.close()


### PR DESCRIPTION
Add SQLAlchemy ORM example to databases, using `request.state`.

Based on the equivalent in FastAPI: https://fastapi.tiangolo.com/tutorial/sql-databases/

---

I tried to simplify it as much as possible, limit the verbosity of the docs, and keep the style of the rest of the Starlette docs (e.g. without type hints).

I assumed you would prefer it in the same `database.md`, as a short version/note at the end.

But if you prefer, I can change it to a `database-async.md` or similar, in a separate menu section.

Also, if you want I can raise the verbosity of the content/docs.