### PR TITLE
Fix lower case header value preflight request

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -56,7 +56,7 @@ class CORSMiddleware:
         self.app = app
         self.allow_origins = allow_origins
         self.allow_methods = allow_methods
-        self.allow_headers = allow_headers
+        self.allow_headers = [h.lower() for h in allow_headers]
         self.allow_all_origins = "*" in allow_origins
         self.allow_all_headers = "*" in allow_headers
         self.allow_origin_regex = compiled_allow_origin_regex
@@ -117,7 +117,7 @@ class CORSMiddleware:
         if self.allow_all_headers and requested_headers is not None:
             headers["Access-Control-Allow-Headers"] = requested_headers
         elif requested_headers is not None:
-            for header in requested_headers.split(","):
+            for header in [h.lower() for h in requested_headers.split(",")]:
                 if header.strip() not in self.allow_headers:
                     failures.append("headers")
 

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -55,7 +55,7 @@ def test_cors_allow_specific_origin():
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["https://example.org"],
-        allow_headers=["X-Example"],
+        allow_headers=["X-Example", "Content-Type"],
     )
 
     @app.route("/")
@@ -68,13 +68,13 @@ def test_cors_allow_specific_origin():
     headers = {
         "Origin": "https://example.org",
         "Access-Control-Request-Method": "GET",
-        "Access-Control-Request-Headers": "X-Example",
+        "Access-Control-Request-Headers": "X-Example, Content-Type",
     }
     response = client.options("/", headers=headers)
     assert response.status_code == 200
     assert response.text == "OK"
     assert response.headers["access-control-allow-origin"] == "https://example.org"
-    assert response.headers["access-control-allow-headers"] == "X-Example"
+    assert response.headers["access-control-allow-headers"] == "X-Example, Content-Type"
 
     # Test standard response
     headers = {"Origin": "https://example.org"}
@@ -120,7 +120,9 @@ def test_cors_allow_origin_regex():
     app = Starlette()
 
     app.add_middleware(
-        CORSMiddleware, allow_headers=["X-Example"], allow_origin_regex="https://*"
+        CORSMiddleware,
+        allow_headers=["X-Example", "Content-Type"],
+        allow_origin_regex="https://*",
     )
 
     @app.route("/")
@@ -149,13 +151,13 @@ def test_cors_allow_origin_regex():
     headers = {
         "Origin": "https://another.com",
         "Access-Control-Request-Method": "GET",
-        "Access-Control-Request-Headers": "X-Example",
+        "Access-Control-Request-Headers": "X-Example, content-type",
     }
     response = client.options("/", headers=headers)
     assert response.status_code == 200
     assert response.text == "OK"
     assert response.headers["access-control-allow-origin"] == "https://another.com"
-    assert response.headers["access-control-allow-headers"] == "X-Example"
+    assert response.headers["access-control-allow-headers"] == "X-Example, Content-Type"
 
     # Test disallowed pre-flight response
     headers = {


### PR DESCRIPTION
Some browers send lower case values for the `Access-Control-Request-Headers`. This diff makes sure everything is handled case insensitive.

![screenshot 2019-02-24 at 10 11 14](https://user-images.githubusercontent.com/2479/53297398-be09d300-381e-11e9-972a-0bc4b9b91a7a.png)
