### PR TITLE
Add documentation for UploadFile class in the Request section

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -116,6 +116,45 @@ In some cases such as long-polling, or streaming responses you might need to
 determine if the client has dropped the connection. You can determine this
 state with `disconnected = await request.is_disconnected()`.
 
+#### Request Files
+
+Request files are normally sent as multipart form data (`multipart/form-data`).
+
+When you call `await request.form()` you receive a `starlette.datastructures.FormData` which is an immutable
+multidict, containing both file uploads and text input.
+
+When one of the fields is a file upload, you will get a `starlette.datastructures.UploadFile`.
+
+`UploadFile` has the following attributes:
+
+* `filename`: A `str` with the original file name that was uploaded (e.g. `myimage.jpg`).
+* `content_type`: A `str` with the content type (MIME type / media type) (e.g. `image/jpeg`).
+* `file`: A <a href="https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile" target="_blank">`SpooledTemporaryFile`</a> (a <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> object). This is the actual Python file that you can pass directly to other functions or libraries that expect a "file-like" object.
+
+
+`UploadFile` has the following `async` methods. They all call the corresponding file methods underneath (using the internal `SpooledTemporaryFile`) in a threadpool.
+
+* `write(data)`: Writes `data` (`str` or `bytes`) to the file.
+* `read(size)`: Reads `size` (`int`) bytes/characters of the file.
+* `seek(offset)`: Goes to the byte position `offset` (`int`) in the file.
+    * E.g., `await myfile.seek(0)` would go to the start of the file.
+    * This is especially useful if you run `await myfile.read()` once and then need to read the contents again.
+* `close()`: Closes the file.
+
+As all these methods are `async` methods, you need to "await" them.
+
+For example, inside of an `async` route you can get the contents with:
+
+```Python
+contents = await myfile.read()
+```
+
+If you are inside of a normal `def` route, you can access the `UploadFile.file` directly, for example:
+
+```Python
+contents = myfile.file.read()
+```
+
 #### Other state
 
 If you want to store additional information on the request you can do so

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -140,29 +140,12 @@ multidict, containing both file uploads and text input. File upload items are re
 
 As all these methods are `async` methods, you need to "await" them.
 
-For example:
+For example, you can get the file name and the contents with:
 
 ```python
-from starlette.requests import Request
-from starlette.responses import Response
-
-
-class App:
-    def __init__(self, scope):
-        assert scope["type"] == "http"
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        request = Request(self.scope, receive)
-        form = await request.form()
-        myfile = form["file"]
-        filename = myfile.filename
-        contents_bytes = await myfile.read()
-        contents_str = contents_bytes.decode("utf-8")
-        response = Response(
-            f"The file {filename} contains: {contents_str}", media_type="text/plain"
-        )
-        await response(receive, send)
+form = await request.form()
+filename = form["upload_file"].filename
+contents = await form["upload_file"].read()
 ```
 
 #### Other state


### PR DESCRIPTION
Add documentation for `UploadFile` class in the Request section, the class received when getting uploaded files in a request.

This is extracted and adapted from FastAPI that uses/inherits the same Starlette class https://fastapi.tiangolo.com/tutorial/request-files/.

If it's too verbose, I can simplify it and eliminate explanations, etc.