### PR TITLE
Add password hashing classes.

### DIFF
--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -19,9 +19,9 @@ that the hashed password needs to be updated (eg. algorithm has changed).
 
 ```python
 from starlette.passwords import (
-    PlainPasswordHasher, PBKDF2PasswordHasher, PasswordChecker
+    InsecurePasswordHasher, PBKDF2PasswordHasher, PasswordChecker
 )
-hashers = [PlainPasswordHasher(), PBKDF2PasswordHasher()]
+hashers = [InsecurePasswordHasher(), PBKDF2PasswordHasher()]
 checker = PasswordChecker(hashers)
 
 await checker.make('password_to_hash')
@@ -32,7 +32,7 @@ print(checker.requires_update) # True if password needs to be rehashed
 
 ## Included hashers
 
-### PlainPasswordHasher
+### InsecurePasswordHasher
 
 This class does not encode the password and returns it "as is".  
 Warning: this hasher does not offer any security and is provided exclusively 

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -1,5 +1,5 @@
 Starlette includes several password hashing classes that let you
-to make and check passwords.
+create and check passwords.
 
 
 ## PasswordChecker

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -5,7 +5,7 @@ create and check passwords.
 ## PasswordChecker
 
 Among these classes is a special class `PasswordChecker`.
-It is intended to be a common interface to a multiple underlying hashers.
+It is intended to be a common interface to multiple underlying hashers.
 
 `PasswordChecker#check` will iterate over all given hashers asking each to verify
 the given password. If none of them succeeds then it returns `False`.

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -34,7 +34,7 @@ print(checker.requires_update) # True if password needs to be rehashed
 
 ### InsecurePasswordHasher
 
-This class does not encode password and returns it "as is".
+This class does not encode the password and returns it "as is".
 
 ### PBKDF2PasswordHasher
 

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -1,0 +1,70 @@
+Starlette includes several password hashing classes that let you
+to make and check passwords.
+
+
+## PasswordChecker
+
+Among these classes is a special class `PasswordChecker`.
+It is intended to be a common interface to a multiple underlying hashers.
+
+`PasswordChecker#check` will iterate over all given hashes asking each to verify
+the given password. If none of them succeed then returns `False`.
+
+Note, that `PasswordChecker#make` will use only the first item from 
+the `hashers` list to encode a plain password.
+
+This class also provides `requries_update` property which indicates
+that the hashed password needs to be updated (eg. algorithm has changed).
+
+
+```python
+from starlette.passwords import (
+    InsecurePasswordHasher, PBKDF2PasswordHasher, PasswordChecker
+)
+hashers = [InsecurePasswordHasher(), PBKDF2PasswordHasher()]
+checker = PasswordChecker(hashers)
+
+await checker.make('password_to_hash')
+await checker.check('plain_password', 'hashed_password')
+
+print(checker.requires_update) # True if password needs to be rehashed
+```
+
+## Included hashers
+
+### InsecurePasswordHasher
+
+This class does not encode password and returns them "as is".
+
+### PBKDF2PasswordHasher
+
+PBKDF2 password hashing algorithm.
+Does not have any dependencies. 
+
+### BCryptPasswordHasher
+
+Uses bcrypt algorithm as a hashing backend. 
+Requires `bcrypt` library to be installed.
+
+### Argon2PasswordHasher
+
+Uses argon2 algorithm as a hashing backend. 
+Requires `argon2` library to be installed.
+
+
+## Custom password hasher
+
+When you need to make your own password hasher 
+then create a new class and implement `starlette.passwords.PasswordHasher` interface:
+
+```python
+from typing import Any
+from starlette.passwords import PasswordHasher
+
+class MyPasswordHasher(PasswordHasher):
+    async def make(self, password: str, salt: str = None, **kwargs: Any) -> str:
+        ...
+    
+    async def check(self, password: str, encoded: str) -> bool:
+        ...
+```

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -7,8 +7,8 @@ to make and check passwords.
 Among these classes is a special class `PasswordChecker`.
 It is intended to be a common interface to a multiple underlying hashers.
 
-`PasswordChecker#check` will iterate over all given hashes asking each to verify
-the given password. If none of them succeed then returns `False`.
+`PasswordChecker#check` will iterate over all given hashers asking each to verify
+the given password. If none of them succeeds then it returns `False`.
 
 Note, that `PasswordChecker#make` will use only the first item from 
 the `hashers` list to encode a plain password.
