### PR TITLE
Doc hint about enabling code reload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $ uvicorn example:App
 INFO: Started server process [11509]
 INFO: Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
 ```
-Run uvicorn with `--debug` to enable auto-reloading on code changes and display error tracebacks.
+Run uvicorn with `--reload` to enable auto-reloading on code changes.
 
 ## Modularity
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ $ uvicorn example:App
 INFO: Started server process [11509]
 INFO: Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
 ```
+Run uvicorn with `--debug` to enable auto-reloading on code changes and display error tracebacks.
 
 ## Modularity
 


### PR DESCRIPTION
As currently starlette(debug=True) does not enable reload for code changes, maybe it's useful to point out the corresponding reload feature from the uvicorn and gunicorn packages. As I understand, uvicorn.run() itself doesn't allow this, so one must rely on command line (https://github.com/kennethreitz/responder/issues/239#issuecomment-440260673).

This PR suggests only uvicorn flag hint. gunicorn --reload arg with UvicornWorker has been a bit unstable for me (just the reload part).