### PR TITLE
doc: fix middleware

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -165,13 +165,13 @@ app.add_middleware(CustomHeaderMiddleware)
 If you want to provide configuration options to the middleware class you should
 override the `__init__` method, ensuring that the first argument is `app`, and
 any remaining arguments are optional keyword arguments. Make sure to set the `app`
-attribute on the class if you do this.
+attribute on the instance if you do this.
 
 ```python
 class CustomHeaderMiddleware(BaseHTTPMiddleware):
     def __init__(self, app, header_value='Example'):
         self.app = app
-        self.header_value
+        self.header_value = header_value
 
     async def dispatch(self, request, call_next):
         response = await call_next(request)


### PR DESCRIPTION
It is still broken with regard to `dispatch/dispatch_func` (since 3e2e343) I guess.

Either the `__init__` here should call the parent's constructor, or use `dispatch_func` directly?!

Ref: https://github.com/blueyed/starlette/blob/c2a126ec5797cae28440454c0bf23b8348a630c1/starlette/middleware/base.py#L17