### PR TITLE
Route: inspect signature for `func(request) -> response`

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -149,8 +149,9 @@ class Route(BaseRoute):
         self.name = get_name(endpoint) if name is None else name
         self.include_in_schema = include_in_schema
 
-        if inspect.isfunction(endpoint) or inspect.ismethod(endpoint):
-            # Endpoint is function or method. Treat it as `func(request) -> response`.
+        if (inspect.isfunction(endpoint) or inspect.ismethod(endpoint)) and len(
+            inspect.signature(endpoint).parameters
+        ) == 1:
             self.app = request_response(endpoint)
             if methods is None:
                 methods = ["GET"]


### PR DESCRIPTION
Without this trying to add a route for an app created via the following
would be treated wrongly:

    from channels.http import AsgiHandler
    from asgiref.compatibility import double_to_single_callable

    application = double_to_single_callable(AsgiHandler)

`double_to_single_callable` returns a function:
https://github.com/django/asgiref/blob/e31a26463d002399b3301c92c570de9c9f4a9d1d/asgiref/compatibility.py#L27-L36

Not really sure what I am doing here, and if maybe even `is_double_callable` should/could be used?!

I guess this reflects https://github.com/django/asgiref/commit/fae4ef0#diff-89559d52e4cc62e36fe3d457cea26194L43 somehow.
/cc @andrewgodwin