### PR TITLE
Corrects usage of CommaSeparatedStrings in docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,7 +32,7 @@ app.debug = DEBUG
 DEBUG=True
 DATABASE_URL=postgresql://localhost/myproject
 SECRET_KEY=43n080musdfjt54t-09sdgr
-ALLOWED_HOSTS="127.0.0.1", "localhost"
+ALLOWED_HOSTS=127.0.0.1, localhost
 ```
 
 ## Configuration precedence


### PR DESCRIPTION
Previous example will give list of one string: `127.0.0.1, localhost`, while it is expected list of two strings `127.0.0.1` and `localhost`