### PR TITLE
docs: Add missing import

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -75,6 +75,7 @@ make sure to setup Graphene's AsyncioExecutor using the `executor` argument.
 ```python
 from graphql.execution.executors.asyncio import AsyncioExecutor
 from starlette.applications import Starlette
+from starlette.graphql import GraphQLApp
 import graphene
 
 


### PR DESCRIPTION
The first example on the GraphQL page has complete imports. Then a number of examples without imports follows. This last example is complete, with the exception of this one missing import.