### PR TITLE
CORS: preflight_response: cookie is not used here

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -98,7 +98,6 @@ class CORSMiddleware:
         requested_origin = request_headers["origin"]
         requested_method = request_headers["access-control-request-method"]
         requested_headers = request_headers.get("access-control-request-headers")
-        requested_cookie = "cookie" in request_headers
 
         headers = dict(self.preflight_headers)
         failures = []


### PR DESCRIPTION
Ref: https://github.com/encode/starlette/issues/510#issuecomment-491836700

It gets only called for "OPTIONS", but strictly speaking we should maybe check that there is no cookie before?!  https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests