### PR TITLE
Update response() calls in docs for ASGI 3

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ class App:
 
     async def __call__(self, receive, send):
         response = PlainTextResponse('Hello, world!')
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```
 
 Run the `App` application in `example.py`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,20 +97,16 @@ an ASGI toolkit. You can use any of its components independently.
 from starlette.responses import PlainTextResponse
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        response = PlainTextResponse('Hello, world!')
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    response = PlainTextResponse('Hello, world!')
+    await response(scope, receive, send)
 ```
 
-Run the `App` application in `example.py`:
+Run the `app` application in `example.py`:
 
 ```shell
-$ uvicorn example:App
+$ uvicorn example:app
 INFO: Started server process [11509]
 INFO: Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
 ```

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -20,7 +20,7 @@ class App:
         request = Request(self.scope, receive)
         content = '%s %s' % (request.method, request.url.path)
         response = Response(content, media_type='text/plain')
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```
 
 Requests present a mapping interface, so you can use them in the same
@@ -105,7 +105,7 @@ class App:
         async for chunk in request.stream():
             body += chunk
         response = Response(body, media_type='text/plain')
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```
 
 If you access `.stream()` then the byte chunks are provided without storing

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -11,16 +11,12 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        request = Request(self.scope, receive)
-        content = '%s %s' % (request.method, request.url.path)
-        response = Response(content, media_type='text/plain')
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    request = Request(scope, receive)
+    content = '%s %s' % (request.method, request.url.path)
+    response = Response(content, media_type='text/plain')
+    await response(scope, receive, send)
 ```
 
 Requests present a mapping interface, so you can use them in the same
@@ -93,19 +89,15 @@ You can also access the request body as a stream, using the `async for` syntax:
 from starlette.requests import Request
 from starlette.responses import Response
 
-
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        request = Request(self.scope, receive)
-        body = b''
-        async for chunk in request.stream():
-            body += chunk
-        response = Response(body, media_type='text/plain')
-        await response(self.scope, receive, send)
+    
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    request = Request(scope, receive)
+    body = b''
+    async for chunk in request.stream():
+        body += chunk
+    response = Response(body, media_type='text/plain')
+    await response(scope, receive, send)
 ```
 
 If you access `.stream()` then the byte chunks are provided without storing

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -29,7 +29,7 @@ class App:
 
     async def __call__(self, receive, send):
         response = Response('Hello, world!', media_type='text/plain')
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```
 #### Set Cookie
 
@@ -68,7 +68,7 @@ class App:
 
     async def __call__(self, receive, send):
         response = HTMLResponse('<html><body><h1>Hello, world!</h1></body></html>')
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```
 
 ### PlainTextResponse
@@ -86,7 +86,7 @@ class App:
 
     async def __call__(self, receive, send):
         response = PlainTextResponse('Hello, world!')
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```
 
 ### JSONResponse
@@ -104,7 +104,7 @@ class App:
 
     async def __call__(self, receive, send):
         response = JSONResponse({'hello': 'world'})
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```
 
 ### UJSONResponse
@@ -128,7 +128,7 @@ class App:
 
     async def __call__(self, receive, send):
         response = UJSONResponse({'hello': 'world'})
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```
 
 ### RedirectResponse
@@ -149,7 +149,7 @@ class App:
             response = RedirectResponse(url='/')
         else:
             response = PlainTextResponse('Hello, world!')
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```
 
 ### StreamingResponse
@@ -177,7 +177,7 @@ class App:
     async def __call__(self, receive, send):
         generator = slow_numbers(1, 10)
         response = StreamingResponse(generator, media_type='text/html')
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```
 
 Have in mind that <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> objects (like those created by `open()`) are normal iterators. So, you can return them directly in a `StreamingResponse`.
@@ -206,5 +206,5 @@ class App:
 
     async def __call__(self, receive, send):
         response = FileResponse('statics/favicon.ico')
-        await response(receive, send)
+        await response(self.scope, receive, send)
 ```

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -22,14 +22,10 @@ ASGI application instance.
 from starlette.responses import Response
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        response = Response('Hello, world!', media_type='text/plain')
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    response = Response('Hello, world!', media_type='text/plain')
+    await response(scope, receive, send)
 ```
 #### Set Cookie
 
@@ -61,14 +57,10 @@ Takes some text or bytes and returns an HTML response.
 from starlette.responses import HTMLResponse
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        response = HTMLResponse('<html><body><h1>Hello, world!</h1></body></html>')
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    response = HTMLResponse('<html><body><h1>Hello, world!</h1></body></html>')
+    await response(scope, receive, send)
 ```
 
 ### PlainTextResponse
