### PR TITLE
Starlette.__init__: remove template_directory

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -11,10 +11,7 @@ from starlette.types import ASGIApp, ASGIInstance, Scope
 
 class Starlette:
     def __init__(
-        self,
-        debug: bool = False,
-        routes: typing.List[BaseRoute] = None,
-        template_directory: str = None,
+        self, debug: bool = False, routes: typing.List[BaseRoute] = None
     ) -> None:
         self._debug = debug
         self.router = Router(routes)


### PR DESCRIPTION
This appears to be unused since 37ee43e.