### PR TITLE
#493 and #495 cache body content

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -139,8 +139,8 @@ class Request(HTTPConnection):
         return self._receive
 
     async def stream(self) -> typing.AsyncGenerator[bytes, None]:
-        if hasattr(self, "_body"):
-            yield self._body
+        if "body" in self._scope:
+            yield self._scope["body"]
             yield b""
             return
 
@@ -162,12 +162,12 @@ class Request(HTTPConnection):
         yield b""
 
     async def body(self) -> bytes:
-        if not hasattr(self, "_body"):
+        if not "body" in self._scope:
             body = b""
             async for chunk in self.stream():
                 body += chunk
-            self._body = body
-        return self._body
+            self._scope["body"] = body
+        return self._scope["body"]
 
     async def json(self) -> typing.Any:
         if not hasattr(self, "_json"):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -160,7 +160,7 @@ def test_request_body_twice():
         request = Request(scope, receive)
         body = await request.body()
         new_request = Request(scope, receive)
-        new_body = await request.body()
+        new_body = await new_request.body()
         response = JSONResponse(
             {"body_one": body.decode(), "body_two": new_body.decode()}
         )

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -155,6 +155,23 @@ def test_request_stream_then_body():
     assert response.json() == {"body": "<stream consumed>", "stream": "abc"}
 
 
+def test_request_body_twice():
+    async def app(scope, receive, send):
+        request = Request(scope, receive)
+        body = await request.body()
+        new_request = Request(scope, receive)
+        new_body = await request.body()
+        response = JSONResponse(
+            {"body_one": body.decode(), "body_two": new_body.decode()}
+        )
+        await response(scope, receive, send)
+
+    client = TestClient(app)
+
+    response = client.post("/", data="abc")
+    assert response.json() == {"body_one": "abc", "body_two": "abc"}
+
+
 def test_request_json():
     async def app(scope, receive, send):
         request = Request(scope, receive)


### PR DESCRIPTION
Hi dear developers, not sure if it is 100% compliant with your code base, but I'll be more than welcome to refactor it if not. This is one of the tests that I did locally in order to be able to consume the Request.Body more than one time when recreating a Request object from the Scope, this fix is caching the body content inside the scope rather than a local variable. 