@@ -34,7 +34,7 @@ print(checker.requires_update) # True if password needs to be rehashed
 
 ### InsecurePasswordHasher
 
-This class does not encode password and returns them "as is".
+This class does not encode password and returns it "as is".
 
 ### PBKDF2PasswordHasher
 

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -34,7 +34,9 @@ print(checker.requires_update) # True if password needs to be rehashed
 
 ### PlainPasswordHasher
 
-This class does not encode the password and returns it "as is".
+This class does not encode the password and returns it "as is".  
+Warning: this hasher does not offer any security and is provided exclusively 
+for making password operations faster in test suites.
 
 ### PBKDF2PasswordHasher
 

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -54,8 +54,7 @@ Requires `argon2` library to be installed.
 
 ## Custom password hasher
 
-When you need to make your own password hasher 
-then create a new class and implement `starlette.passwords.PasswordHasher` interface:
+You can create your own password hasher by creating a new class and implementing the `starlette.passwords.PasswordHasher` interface:
 
 ```python
 from typing import Any

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -35,7 +35,8 @@ print(checker.requires_update) # True if password needs to be rehashed
 ### PlainPasswordHasher
 
 This class does not encode the password and returns it "as is".  
-Warning: this hasher does not offer any security and is provided exclusively 
+
+> **Warning**: this hasher does not offer any security and is provided exclusively 
 for making password operations faster in test suites.
 
 ### PBKDF2PasswordHasher

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -19,9 +19,9 @@ that the hashed password needs to be updated (eg. algorithm has changed).
 
 ```python
 from starlette.passwords import (
-    InsecurePasswordHasher, PBKDF2PasswordHasher, PasswordChecker
+    PlainPasswordHasher, PBKDF2PasswordHasher, PasswordChecker
 )
-hashers = [InsecurePasswordHasher(), PBKDF2PasswordHasher()]
+hashers = [PlainPasswordHasher(), PBKDF2PasswordHasher()]
 checker = PasswordChecker(hashers)
 
 await checker.make('password_to_hash')
@@ -32,7 +32,7 @@ print(checker.requires_update) # True if password needs to be rehashed
 
 ## Included hashers
 
-### InsecurePasswordHasher
+### PlainPasswordHasher
 
 This class does not encode the password and returns it "as is".
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - Database: 'database.md'
     - GraphQL: 'graphql.md'
     - Authentication: 'authentication.md'
+    - Password Hashing: 'passwords.md'
     - API Schemas: 'schemas.md'
     - Events: 'events.md'
     - Background Tasks: 'background.md'

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ isort
 mypy
 pytest
 pytest-cov
+pytest-asyncio
 
 # Documentation
 mkdocs

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ python-multipart
 pyyaml
 requests
 ujson
+bcrypt
+argon2-cffi
 
 # Testing
 autoflake

