### PR TITLE
Allow callable functions to be passed into the config's casting

### DIFF
--- a/starlette/config.py
+++ b/starlette/config.py
@@ -54,12 +54,12 @@ class Config:
             self.file_values = self._read_file(env_file)
 
     def __call__(
-        self, key: str, cast: type = None, default: typing.Any = undefined
+        self, key: str, cast: typing.Callable = None, default: typing.Any = undefined,
     ) -> typing.Any:
         return self.get(key, cast, default)
 
     def get(
-        self, key: str, cast: type = None, default: typing.Any = undefined
+        self, key: str, cast: typing.Callable = None, default: typing.Any = undefined,
     ) -> typing.Any:
         if key in self.environ:
             value = self.environ[key]
@@ -84,7 +84,7 @@ class Config:
         return file_values
 
     def _perform_cast(
-        self, key: str, value: typing.Any, cast: type = None
+        self, key: str, value: typing.Any, cast: typing.Callable = None,
     ) -> typing.Any:
         if cast is None or value is None:
             return value


### PR DESCRIPTION
in `starlette/config.py`, the `cast` parameter has an expected type `type`. Below is an example of a simple use case where passing a function would also be useful. 

```python
def cast_to_datetime(date_time_string: str) -> datetime:
    return datetime.strptime(date_time_string, "%Y-%m-%d %H:%M:%S")

config = Config()

time = config("MY_TIME", cast=cast_to_datetime, default="2017-01-12 14:12:06") 

```

This works like a charm, but mypy will complain that `cast` can only be `type`. This contribution is meant to allow callables to be passed into `cast` as well. 