### PR TITLE
Add WebSocketException and support for WS handlers

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -42,6 +42,14 @@ async def http_exception(request, exc):
     return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
 ```
 
+You might also want to override how `WebSocketException` is handled:
+
+```python
+@app.exception_handler(WebSocketException)
+async def websocket_exception(websocket, exc):
+    await websocket.close(code=1008)
+```
+
 ## Errors and handled exceptions
 
 It is important to differentiate between handled exceptions and errors.
@@ -74,3 +82,11 @@ returning plain-text HTTP responses for any `HTTPException`.
 
 You should only raise `HTTPException` inside routing or endpoints. Middleware
 classes should instead just return appropriate responses directly.
+
+## WebSocketException
+
+You can use the `WebSocketException` class to raise errors inside of WebSocket endpoints.
+
+* `WebSocketException(code=1008)`
+
+You can set any code valid as defined [in the specification](https://tools.ietf.org/html/rfc6455#section-7.4.1).

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -2,10 +2,12 @@ import asyncio
 import http
 import typing
 
+from starlette import status
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from starlette.websockets import WebSocket, WebSocketClose
 
 
 class HTTPException(Exception):
@@ -16,13 +18,31 @@ class HTTPException(Exception):
         self.detail = detail
 
 
+class WebSocketException(Exception):
+    def __init__(self, code: int = status.WS_1008_POLICY_VIOLATION) -> None:
+        """
+        `code` defaults to 1008, from the WebSocket specification:
+
+        > 1008 indicates that an endpoint is terminating the connection
+        > because it has received a message that violates its policy.  This
+        > is a generic status code that can be returned when there is no
+        > other more suitable status code (e.g., 1003 or 1009) or if there
+        > is a need to hide specific details about the policy.
+
+        Set `code` to any value allowed by
+        [the WebSocket specification](https://tools.ietf.org/html/rfc6455#section-7.4.1).
+        """
+        self.code = code
+
+
 class ExceptionMiddleware:
     def __init__(self, app: ASGIApp, debug: bool = False) -> None:
         self.app = app
         self.debug = debug  # TODO: We ought to handle 404 cases if debug is set.
         self._status_handlers = {}  # type: typing.Dict[int, typing.Callable]
         self._exception_handlers = {
-            HTTPException: self.http_exception
+            HTTPException: self.http_exception,
+            WebSocketException: self.websocket_exception,
         }  # type: typing.Dict[typing.Type[Exception], typing.Callable]
 
     def add_exception_handler(
@@ -45,7 +65,7 @@ class ExceptionMiddleware:
         return None
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http":
+        if scope["type"] not in {"http", "websocket"}:
             await self.app(scope, receive, send)
             return
 
@@ -76,14 +96,26 @@ class ExceptionMiddleware:
                 msg = "Caught handled exception, but response already started."
                 raise RuntimeError(msg) from exc
 
-            request = Request(scope, receive=receive)
-            if asyncio.iscoroutinefunction(handler):
-                response = await handler(request, exc)
-            else:
-                response = await run_in_threadpool(handler, request, exc)
-            await response(scope, receive, sender)
+            if scope["type"] == "http":
+                request = Request(scope, receive=receive)
+                if asyncio.iscoroutinefunction(handler):
+                    response = await handler(request, exc)
+                else:
+                    response = await run_in_threadpool(handler, request, exc)
+                await response(scope, receive, sender)
+            elif scope["type"] == "websocket":
+                websocket = WebSocket(scope, receive=receive, send=send)
+                if asyncio.iscoroutinefunction(handler):
+                    await handler(websocket, exc)
+                else:
+                    await run_in_threadpool(handler, websocket, exc)
 
     def http_exception(self, request: Request, exc: HTTPException) -> Response:
         if exc.status_code in {204, 304}:
             return Response(b"", status_code=exc.status_code)
         return PlainTextResponse(exc.detail, status_code=exc.status_code)
+
+    async def websocket_exception(
+        self, websocket: WebSocket, exc: WebSocketException
+    ) -> None:
+        await websocket.close(code=exc.code)

--- a/tests/middleware/test_errors.py
+++ b/tests/middleware/test_errors.py
@@ -3,6 +3,7 @@ import pytest
 from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.responses import JSONResponse, Response
 from starlette.testclient import TestClient
+from starlette.websockets import WebSocket, WebSocketDisconnect
 
 
 def test_handler():
@@ -55,16 +56,12 @@ def test_debug_after_response_sent():
         client.get("/")
 
 
-def test_debug_not_http():
-    """
-    DebugMiddleware should just pass through any non-http messages as-is.
-    """
-
+def test_debug_websocket():
     async def app(scope, receive, send):
         raise RuntimeError("Something went wrong")
 
     app = ServerErrorMiddleware(app)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect):
         client = TestClient(app)
         client.websocket_connect("/")


### PR DESCRIPTION
Add WebSocketException and support for WS handlers.

Currently, if an exception is raised inside of a WebSocket endpoint, it bubbles, until a `500` HTTP error is thrown.

This PR implements support for raising and handling exceptions inside of WebSocket endpoints.

It has default handlers using WebSocket codes from the specification.

It includes a generic `WebSocketException` comparable to `HTTPException`.

This would allow raising inside WebSocket endpoints, sub-functions, etc. And handling those errors in a custom manner. It might be used to, e.g. log WebSocket errors, customize a WebSocket closing code, etc.

Related issues: https://github.com/encode/starlette/issues/483, https://github.com/encode/starlette/issues/494

---

In FastAPI, this would allow using dependencies that can raise early in WebSocket routes (e.g. if the correct headers are not present) and other scenarios.