### PR TITLE
Replace mutable "allowed_hosts" argument of TrustedHostMiddleware with None

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -11,9 +11,12 @@ class TrustedHostMiddleware:
     def __init__(
         self,
         app: ASGIApp,
-        allowed_hosts: typing.Sequence[str] = ["*"],
+        allowed_hosts: typing.Sequence[str] = None,
         www_redirect: bool = True,
     ) -> None:
+        if not allowed_hosts:
+            allowed_hosts = ["*"]
+
         for pattern in allowed_hosts:
             assert "*" not in pattern[1:], ENFORCE_DOMAIN_WILDCARD
             if pattern.startswith("*") and pattern != "*":

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -14,7 +14,7 @@ class TrustedHostMiddleware:
         allowed_hosts: typing.Sequence[str] = None,
         www_redirect: bool = True,
     ) -> None:
-        if not allowed_hosts:
+        if allowed_hosts is not None:
             allowed_hosts = ["*"]
 
         for pattern in allowed_hosts:

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -14,7 +14,7 @@ class TrustedHostMiddleware:
         allowed_hosts: typing.Sequence[str] = None,
         www_redirect: bool = True,
     ) -> None:
-        if allowed_hosts is not None:
+        if allowed_hosts is None:
             allowed_hosts = ["*"]
 
         for pattern in allowed_hosts:

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -28,10 +28,10 @@ def test_trusted_host_middleware():
     assert response.status_code == 400
 
 
-def test_default_allowed_hosts_equalto_wildcard_if_not_specified():
+def test_default_allowed_hosts():
     app = Starlette()
     middleware = TrustedHostMiddleware(app)
-    assert middleware.allowed_hosts == ['*']
+    assert middleware.allowed_hosts == ["*"]
 
 
 def test_www_redirect():

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -28,6 +28,12 @@ def test_trusted_host_middleware():
     assert response.status_code == 400
 
 
+def test_trusted_host_middleware_uses_wildcard_if_no_allowed_hosts_specified():
+    app = Starlette()
+    middleware = TrustedHostMiddleware(app)
+    assert middleware.allowed_hosts == ['*']
+
+
 def test_www_redirect():
     app = Starlette()
 

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -28,7 +28,7 @@ def test_trusted_host_middleware():
     assert response.status_code == 400
 
 
-def test_trusted_host_middleware_uses_wildcard_if_no_allowed_hosts_specified():
+def test_default_allowed_hosts_equalto_wildcard_if_not_specified():
     app = Starlette()
     middleware = TrustedHostMiddleware(app)
     assert middleware.allowed_hosts == ['*']


### PR DESCRIPTION
This replaces mutable `allowed_hosts=['*']` with `None` in `__init__` method of 
`starlette.middleware.trustedhost.TrustedHostMiddleware`