--- a/starlette/passwords.py
+++ b/starlette/passwords.py
@@ -1,0 +1,191 @@
+import abc
+import base64
+import binascii
+import hashlib
+import hmac
+import random
+from typing import Any, Callable, Optional, Sequence
+
+from starlette.concurrency import run_in_threadpool
+
+try:
+    import argon2
+except ImportError:  # pragma: nocover
+    argon2 = None
+
+try:
+    import bcrypt
+except ImportError:  # pragma: nocover
+    bcrypt = None
+
+ALNUM_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+
+class PasswordHasher(abc.ABC):
+    algorithm: str = ""
+    rounds: int = 150000
+
+    @abc.abstractmethod
+    async def check(self, password: str, encoded: str) -> bool:
+        raise NotImplementedError()  # pragma: nocover
+
+    @abc.abstractmethod
+    async def make(self, password: str, salt: str = None, **kwargs: Any) -> str:
+        raise NotImplementedError()  # pragma: nocover
+
+    def generate_salt(self, length: int = 8) -> str:
+        if length <= 0:
+            raise ValueError("Salt length must be greater than zero.")
+        randomizer = random.SystemRandom()
+        randomizer.seed()
+        return "".join(randomizer.choice(ALNUM_CHARS) for _ in range(length))
+
+
+class PasswordChecker(PasswordHasher):
+    """
+    Checks password using multiple hashers.
+
+    The first hasher is considered default and used to hash passwords.
+    All the rest are used to check the passed password.
+    """
+
+    @property
+    def requires_update(self) -> bool:
+        if self._requires_update is None:
+            raise ValueError(
+                "Run password check before accessing " "'requires_update' property."
+            )
+        return self._requires_update
+
+    def __init__(self, hashers: Sequence[PasswordHasher]):
+        assert len(hashers) > 0
+        self._hashers = hashers
+        self._requires_update: Optional[bool] = None
+
+    async def check(self, password: str, encoded: str) -> bool:
+        self._requires_update = False
+        algorithm, _ = encoded.split("$", 1)
+
+        for hasher in self._hashers:
+            if hasher.algorithm == algorithm:
+                return await hasher.check(password, encoded)
+
+            # the default hasher is the one at index 0
+            # when it's algorithm is not the one used to hash the password
+            # then the password must be updated
+            self._requires_update = True
+        return False
+
+    async def make(self, password: str, salt: str = None, **kwargs: Any) -> str:
+        return await self._hashers[0].make(password, salt, **kwargs)
+
+
+class BCryptPasswordHasher(PasswordHasher):
+    algorithm: str = "bcrypt_sha256"
+    rounds: int = 12
+    digest: Callable = hashlib.sha256
+
+    def __init__(self) -> None:
+        assert bcrypt, "bcrypt library is not installed."
+
+    async def check(self, password: str, encoded: str) -> bool:
+        algorithm, data = encoded.split("$", 1)
+        assert algorithm == self.algorithm
+        reference = await self.make(password, data)
+        return hmac.compare_digest(encoded.encode(), reference.encode())
+
+    async def make(
+        self, password: str, salt: str = None, *args: Any, **kwargs: Any
+    ) -> str:
+        salt = salt or self.generate_salt()
+
+        if self.digest is not None:
+            password = binascii.hexlify(
+                self.digest(password.encode()).digest()
+            ).decode()
+
+        hash_ = await run_in_threadpool(bcrypt.hashpw, password.encode(), salt.encode())
+        return "%s$%s" % (self.algorithm, hash_.decode())
+
+    def generate_salt(self, length: int = 8) -> str:
+        return bcrypt.gensalt(self.rounds).decode()
+
+
+class Argon2PasswordHasher(PasswordHasher):
+    algorithm: str = "argon2"
+    time_cost: int = 2
+    memory_cost: int = 512
+    parallelism: int = 2
+
+    def __init__(self) -> None:
+        assert argon2, "argon2 library is not installed."
+
+    async def check(self, password: str, encoded: str) -> bool:
+        algorithm, data = encoded.split("$", 1)
+        assert algorithm == self.algorithm
+
+        try:
+            return argon2.low_level.verify_secret(
+                ("$" + data).encode(), password.encode(), type=argon2.low_level.Type.I
+            )
+        except argon2.exceptions.VerificationError:
+            return False
+
+    async def make(self, password: str, salt: str = None, **kwargs: Any) -> str:
+        salt = salt or self.generate_salt()
+        data = argon2.low_level.hash_secret(
+            password.encode(),
+            salt.encode(),
+            time_cost=self.time_cost,
+            memory_cost=self.memory_cost,
+            parallelism=self.parallelism,
+            hash_len=argon2.DEFAULT_HASH_LENGTH,
+            type=argon2.low_level.Type.I,
+        ).decode()
+        return self.algorithm + data
+
+
+class PBKDF2PasswordHasher(PasswordHasher):
+    """
+    PBKDF2 password hashing algorithm.
+
+    The result is a 64 byte binary string.
+    """
+
+    algorithm: str = "pbkdf2_sha256"
+    rounds: int = 150000
+    digest: Callable = hashlib.sha256
+
+    async def check(self, password: str, encoded: str) -> bool:
+        algorithm, rounds, salt, hash_ = encoded.split("$", 3)
+        assert algorithm == self.algorithm
+        reference = await self.make(password, salt, rounds=int(rounds))
+        return hmac.compare_digest(encoded.encode(), reference.encode())
+
+    async def make(
+        self, password: str, salt: str = None, rounds: int = None, **kwargs: Any
+    ) -> str:
+        rounds = rounds or self.rounds
+        salt = salt or self.generate_salt()
+        hash_ = await run_in_threadpool(
+            hashlib.pbkdf2_hmac,
+            self.digest().name,
+            password.encode(),
+            salt.encode(),
+            int(rounds),
+            **kwargs,
+        )
+        hash_ = base64.b64encode(hash_).decode().strip()
+        return "%s$%d$%s$%s" % (self.algorithm, self.rounds, salt, hash_)
+
+
+class InsecurePasswordHasher(PasswordHasher):
+    algorithm: str = "plain"
+
+    async def check(self, password: str, encoded: str) -> bool:
+        algorithm, data = encoded.split("$", 1)
+        assert algorithm == self.algorithm
+        return password == data
+
+    async def make(self, password: str, *args: Any, **kwargs: Any) -> str:
+        return "%s$%s" % (self.algorithm, password)

