### PR TITLE
Implement file handling independent of aiofiles, add support for file-like objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ For a more complete example, see [encode/starlette-example](https://github.com/e
 Starlette does not have any hard dependencies, but the following are optional:
 
 * [`requests`][requests] - Required if you want to use the `TestClient`.
-* [`aiofiles`][aiofiles] - Required if you want to use `FileResponse` or `StaticFiles`.
 * [`jinja2`][jinja2] - Required if you want to use `Jinja2Templates`.
 * [`python-multipart`][python-multipart] - Required if you want to support form parsing, with `request.form()`.
 * [`itsdangerous`][itsdangerous] - Required for `SessionMiddleware` support.
@@ -168,7 +167,6 @@ gunicorn -k uvicorn.workers.UvicornH11Worker ...
 <p align="center"><i>Starlette is <a href="https://github.com/encode/starlette/blob/master/LICENSE.md">BSD licensed</a> code. Designed & built in Brighton, England.</i></p>
 
 [requests]: http://docs.python-requests.org/en/master/
-[aiofiles]: https://github.com/Tinche/aiofiles
 [jinja2]: http://jinja.pocoo.org/
 [python-multipart]: https://andrew-d.github.io/python-multipart/
 [graphene]: https://graphene-python.org/

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,6 @@ For a more complete example, [see here](https://github.com/encode/starlette-exam
 Starlette does not have any hard dependencies, but the following are optional:
 
 * [`requests`][requests] - Required if you want to use the `TestClient`.
-* [`aiofiles`][aiofiles] - Required if you want to use `FileResponse` or `StaticFiles`.
 * [`jinja2`][jinja2] - Required if you want to use `Jinja2Templates`.
 * [`python-multipart`][python-multipart] - Required if you want to support form parsing, with `request.form()`.
 * [`itsdangerous`][itsdangerous] - Required for `SessionMiddleware` support.
@@ -164,7 +163,6 @@ gunicorn -k uvicorn.workers.UvicornH11Worker ...
 <p align="center"><i>Starlette is <a href="https://github.com/encode/starlette/blob/master/LICENSE.md">BSD licensed</a> code. Designed & built in Brighton, England.</i></p>
 
 [requests]: http://docs.python-requests.org/en/master/
-[aiofiles]: https://github.com/Tinche/aiofiles
 [jinja2]: http://jinja.pocoo.org/
 [python-multipart]: https://andrew-d.github.io/python-multipart/
 [graphene]: https://graphene-python.org/

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -188,12 +188,12 @@ Asynchronously streams a file as the response.
 
 Takes a different set of arguments to instantiate than the other response types:
 
-* `path` - The filepath to the file to stream.
+* `file_or_path` - Can be a file path as a `str`, or a `pathlib.Path`. Can also be a [file-like object](https://docs.python.org/3/glossary.html#term-file-like-object) like those returned by `open(some_path, mode="rb")`.
 * `headers` - Any custom headers to include, as a dictionary.
-* `media_type` - A string giving the media type. If unset, the filename or path will be used to infer a media type.
-* `filename` - If set, this will be included in the response `Content-Disposition`.
+* `media_type` - A string giving the media type. If unset, the filename or path will be used to infer a media type (if `file_or_path` is a path).
+* `filename` - If set, this will be included in the response `Content-Disposition`. For example, instructing the browser to download the file instead of displaying it.
 
-File responses will include appropriate `Content-Length`, `Last-Modified` and `ETag` headers.
+File responses will include appropriate `Content-Length`, `Last-Modified` and `ETag` headers if `file_or_path` was a path.
 
 ```python
 from starlette.responses import FileResponse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # Optionals
-aiofiles
 graphene
 itsdangerous
 jinja2

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
     data_files=[("", ["LICENSE.md"])],
     extras_require={
         "full": [
-            "aiofiles",
             "asyncpg",
             "graphene",
             "itsdangerous",

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -4,8 +4,7 @@ import stat
 import typing
 from email.utils import parsedate
 
-from aiofiles.os import stat as aio_stat
-
+from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import URL, Headers
 from starlette.responses import (
     FileResponse,
@@ -149,7 +148,7 @@ class StaticFiles:
         for directory in self.all_directories:
             full_path = os.path.join(directory, path)
             try:
-                stat_result = await aio_stat(full_path)
+                stat_result = await run_in_threadpool(os.stat, full_path)
                 return (full_path, stat_result)
             except FileNotFoundError:
                 pass
@@ -182,7 +181,7 @@ class StaticFiles:
             return
 
         try:
-            stat_result = await aio_stat(self.directory)
+            stat_result = await run_in_threadpool(os.stat, self.directory)
         except FileNotFoundError:
             raise RuntimeError(
                 f"StaticFiles directory '{self.directory}' does not exist."


### PR DESCRIPTION
This PR removes `aiofiles` as a dependency, handling files directly.

It also adds support for file-like objects in `FileResponse` apart from file paths.

This is related to  https://github.com/encode/starlette/pull/461 and @tomchristie's comment at https://github.com/encode/starlette/pull/457#issuecomment-478965259