### PR TITLE
Add custom headers to HTTPException

### DIFF
--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -9,11 +9,16 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 class HTTPException(Exception):
-    def __init__(self, status_code: int, detail: str = None) -> None:
+    def __init__(
+        self, status_code: int, detail: str = None, headers: dict = None
+    ) -> None:
         if detail is None:
             detail = http.HTTPStatus(status_code).phrase
+        if headers is None:
+            headers = {}
         self.status_code = status_code
         self.detail = detail
+        self.headers = headers
 
 
 class ExceptionMiddleware:
@@ -85,5 +90,7 @@ class ExceptionMiddleware:
 
     def http_exception(self, request: Request, exc: HTTPException) -> Response:
         if exc.status_code in {204, 304}:
-            return Response(b"", status_code=exc.status_code)
-        return PlainTextResponse(exc.detail, status_code=exc.status_code)
+            return Response(b"", status_code=exc.status_code, headers=exc.headers)
+        return PlainTextResponse(
+            exc.detail, status_code=exc.status_code, headers=exc.headers
+        )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -18,6 +18,10 @@ def not_modified(request):
     raise HTTPException(status_code=304)
 
 
+def unauthorized(request):
+    raise HTTPException(status_code=401, headers={"WWW-Authenticate": "Basic"})
+
+
 class HandledExcAfterResponse:
     async def __call__(self, scope, receive, send):
         response = PlainTextResponse("OK", status_code=200)
@@ -30,6 +34,7 @@ router = Router(
         Route("/runtime_error", endpoint=raise_runtime_error),
         Route("/not_acceptable", endpoint=not_acceptable),
         Route("/not_modified", endpoint=not_modified),
+        Route("/unauthorized", endpoint=unauthorized),
         Route("/handled_exc_after_response", endpoint=HandledExcAfterResponse()),
         WebSocketRoute("/runtime_error", endpoint=raise_runtime_error),
     ]
@@ -50,6 +55,13 @@ def test_not_modified():
     response = client.get("/not_modified")
     assert response.status_code == 304
     assert response.text == ""
+
+
+def test_unauthorized():
+    response = client.get("/unauthorized")
+    assert response.status_code == 401
+    assert response.text == "Unauthorized"
+    assert response.headers["WWW-Authenticate"] == "Basic"
 
 
 def test_websockets_should_raise():


### PR DESCRIPTION
Hi there,

Dealing with HTTP errors sometimes requires setting custom headers in the response. Ideally these should be defined when raising the `HTTPException`, which is what this PR proposes to allow.

FYI, FastAPI uses a custom `HTTPException` that adds just this: https://github.com/tiangolo/fastapi/blob/master/fastapi/exceptions.py