### PR TITLE
WIP: add tox config, revisit coverage/pytest config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,24 @@
-sudo: required
 dist: xenial
 language: python
 
 cache: pip
 
-python:
-    - "3.6"
-    - "3.7"
-    - "3.8-dev"
+jobs:
+    include:
+        - env: TOXENV=py36-coverage
+          python: "3.6"
+        - env: TOXENV=py37-coverage
+          python: "3.7"
+        - env: TOXENV=py38-coverage
+          python: "3.8-dev"
+        - env: TOXENV=mypy,autoflake,black
+          python: "3.7"
 
 install:
     - pip install -U -r requirements.txt
 
 script:
-    - scripts/test
+    - tox
 
 after_script:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 
 cache: pip
 
+env:
+    global:
+        - PYTEST_ADDOPTS=--cov-report=xml
+
 jobs:
     include:
         - env: TOXENV=py36-coverage
@@ -21,4 +25,9 @@ script:
     - tox
 
 after_script:
-    - codecov
+    - |
+      # Upload coverage.
+      if [[ -f coverage.xml ]]; then
+          pip install codecov
+          codecov -f coverage.xml
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
           python: "3.7"
 
 install:
-    - pip install -U -r requirements.txt
+    - pip install tox
 
 script:
     - tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[tool:pytest]
+testpaths = tests
+filterwarnings = ignore::DeprecationWarning
+
+[coverage:run]
+source = starlette, tests
+omit =
+  starlette/middleware/lifespan.py

--- a/tests/.ignore_lifespan
+++ b/tests/.ignore_lifespan
@@ -1,3 +1,0 @@
-[coverage:run]
-omit =
-  starlette/middleware/lifespan.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[testenv]
+setenv =
+  coverage: PYTEST_ADDOPTS=--cov --cov-fail-under=100 --cov-report=term-missing {env:PYTEST_ADDOPTS:}
+deps = -r requirements.txt
+commands = pytest {posargs}
+
+[testenv:mypy]
+deps =
+  mypy
+commands =
+  flase
+  mypy starlette --ignore-missing-imports --disallow-untyped-defs
+[testenv:autoflake]
+deps =
+  autoflake
+commands =
+  autoflake --recursive starlette tests setup.py
+[testenv:black]
+deps =
+  black
+commands =
+  black starlette tests setup.py --check

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ commands = pytest {posargs}
 deps =
   mypy
 commands =
-  flase
   mypy starlette --ignore-missing-imports --disallow-untyped-defs
 [testenv:autoflake]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,15 @@
 [testenv]
-setenv =
-  coverage: PYTEST_ADDOPTS=--cov --cov-fail-under=100 --cov-report=term-missing {env:PYTEST_ADDOPTS:}
 deps = -r requirements.txt
 commands = pytest {posargs}
+setenv =
+  coverage: PYTEST_ADDOPTS=--cov --cov-fail-under=100 --cov-report=term-missing {env:PYTEST_ADDOPTS:}
 
 [testenv:mypy]
-deps =
-  mypy
-commands =
-  mypy starlette --ignore-missing-imports --disallow-untyped-defs
+deps = mypy
+commands = mypy starlette --ignore-missing-imports --disallow-untyped-defs
 [testenv:autoflake]
-deps =
-  autoflake
-commands =
-  autoflake --recursive starlette tests setup.py
+deps = autoflake
+commands = autoflake --recursive starlette tests setup.py
 [testenv:black]
-deps =
-  black
-commands =
-  black starlette tests setup.py --check
+deps = black
+commands = black starlette tests setup.py --check


### PR DESCRIPTION
Main motivation: have QA failure reported in a separate/single job on Travis.

But tox allows for easier isolated running of tests in general.