### PR TITLE
Drop 3.8-dev from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache: pip
 python:
     - "3.6"
     - "3.7"
-    - "3.8-dev"
 
 install:
     - pip install -U -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ isort
 mypy
 pytest
 pytest-cov
-typed-ast==1.3.4
 
 # Documentation
 mkdocs

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ isort
 mypy
 pytest
 pytest-cov
+typed-ast==1.3.4
 
 # Documentation
 mkdocs


### PR DESCRIPTION
We've currently got failing builds on Python 3.8, which appears to be a compilation issue with "typed-ast" (A dependency of mypy)

Going to pin it to a slightly earlier version here to see if it resolves the issue.