### PR TITLE
Add py.typed to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,4 +72,5 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
+    zip_safe=False,
 )


### PR DESCRIPTION
This package would be installed along with the package (since it is listed in `package_data`), to let mypy pick up type hints in the package source.

Quoting [Mypy’s documentation](https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages) on how to create a PEP 561 compatible package:

> [P]ackages that supply type information via type comments or annotations in the code should put a py.typed in their package directory.

The `package_data` entry is already added in #253.

Fix #452.