### PR TITLE
Send lifespan.startup.failed if exception occurs during startup

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import re
+import traceback
 import typing
 from enum import Enum
 
@@ -469,8 +470,14 @@ class Lifespan(BaseRoute):
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         message = await receive()
         assert message["type"] == "lifespan.startup"
-        await self.startup()
-        await send({"type": "lifespan.startup.complete"})
+        try:
+            await self.startup()
+        except BaseException as exc:
+            msg = traceback.format_exc()
+            await send({"type": "lifespan.startup.failed", "message": msg})
+            raise exc from None
+        else:
+            await send({"type": "lifespan.startup.complete"})
 
         message = await receive()
         assert message["type"] == "lifespan.shutdown"

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -470,15 +470,15 @@ class Lifespan(BaseRoute):
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         message = await receive()
         assert message["type"] == "lifespan.startup"
+
         try:
             await self.startup()
-        except BaseException as exc:
+        except BaseException:
             msg = traceback.format_exc()
             await send({"type": "lifespan.startup.failed", "message": msg})
-            raise exc from None
-        else:
-            await send({"type": "lifespan.startup.complete"})
+            raise
 
+        await send({"type": "lifespan.startup.complete"})
         message = await receive()
         assert message["type"] == "lifespan.shutdown"
         await self.shutdown()

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -463,7 +463,10 @@ class TestClient(requests.Session):
     async def wait_startup(self) -> None:
         await self.receive_queue.put({"type": "lifespan.startup"})
         message = await self.send_queue.get()
-        assert message["type"] in ("lifespan.startup.complete", "lifespan.startup.failed")
+        assert message["type"] in (
+            "lifespan.startup.complete",
+            "lifespan.startup.failed",
+        )
 
     async def wait_shutdown(self) -> None:
         await self.receive_queue.put({"type": "lifespan.shutdown"})

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -465,7 +465,7 @@ class TestClient(requests.Session):
         message = await self.send_queue.get()
         if message is None:
             self.task.result()
-        assert message["type"] == "lifespan.startup.complete"
+        assert message["type"] in ("lifespan.startup.complete", "lifespan.startup.failed")
 
     async def wait_shutdown(self) -> None:
         await self.receive_queue.put({"type": "lifespan.shutdown"})

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -463,8 +463,6 @@ class TestClient(requests.Session):
     async def wait_startup(self) -> None:
         await self.receive_queue.put({"type": "lifespan.startup"})
         message = await self.send_queue.get()
-        if message is None:
-            self.task.result()
         assert message["type"] in ("lifespan.startup.complete", "lifespan.startup.failed")
 
     async def wait_shutdown(self) -> None:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -467,6 +467,10 @@ class TestClient(requests.Session):
             "lifespan.startup.complete",
             "lifespan.startup.failed",
         )
+        if message["type"] == "lifespan.startup.failed":
+            message = await self.send_queue.get()
+            if message is None:
+                self.task.result()
 
     async def wait_shutdown(self) -> None:
         await self.receive_queue.put({"type": "lifespan.shutdown"})

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import pytest
 
 from starlette.applications import Starlette


### PR DESCRIPTION
Fixes #486.

Note: requires https://github.com/encode/uvicorn/pull/350 to work. With the current state of uvicorn (0.7.0), the `ASGI 'lifespan' protocol appears unsupported.` message is still displayed and startup does not abort.

With:

```python
# app.py
from starlette.applications import Starlette

app = Starlette()

@app.on_event("startup")
async def startup():
    raise ValueError("Nope!")

```

`$ uvicorn app:app` results in:

```
INFO: Started server process [71364]
INFO: Waiting for application startup.
ERROR: Traceback (most recent call last):
  File "./starlette/routing.py", line 474, in __call__
    await self.startup()
  File "./starlette/routing.py", line 459, in startup
    await handler()
  File "./app.py", line 8, in startup
    raise ValueError("Nope")
ValueError: Nope

ERROR: Application startup failed. Exiting
```

i.e. the error traceback is logged and startup aborts :tada:.