### PR TITLE
Make StreamingResponse compatible with normal iterators

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -180,6 +180,31 @@ class App:
         await response(receive, send)
 ```
 
+If you have a standard generator or iterator (instead of an async generator), you can wrap it with `starlette.concurrency.iterator_to_async` to convert it to an async generator.
+
+Then you can use it with a `StreamingResponse`.
+
+This is specially useful for synchronous <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> or streaming objects, like those provided by cloud storage providers.
+
+```python
+from starlette.responses import StreamingResponse
+from starlette.concurrency import iterator_to_async
+
+def get_stream():
+    # this would return an iterator or file-like object, etc.
+    pass
+
+class App:
+    def __init__(self, scope):
+        assert scope['type'] == 'http'
+        self.scope = scope
+
+    async def __call__(self, receive, send):
+        generator = iterator_to_async(get_stream())
+        response = StreamingResponse(generator, media_type='application/octet-stream')
+        await response(receive, send)
+```
+
 ### FileResponse
 
 Asynchronously streams a file as the response.

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -154,7 +154,7 @@ class App:
 
 ### StreamingResponse
 
-Takes a an async generator or a normal generator/iterator and streams the response body.
+Takes an async generator or a normal generator/iterator and streams the response body.
 
 ```python
 from starlette.responses import StreamingResponse

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -154,7 +154,7 @@ class App:
 
 ### StreamingResponse
 
-Takes an async generator and streams the response body.
+Takes a an async generator or a normal generator/iterator and streams the response body.
 
 ```python
 from starlette.responses import StreamingResponse
@@ -180,30 +180,7 @@ class App:
         await response(receive, send)
 ```
 
-If you have a standard generator or iterator (instead of an async generator), you can wrap it with `starlette.concurrency.iterator_to_async` to convert it to an async generator.
-
-Then you can use it with a `StreamingResponse`.
-
-This is specially useful for synchronous <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> or streaming objects, like those provided by cloud storage providers.
-
-```python
-from starlette.responses import StreamingResponse
-from starlette.concurrency import iterator_to_async
-
-def get_stream():
-    # this would return an iterator or file-like object, etc.
-    pass
-
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        generator = iterator_to_async(get_stream())
-        response = StreamingResponse(generator, media_type='application/octet-stream')
-        await response(receive, send)
-```
+Have in mind that <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> objects (like those created by `open()`) are normal iterators. So, you can return them directly in a `StreamingResponse`.
 
 ### FileResponse
 

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -37,7 +37,7 @@ def _interceptable_next(iterator: Iterator) -> Any:
         raise _StopSyncIteration
 
 
-async def iterator_to_async(iterator: Iterator) -> AsyncGenerator:
+async def iterate_in_threadpool(iterator: Iterator) -> AsyncGenerator:
     while True:
         try:
             result = await run_in_threadpool(_interceptable_next, iterator)

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import typing
+from typing import Any, AsyncGenerator, Iterator
 
 try:
     import contextvars  # Python 3.7+ only.
@@ -22,3 +23,24 @@ async def run_in_threadpool(
         # loop.run_in_executor doesn't accept 'kwargs', so bind them in here
         func = functools.partial(func, **kwargs)
     return await loop.run_in_executor(None, func, *args)
+
+
+class _StopSyncIteration(Exception):
+    pass
+
+
+def _interceptable_next(iterator: Iterator) -> Any:
+    try:
+        result = next(iterator)
+        return result
+    except StopIteration:
+        raise _StopSyncIteration
+
+
+async def iterator_to_async(iterator: Iterator) -> AsyncGenerator:
+    while True:
+        try:
+            result = await run_in_threadpool(_interceptable_next, iterator)
+            yield result
+        except _StopSyncIteration:
+            break

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -181,7 +181,6 @@ class StreamingResponse(Response):
             self.body_iterator = content
         else:
             self.body_iterator = iterator_to_async(content)
-
         self.status_code = status_code
         self.media_type = self.media_type if media_type is None else media_type
         self.background = background

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -10,7 +10,7 @@ from mimetypes import guess_type
 from urllib.parse import quote_plus
 
 from starlette.background import BackgroundTask
-from starlette.concurrency import iterator_to_async
+from starlette.concurrency import iterate_in_threadpool
 from starlette.datastructures import URL, MutableHeaders
 from starlette.types import Receive, Scope, Send
 
@@ -180,7 +180,7 @@ class StreamingResponse(Response):
         if inspect.isasyncgen(content):
             self.body_iterator = content
         else:
-            self.body_iterator = iterator_to_async(content)
+            self.body_iterator = iterate_in_threadpool(content)
         self.status_code = status_code
         self.media_type = self.media_type if media_type is None else media_type
         self.background = background

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -1,5 +1,6 @@
 import hashlib
 import http.cookies
+import inspect
 import json
 import os
 import stat
@@ -9,6 +10,7 @@ from mimetypes import guess_type
 from urllib.parse import quote_plus
 
 from starlette.background import BackgroundTask
+from starlette.concurrency import iterator_to_async
 from starlette.datastructures import URL, MutableHeaders
 from starlette.types import Receive, Scope, Send
 
@@ -175,7 +177,11 @@ class StreamingResponse(Response):
         media_type: str = None,
         background: BackgroundTask = None,
     ) -> None:
-        self.body_iterator = content
+        if inspect.isasyncgen(content):
+            self.body_iterator = content
+        else:
+            self.body_iterator = iterator_to_async(content)
+
         self.status_code = status_code
         self.media_type = self.media_type if media_type is None else media_type
         self.background = background

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -91,7 +91,7 @@ def test_streaming_response():
     assert filled_by_bg_task == "6, 7, 8, 9"
 
 
-def test_streaming_response_from_sync_stream():
+def test_sync_streaming_response():
     async def app(scope, receive, send):
         def numbers(minimum, maximum):
             for i in range(minimum, maximum + 1):
@@ -100,8 +100,7 @@ def test_streaming_response_from_sync_stream():
                     yield ", "
 
         generator = numbers(1, 5)
-        aio_generator = iterator_to_async(generator)
-        response = StreamingResponse(aio_generator, media_type="text/plain")
+        response = StreamingResponse(generator, media_type="text/plain")
         await response(scope, receive, send)
 
     client = TestClient(app)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -5,7 +5,6 @@ import pytest
 
 from starlette import status
 from starlette.background import BackgroundTask
-from starlette.concurrency import iterator_to_async
 from starlette.requests import Request
 from starlette.responses import (
     FileResponse,


### PR DESCRIPTION
Make `StreamingResponse` compatible with normal iterators.

Continuing from #457, https://github.com/encode/starlette/pull/457#issuecomment-478965259

---

I also removed the mention to `iterator_to_async` from the docs, only mention that it supports both async and normal generators.

> I'd also be interested in if there's any nice ways around we could use something like this and drop `aiofiles` [...]

Let's see what do you think about this one and then I'll take a stab at that :smile: 