@@ -79,14 +71,10 @@ Takes some text or bytes and returns an plain text response.
 from starlette.responses import PlainTextResponse
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        response = PlainTextResponse('Hello, world!')
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    response = PlainTextResponse('Hello, world!')
+    await response(scope, receive, send)
 ```
 
 ### JSONResponse
@@ -97,14 +85,10 @@ Takes some data and returns an `application/json` encoded response.
 from starlette.responses import JSONResponse
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        response = JSONResponse({'hello': 'world'})
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    response = JSONResponse({'hello': 'world'})
+    await response(scope, receive, send)
 ```
 
 ### UJSONResponse
@@ -121,14 +105,10 @@ you are micro-optimising a particular endpoint.
 from starlette.responses import UJSONResponse
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        response = UJSONResponse({'hello': 'world'})
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    response = UJSONResponse({'hello': 'world'})
+    await response(scope, receive, send)
 ```
 
 ### RedirectResponse
@@ -139,17 +119,13 @@ Returns an HTTP redirect. Uses a 302 status code by default.
 from starlette.responses import PlainTextResponse, RedirectResponse
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        if self.scope['path'] != '/':
-            response = RedirectResponse(url='/')
-        else:
-            response = PlainTextResponse('Hello, world!')
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    if scope['path'] != '/':
+        response = RedirectResponse(url='/')
+    else:
+        response = PlainTextResponse('Hello, world!')
+    await response(scope, receive, send)
 ```
 
 ### StreamingResponse
@@ -169,15 +145,11 @@ async def slow_numbers(minimum, maximum):
     yield('</ul></body></html>')
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        generator = slow_numbers(1, 10)
-        response = StreamingResponse(generator, media_type='text/html')
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    generator = slow_numbers(1, 10)
+    response = StreamingResponse(generator, media_type='text/html')
+    await response(scope, receive, send)
 ```
 
 Have in mind that <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> objects (like those created by `open()`) are normal iterators. So, you can return them directly in a `StreamingResponse`.
@@ -199,12 +171,8 @@ File responses will include appropriate `Content-Length`, `Last-Modified` and `E
 from starlette.responses import FileResponse
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        response = FileResponse('statics/favicon.ico')
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    response = FileResponse('statics/favicon.ico')
+    await response(scope, receive, send)
 ```

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -14,7 +14,7 @@ class App:
 
     async def __call__(self, receive, send):
         response = HTMLResponse('<html><body>Hello, world!</body></html>')
-        await response(receive, send)
+        await response(self.scope, receive, send)
 
 
 def test_app():

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -7,18 +7,14 @@ from starlette.responses import HTMLResponse
 from starlette.testclient import TestClient
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'http'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        response = HTMLResponse('<html><body>Hello, world!</body></html>')
-        await response(self.scope, receive, send)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    response = HTMLResponse('<html><body>Hello, world!</body></html>')
+    await response(scope, receive, send)
 
 
 def test_app():
-    client = TestClient(App)
+    client = TestClient(app)
     response = client.get('/')
     assert response.status_code == 200
 ```
@@ -48,20 +44,16 @@ from starlette.testclient import TestClient
 from starlette.websockets import WebSocket
 
 
-class App:
-    def __init__(self, scope):
-        assert scope['type'] == 'websocket'
-        self.scope = scope
-
-    async def __call__(self, receive, send):
-        websocket = WebSocket(self.scope, receive=receive, send=send)
-        await websocket.accept()
-        await websocket.send_text('Hello, world!')
-        await websocket.close()
+async def app(scope, receive, send):
+    assert scope['type'] == 'websocket'
+    websocket = WebSocket(scope, receive=receive, send=send)
+    await websocket.accept()
+    await websocket.send_text('Hello, world!')
+    await websocket.close()
 
 
 def test_app():
-    client = TestClient(App)
+    client = TestClient(app)
     with client.websocket_connect('/') as websocket:
         data = websocket.receive_text()
         assert data == 'Hello, world!'


### PR DESCRIPTION
I've noticed that code examples in docs are missing `scope` argument in `response()` call, producing `TypeError: __call__() missing 1 required positional argument: 'send'` error when ran.

This PR fixes those.