### PR TITLE
Allow None for JSONResponse

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -39,10 +39,7 @@ class Response:
         media_type: str = None,
         background: BackgroundTask = None,
     ) -> None:
-        if content is None:
-            self.body = b""
-        else:
-            self.body = self.render(content)
+        self.body = self.render(content)
         self.status_code = status_code
         if media_type is not None:
             self.media_type = media_type
@@ -50,6 +47,8 @@ class Response:
         self.init_headers(headers)
 
     def render(self, content: typing.Any) -> bytes:
+        if content is None:
+            return b""
         if isinstance(content, bytes):
             return content
         return content.encode(self.charset)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -12,6 +12,7 @@ from starlette.responses import (
     Response,
     StreamingResponse,
     UJSONResponse,
+    JSONResponse,
 )
 from starlette.testclient import TestClient
 
@@ -44,6 +45,16 @@ def test_ujson_response():
     client = TestClient(app)
     response = client.get("/")
     assert response.json() == {"hello": "world"}
+
+
+def test_json_none_response():
+    async def app(scope, receive, send):
+        response = JSONResponse(None)
+        await response(scope, receive, send)
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.json() is None
 
 
 def test_redirect_response():


### PR DESCRIPTION
Previously `JSONResponse(None)` rendered empty string, but it should be `'null'` instead.

This change fixes it.