--- a/starlette/passwords.py
+++ b/starlette/passwords.py
@@ -178,7 +178,7 @@ class PBKDF2PasswordHasher(PasswordHasher):
         return "%s$%d$%s$%s" % (self.algorithm, self.rounds, salt, hash_)
 
 
-class PlainPasswordHasher(PasswordHasher):
+class InsecurePasswordHasher(PasswordHasher):
     algorithm: str = "plain"
 
     async def check(self, password: str, encoded: str) -> bool:

--- a/starlette/passwords.py
+++ b/starlette/passwords.py
@@ -23,7 +23,6 @@ ALNUM_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 class PasswordHasher(abc.ABC):
     algorithm: str = ""
-    rounds: int = 150000
 
     @abc.abstractmethod
     async def check(self, password: str, encoded: str) -> bool:
@@ -179,7 +178,7 @@ class PBKDF2PasswordHasher(PasswordHasher):
         return "%s$%d$%s$%s" % (self.algorithm, self.rounds, salt, hash_)
 
 
-class InsecurePasswordHasher(PasswordHasher):
+class PlainPasswordHasher(PasswordHasher):
     algorithm: str = "plain"
 
     async def check(self, password: str, encoded: str) -> bool:

--- a/tests/test_passwords.py
+++ b/tests/test_passwords.py
@@ -1,0 +1,145 @@
+from unittest import mock
+
+import pytest
+
+from starlette.passwords import (
+    Argon2PasswordHasher,
+    BCryptPasswordHasher,
+    InsecurePasswordHasher,
+    PasswordChecker,
+    PasswordHasher,
+    PBKDF2PasswordHasher,
+)
+
+try:
+    import bcrypt
+except ImportError:  # pragma: nocover
+    bcrypt = None
+
+try:
+    import argon2
+except ImportError:  # pragma: nocover
+    argon2 = None
+
+
+def test_generic_password_hasher():
+    class _Child(PasswordHasher):
+        async def check(self, password: str, encoded: str) -> bool:
+            pass  # pragma: nocover
+
+        async def make(self, password: str, salt: str = None, **kwargs) -> str:
+            pass  # pragma: nocover
+
+    hasher = _Child()
+    assert len(hasher.generate_salt(4)) == 4
+    assert len(hasher.generate_salt(8)) == 8
+
+    with pytest.raises(ValueError):
+        hasher.generate_salt(0)
+
+    with pytest.raises(ValueError):
+        hasher.generate_salt(-1)
+
+
+@pytest.mark.asyncio
+async def test_insecure_hasher():
+    password = "pàsšўoЯd"
+    invalid_password = "pàsšўord"
+    hasher = InsecurePasswordHasher()
+    hashed = await hasher.make(password)
+    assert hasher.algorithm in hashed
+    assert await hasher.check(password, hashed)
+    assert not await hasher.check(invalid_password, hashed)
+
+
+@pytest.mark.asyncio
+async def test_pbkdf2_hasher():
+    salt = "salt"
+    password = "pàsšўoЯd"
+    invalid_password = "pàsšўord"
+    rounds = 150000
+    hasher = PBKDF2PasswordHasher()
+    ref = "pbkdf2_sha256$150000$salt$sLxQyeJXlgmnc/aDxFypP9iHjIYKl9RBxx85G3gn7ZA="
+    hashed = await hasher.make(password, salt, rounds)
+    assert hashed == ref
+    assert hasher.algorithm in hashed
+    assert str(rounds) in hashed
+    assert salt in hashed
+    assert await hasher.check(password, hashed)
+    assert not await hasher.check(invalid_password, hashed)
+
+
+@pytest.mark.skipif(not bcrypt, reason="bcrypt is not installed")
+@pytest.mark.asyncio
+async def test_bcrypt_hasher():
+    password = "pàsšўoЯd"
+    invalid_password = "pàsšўord"
+    hasher = BCryptPasswordHasher()
+    salt = hasher.generate_salt()
+    hashed = await hasher.make(password, salt)
+    assert hasher.algorithm in hashed
+    assert salt in hashed
+    assert await hasher.check(password, hashed)
+    assert not await hasher.check(invalid_password, hashed)
+
+    with mock.patch("starlette.passwords.bcrypt", None):
+        with pytest.raises(AssertionError):
+            BCryptPasswordHasher()
+
+
+@pytest.mark.skipif(not argon2, reason="argon2 is not installed")
+@pytest.mark.asyncio
+async def test_argon2_hasher():
+    salt = "saltsaltsalt"
+    password = "pàsšўoЯd"
+    invalid_password = "pàsšўord"
+    hasher = Argon2PasswordHasher()
+    hashed = await hasher.make(password, salt)
+    assert hasher.algorithm in hashed
+    assert await hasher.check(password, hashed)
+    assert not await hasher.check(invalid_password, hashed)
+
+    with mock.patch("starlette.passwords.argon2", None):
+        with pytest.raises(AssertionError):
+            Argon2PasswordHasher()
+
+
+class TestPasswordChecker:
+    def test_requires_hashers(self):
+        with pytest.raises(AssertionError):
+            PasswordChecker([])
+
+    @pytest.mark.asyncio
+    async def test_looksup_hashers(self):
+        # this set requires password update
+        hashers = [PBKDF2PasswordHasher(), InsecurePasswordHasher()]
+        hashed = "plain$password"
+        checker = PasswordChecker(hashers)
+        assert await checker.check("password", hashed)
+        assert not await checker.check("invalid_password", hashed)
+        assert checker.requires_update
+
+        # this set does not require the password update
+        # because the default (the first) hasher confirms the password
+        hashed = "plain$password"
+        hashers = [InsecurePasswordHasher(), PBKDF2PasswordHasher()]
+        checker = PasswordChecker(hashers)
+        assert not await checker.check("invalid_password", hashed)
+        assert not checker.requires_update
+
+        # this has to fail as no hashers can verify the password
+        hashed = "unsupported$password"
+        hashers = [InsecurePasswordHasher(), PBKDF2PasswordHasher()]
+        checker = PasswordChecker(hashers)
+        assert not await checker.check("password", hashed)
+
+    def test_requires_update(self):
+        checker = PasswordChecker([InsecurePasswordHasher()])
+        with pytest.raises(ValueError):
+            checker.requires_update
+
+    @pytest.mark.asyncio
+    async def test_make(self):
+        checker = PasswordChecker([InsecurePasswordHasher(), PBKDF2PasswordHasher()])
+        hashed = await checker.make("password")
+        assert hashed == "plain$password"

