### PR TITLE
Add concurrency.iterator_to_async, tests and docs

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -180,6 +180,31 @@ class App:
         await response(receive, send)
 ```
 
+If you have a standard generator or iterator (instead of an async generator), you can wrap it with `starlette.concurrency.iterator_to_async` to convert it to an async generator.
+
+Then you can use it with a `StreamingResponse`.
+
+This is specially useful for synchronous <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> or streaming objects, like those provided by cloud storage providers.
+
+```python
+from starlette.responses import StreamingResponse
+from starlette.concurrency import iterator_to_async
+
+def get_stream():
+    # this would return an iterator or file-like object, etc.
+    pass
+
+class App:
+    def __init__(self, scope):
+        assert scope['type'] == 'http'
+        self.scope = scope
+
+    async def __call__(self, receive, send):
+        generator = iterator_to_async(get_stream())
+        response = StreamingResponse(generator, media_type='application/octet-stream')
+        await response(receive, send)
+```
+
 ### FileResponse
 
 Asynchronously streams a file as the response.

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import typing
+from typing import Any, AsyncGenerator, Iterator
 
 try:
     import contextvars  # Python 3.7+ only.
@@ -22,3 +23,24 @@ async def run_in_threadpool(
         # loop.run_in_executor doesn't accept 'kwargs', so bind them in here
         func = functools.partial(func, **kwargs)
     return await loop.run_in_executor(None, func, *args)
+
+
+class _StopSyncIteration(Exception):
+    pass
+
+
+def _interceptable_next(iterator: Iterator) -> Any:
+    try:
+        result = next(iterator)
+        return result
+    except StopIteration:
+        raise _StopSyncIteration
+
+
+async def iterator_to_async(iterator: Iterator) -> AsyncGenerator:
+    while True:
+        try:
+            result = await run_in_threadpool(_interceptable_next, iterator)
+            yield result
+        except _StopSyncIteration:
+            break


### PR DESCRIPTION
Add `concurrency.iterator_to_async`.

This is another utility function similar to `run_in_threadpool` (and uses it inside).

It takes a normal (non-async) iterator and returns an async generator.

There are some libraries that return a stream object that can be iterated normally but not with async.

Wrapping those objects with `iterator_to_async` would allow returning them in `StreamingResponse`s.

For example, file-like and similar objects, especially when they don't have a physical path that can be passed to `FileResponse`s.

A notable example is the kinds of objects from cloud storage providers (Minio, Amazon S3, Google Cloud Storage, Azure Storage).