### PR TITLE
Adding a `%` to quote_plus's safe in RedirectResponse 

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -163,7 +163,7 @@ class RedirectResponse(Response):
         self, url: typing.Union[str, URL], status_code: int = 302, headers: dict = None
     ) -> None:
         super().__init__(content=b"", status_code=status_code, headers=headers)
-        self.headers["location"] = quote_plus(str(url), safe=":/#?&=@[]!$&'()*+,;")
+        self.headers["location"] = quote_plus(str(url), safe=":/%#?&=@[]!$&'()*+,;")
 
 
 class StreamingResponse(Response):


### PR DESCRIPTION
Fix the bug when `%` is quoted

```
>>> quote_plus(str("http://localhost:8000/?var=dsfs%20sd"), safe=":/#?&=@[]!$&'()*+,;")
'http://localhost:8000/?var=dsfs%2520sd'
```

https://github.com/huge-success/sanic/issues/1356