--- a/tests/test_passwords.py
+++ b/tests/test_passwords.py
@@ -5,10 +5,10 @@ import pytest
 from starlette.passwords import (
     Argon2PasswordHasher,
     BCryptPasswordHasher,
-    InsecurePasswordHasher,
     PasswordChecker,
     PasswordHasher,
     PBKDF2PasswordHasher,
+    PlainPasswordHasher,
 )
 
 try:
@@ -42,10 +42,10 @@ def test_generic_password_hasher():
 
 
 @pytest.mark.asyncio
-async def test_insecure_hasher():
+async def test_plain_hasher():
     password = "pàsšўoЯd"
     invalid_password = "pàsšўord"
-    hasher = InsecurePasswordHasher()
+    hasher = PlainPasswordHasher()
     hashed = await hasher.make(password)
     assert hasher.algorithm in hashed
     assert await hasher.check(password, hashed)
@@ -112,7 +112,7 @@ class TestPasswordChecker:
     @pytest.mark.asyncio
     async def test_looksup_hashers(self):
         # this set requires password update
-        hashers = [PBKDF2PasswordHasher(), InsecurePasswordHasher()]
+        hashers = [PBKDF2PasswordHasher(), PlainPasswordHasher()]
         hashed = "plain$password"
         checker = PasswordChecker(hashers)
         assert await checker.check("password", hashed)
@@ -122,24 +122,24 @@ class TestPasswordChecker:
         # this set does not require the password update
         # because the default (the first) hasher confirms the password
         hashed = "plain$password"
-        hashers = [InsecurePasswordHasher(), PBKDF2PasswordHasher()]
+        hashers = [PlainPasswordHasher(), PBKDF2PasswordHasher()]
         checker = PasswordChecker(hashers)
         assert not await checker.check("invalid_password", hashed)
         assert not checker.requires_update
 
         # this has to fail as no hashers can verify the password
         hashed = "unsupported$password"
