### PR TITLE
Allow to edit headers in request object

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -4,7 +4,14 @@ import json
 import typing
 from collections.abc import Mapping
 
-from starlette.datastructures import URL, Address, FormData, Headers, QueryParams
+from starlette.datastructures import (
+    URL,
+    Address,
+    FormData,
+    Headers,
+    MutableHeaders,
+    QueryParams,
+)
 from starlette.formparsers import FormParser, MultiPartParser
 from starlette.types import Message, Receive, Scope
 
@@ -52,9 +59,9 @@ class HTTPConnection(Mapping):
         return self._url
 
     @property
-    def headers(self) -> Headers:
+    def headers(self) -> MutableHeaders:
         if not hasattr(self, "_headers"):
-            self._headers = Headers(scope=self._scope)
+            self._headers = MutableHeaders(scope=self._scope)
         return self._headers
 
     @property

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -286,3 +286,16 @@ def test_chunked_encoding():
 
     response = client.post("/", data=post_body())
     assert response.json() == {"body": "foobar"}
+
+
+def test_edit_request_header():
+    async def app(scope, receive, send):
+        request = Request(scope, receive)
+        request.headers["x-foo"] = "bar"
+        response = JSONResponse({"foo": request.headers.get("X-Foo")})
+        await response(scope, receive, send)
+
+    client = TestClient(app)
+
+    response = client.get("/")
+    assert response.json() == {"foo": "bar"}


### PR DESCRIPTION
It would allow to make `TrustedProxiesMiddleware` middleware like below
```python
import uvicorn
from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
from starlette.requests import Request
from starlette.responses import PlainTextResponse
from starlette.applications import Starlette

app = Starlette()


@app.route("/")
def root(request: Request):
    return PlainTextResponse(request.client.host)


class TrustedProxiesMiddleware(BaseHTTPMiddleware):
    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
        if "x-forwarded-for" in request.headers:
            if request.client.host != "127.0.0.1":
                del request.headers["x-forwarded-for"]
                if request.headers.get("x-forwarded-proto"):
                    del request.headers["x-forwarded-proto"]
        return await call_next(request)


app.add_middleware(ProxyHeadersMiddleware)
app.add_middleware(TrustedProxiesMiddleware)

if __name__ == "__main__":
    uvicorn.run(app, host="0.0.0.0")
```