### PR TITLE
TestClient: do not throw the same exception multiple times

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -252,6 +252,7 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
         try:
             loop.run_until_complete(app(scope, receive, send))
         except BaseException as exc:
+            assert self.handled_server_exception is None
             self.handled_server_exception = exc
             if self.raise_server_exceptions:
                 raise exc from None

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -227,6 +227,8 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
                 template = message["template"]
                 context = message["context"]
 
+        self.handled_server_exception = None
+
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -134,6 +134,10 @@ def test_error_with_middleware_and_testclient_exit(raise_server_exceptions):
     async def http_middleware(request, call_next):
         return await call_next(request)
 
+    @app.middleware("http")
+    async def second_middleware(request, call_next):
+        return await call_next(request)
+
     if raise_server_exceptions:
 
         @app.route("/error")

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -117,7 +117,9 @@ def test_websocket_blocking_receive():
 
 @pytest.mark.parametrize("use_middleware", (0, 1, 2))
 @pytest.mark.parametrize("raise_server_exceptions", (True, False))
-def test_error_with_middleware_and_testclient_exit(use_middleware, raise_server_exceptions):
+def test_error_with_middleware_and_testclient_exit(
+    use_middleware, raise_server_exceptions
+):
     """TestClient's __exit__ should not raise the exception again."""
     app = Starlette()
 
@@ -132,11 +134,13 @@ def test_error_with_middleware_and_testclient_exit(use_middleware, raise_server_
         events.append("shutdown")
 
     if use_middleware:
+
         @app.middleware("http")
         async def http_middleware(request, call_next):
             return await call_next(request)
 
         if use_middleware == 2:
+
             @app.middleware("http")
             async def second_middleware(request, call_next):
                 return await call_next(request)

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -115,8 +115,9 @@ def test_websocket_blocking_receive():
         assert data == {"message": "test"}
 
 
+@pytest.mark.parametrize("use_middleware", (0, 1, 2))
 @pytest.mark.parametrize("raise_server_exceptions", (True, False))
-def test_error_with_middleware_and_testclient_exit(raise_server_exceptions):
+def test_error_with_middleware_and_testclient_exit(use_middleware, raise_server_exceptions):
     """TestClient's __exit__ should not raise the exception again."""
     app = Starlette()
 
@@ -130,13 +131,15 @@ def test_error_with_middleware_and_testclient_exit(raise_server_exceptions):
     async def shutdown():
         events.append("shutdown")
 
-    @app.middleware("http")
-    async def http_middleware(request, call_next):
-        return await call_next(request)
+    if use_middleware:
+        @app.middleware("http")
+        async def http_middleware(request, call_next):
+            return await call_next(request)
 
-    @app.middleware("http")
-    async def second_middleware(request, call_next):
-        return await call_next(request)
+        if use_middleware == 2:
+            @app.middleware("http")
+            async def second_middleware(request, call_next):
+                return await call_next(request)
 
     if raise_server_exceptions:
 


### PR DESCRIPTION
Without this patch it would throw the same exception again during shutdown
(when exiting the context manager).

This leads to pytest reporting it twice (during "call" as failure, and
as error for "teardown").