### PR TITLE
Update Config docs, removing defunct DatabaseURL references

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -9,13 +9,13 @@ that is not committed to source control.
 ```python
 from starlette.applications import Starlette
 from starlette.config import Config
-from starlette.datastructures import CommaSeparatedStrings, DatabaseURL, Secret
+from starlette.datastructures import CommaSeparatedStrings, Secret
 
 # Config will be read from environment variables and/or ".env" files.
 config = Config(".env")
 
 DEBUG = config('DEBUG', cast=bool, default=False)
-DATABASE_URL = config('DATABASE_URL', cast=DatabaseURL)
+DATABASE_URL = config('DATABASE_URL', cast=URL)
 SECRET_KEY = config('SECRET_KEY', cast=Secret)
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=CommaSeparatedStrings)
 
@@ -62,7 +62,7 @@ Secret('**********')
 '98n349$%8b8-7yjn0n8y93T$23r'
 ```
 
-Similarly, the `URL` and `DatabaseURL` class will hide any password component
+Similarly, the `URL` class will hide any password component
 in their representations.
 
 ```python
@@ -128,7 +128,7 @@ application logic separated:
 
 ```python
 from starlette.config import Config
-from starlette.datastructures import DatabaseURL, Secret
+from starlette.datastructures import URL, Secret
 
 config = Config(".env")
 
@@ -136,7 +136,7 @@ DEBUG = config('DEBUG', cast=bool, default=False)
 TESTING = config('TESTING', cast=bool, default=False)
 SECRET_KEY = config('SECRET_KEY', cast=Secret)
 
-DATABASE_URL = config('DATABASE_URL', cast=DatabaseURL)
+DATABASE_URL = config('DATABASE_URL', cast=URL)
 if TESTING:
     DATABASE_URL = DATABASE_URL.replace(database='test_' + DATABASE_URL.database)
 ```
@@ -180,6 +180,11 @@ app.add_middleware(
 @app.route('/', methods=['GET'])
 async def homepage(request):
     ...
+
+@router.get("/settings", tags=["Info"])
+def get_settings() -> dict:
+    return {var: repr(getattr(settings, var)) for var in dir(settings) if var.isupper()}
+
 ```
 
 Now let's deal with our test configuration.

--- a/docs/config.md
+++ b/docs/config.md
@@ -181,9 +181,6 @@ app.add_middleware(
 async def homepage(request):
     ...
 
-@router.get("/settings", tags=["Info"])
-def get_settings() -> dict:
-    return {var: repr(getattr(settings, var)) for var in dir(settings) if var.isupper()}
 
 ```
 


### PR DESCRIPTION
Closes #408 
1. Removed DatabaseURL Class which was removed in v0.11 and changed to URL instead
2. Added example for creating a settings API endpoint to show the settings while maintaining the Secret obfuscation for passwords, etc (example how to do this was shared by @tomchristie in #409)