### PR TITLE
[RFC] Add URL.path_query_fragment

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -95,6 +95,17 @@ class URL:
     def is_secure(self) -> bool:
         return self.scheme in ("https", "wss")
 
+    @property
+    def path_query_fragment(self) -> str:
+        r = self.path
+        query = self.query
+        if query:
+            r += '?' + query
+        fragment = self.fragment
+        if fragment:
+            r += '#' + fragment
+        return r
+
     def replace(self, **kwargs: typing.Any) -> "URL":
         if (
             "username" in kwargs

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -35,6 +35,17 @@ def test_url():
     assert new == "https://example.com:123/path/to/somewhere?abc=123#anchor"
     assert new.hostname == "example.com"
 
+    assert u.path_query_fragment == "/path/to/somewhere?abc=123#anchor"
+    new = u.replace(path="")
+    assert new.path_query_fragment == "?abc=123#anchor"
+    new = u.replace(query="")
+    assert new.path_query_fragment == "/path/to/somewhere#anchor"
+    new = u.replace(fragment="")
+    assert new.path_query_fragment == "/path/to/somewhere?abc=123"
+    new = u.replace(path="", query="")
+    assert new.path_query_fragment == "#anchor"
+    new = u.replace(path="", fragment="")
+    assert new.path_query_fragment == "?abc=123"
 
 def test_hidden_password():
     u = URL("https://example.org/path/to/somewhere")


### PR DESCRIPTION
This is helpful for getting the part after scheme, user, host etc.,
e.g. for local redirects.

While it is easy to wrap this with an own helper I believe it is used often in general.