-        hashers = [InsecurePasswordHasher(), PBKDF2PasswordHasher()]
+        hashers = [PlainPasswordHasher(), PBKDF2PasswordHasher()]
         checker = PasswordChecker(hashers)
         assert not await checker.check("password", hashed)
 
     def test_requires_update(self):
-        checker = PasswordChecker([InsecurePasswordHasher()])
+        checker = PasswordChecker([PlainPasswordHasher()])
         with pytest.raises(ValueError):
             checker.requires_update
 
     @pytest.mark.asyncio
     async def test_make(self):
-        checker = PasswordChecker([InsecurePasswordHasher(), PBKDF2PasswordHasher()])
+        checker = PasswordChecker([PlainPasswordHasher(), PBKDF2PasswordHasher()])
         hashed = await checker.make("password")
         assert hashed == "plain$password"

--- a/tests/test_passwords.py
+++ b/tests/test_passwords.py
@@ -8,7 +8,7 @@ from starlette.passwords import (
     PasswordChecker,
     PasswordHasher,
     PBKDF2PasswordHasher,
-    PlainPasswordHasher,
+    InsecurePasswordHasher,
 )
 
 try:
@@ -42,10 +42,10 @@ def test_generic_password_hasher():
 
 
 @pytest.mark.asyncio
-async def test_plain_hasher():
+async def test_insecure_hasher():
     password = "pàsšўoЯd"
     invalid_password = "pàsšўord"
-    hasher = PlainPasswordHasher()
+    hasher = InsecurePasswordHasher()
     hashed = await hasher.make(password)
     assert hasher.algorithm in hashed
     assert await hasher.check(password, hashed)
@@ -112,7 +112,7 @@ class TestPasswordChecker:
     @pytest.mark.asyncio
     async def test_looksup_hashers(self):
         # this set requires password update
-        hashers = [PBKDF2PasswordHasher(), PlainPasswordHasher()]
+        hashers = [PBKDF2PasswordHasher(), InsecurePasswordHasher()]
         hashed = "plain$password"
         checker = PasswordChecker(hashers)
         assert await checker.check("password", hashed)
@@ -122,24 +122,24 @@ class TestPasswordChecker:
         # this set does not require the password update
         # because the default (the first) hasher confirms the password
         hashed = "plain$password"
-        hashers = [PlainPasswordHasher(), PBKDF2PasswordHasher()]
+        hashers = [InsecurePasswordHasher(), PBKDF2PasswordHasher()]
         checker = PasswordChecker(hashers)
         assert not await checker.check("invalid_password", hashed)
         assert not checker.requires_update
 
         # this has to fail as no hashers can verify the password
         hashed = "unsupported$password"
-        hashers = [PlainPasswordHasher(), PBKDF2PasswordHasher()]
+        hashers = [InsecurePasswordHasher(), PBKDF2PasswordHasher()]
         checker = PasswordChecker(hashers)
         assert not await checker.check("password", hashed)
 
     def test_requires_update(self):
-        checker = PasswordChecker([PlainPasswordHasher()])
+        checker = PasswordChecker([InsecurePasswordHasher()])
         with pytest.raises(ValueError):
             checker.requires_update
 
     @pytest.mark.asyncio
     async def test_make(self):
-        checker = PasswordChecker([PlainPasswordHasher(), PBKDF2PasswordHasher()])
+        checker = PasswordChecker([InsecurePasswordHasher(), PBKDF2PasswordHasher()])
         hashed = await checker.make("password")
         assert hashed == "plain$password"


### PR DESCRIPTION
This adds password hashers to the framework.

refs #293

Included types: `BCryptPasswordHasher`, `Argon2PasswordHasher`, `PBKDF2PasswordHasher`,
`PlainPasswordHasher`.

Also provides aggregate `PasswordChecker` to manage mutiple password hashers.

## Interface
```python
class PasswordHasher:
    async def check(self, password: str, encoded: str) -> bool: ...

    async def make(self, password: str, salt: str = None, **kwargs) -> str: ...
```

## Example

```python
from starlette.passwords import (
    PlainPasswordHasher, PBKDF2PasswordHasher, PasswordChecker
)
hashers = [PlainPasswordHasher(), PBKDF2PasswordHasher()]
checker = PasswordChecker(hashers)

await checker.make('password_to_hash')
await checker.check('plain_password', 'hashed_password')

print(checker.requires_update) # True if password needs to be rehashed
```


upd:
renamed `InsecurePasswordHasher` to `PlainPasswordHasher`