### PR TITLE
Request state and scope

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -29,7 +29,7 @@ class BaseHTTPMiddleware:
         loop = asyncio.get_event_loop()
         queue = asyncio.Queue()  # type: asyncio.Queue
 
-        scope = dict(request)
+        scope = request.scope
         receive = request.receive
         send = queue.put
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -19,8 +19,8 @@ class ClientDisconnect(Exception):
 
 
 class State(object):
-    def __init__(self, state: typing.Dict={}):
-        super(State, self).__setattr__('_state', state)
+    def __init__(self, state: typing.Dict = {}):
+        super(State, self).__setattr__("_state", state)
 
     def __setattr__(self, key: typing.Any, value: typing.Any) -> None:
         self._state[key] = value
@@ -29,10 +29,12 @@ class State(object):
         if key in self._state:
             return self._state[key]
         else:
-            raise AttributeError("'{}' object has no attribute '{}'".format(self.__class__.__name__, key))
+            raise AttributeError(
+                "'{}' object has no attribute '{}'".format(self.__class__.__name__, key)
+            )
 
     def __delattr__(self, key: typing.Any) -> None:
-        if key == '_state':
+        if key == "_state":
             super(State, self).__delattr__(key)
         else:
             del self._state[key]
@@ -49,7 +51,7 @@ class HTTPConnection(Mapping):
         self._scope = scope
 
         # Ensure 'state' has an empty dict if it's not already populated.
-        self._scope.setdefault('state', {})
+        self._scope.setdefault("state", {})
 
     def __getitem__(self, key: str) -> str:
         return self._scope[key]
@@ -127,9 +129,9 @@ class HTTPConnection(Mapping):
 
     @property
     def state(self) -> State:
-        if not hasattr(self, '_state'):
+        if not hasattr(self, "_state"):
             # Create a state instance with a reference to the dict in which it should store info
-            self._state = State(self._scope['state'])
+            self._state = State(self._scope["state"])
         return self._state
 
     def url_for(self, name: str, **path_params: typing.Any) -> str:

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -19,25 +19,19 @@ class ClientDisconnect(Exception):
 
 
 class State(object):
-    def __init__(self, state={}):
-        self._state = state
+    def __init__(self, state: typing.Dict={}):
+        super(State, self).__setattr__('_state', state)
 
-    def __setattr__(self, key, value: typing.Any) -> None:
-        if key == '_state':
-            super(State, self).__setattr__(key, value)
+    def __setattr__(self, key: typing.Any, value: typing.Any) -> None:
+        self._state[key] = value
+
+    def __getattr__(self, key: typing.Any) -> typing.Any:
+        if key in self._state:
+            return self._state[key]
         else:
-            self._state[key] = value
+            raise AttributeError("'{}' object has no attribute '{}'".format(self.__class__.__name__, key))
 
-    def __getattr__(self, key) -> typing.Any:
-        if key == '_state':
-            super(State, self).__getattr__(key)
-        else:
-            if key in self._state:
-                return self._state[key]
-            else:
-                raise AttributeError("'{}' object has no attribute '{}'".format(self.__class__.__name__, key))
-
-    def __delattr__(self, key) -> None:
+    def __delattr__(self, key: typing.Any) -> None:
         if key == '_state':
             super(State, self).__delattr__(key)
         else:

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -19,7 +19,8 @@ class ClientDisconnect(Exception):
 
 
 class State:
-    pass
+    def __init__(self, state_dict={}):
+        self.__dict__.update(state_dict)
 
 
 class HTTPConnection(Mapping):
@@ -31,6 +32,9 @@ class HTTPConnection(Mapping):
     def __init__(self, scope: Scope, receive: Receive = None) -> None:
         assert scope["type"] in ("http", "websocket")
         self._scope = scope
+
+        # Ensure 'state' has an empty dict if it's not already populated.
+        self._scope.setdefault('state', {})
 
     def __getitem__(self, key: str) -> str:
         return self._scope[key]
@@ -108,9 +112,10 @@ class HTTPConnection(Mapping):
 
     @property
     def state(self) -> State:
-        if "state" not in self._scope:
-            self._scope["state"] = State()
-        return self._scope["state"]
+        if not hasattr(self, '_state'):
+            # Create a state instance with a reference to the dict in which it should store info
+            self._state = State(self._scope['state'])
+        return self._state
 
     def url_for(self, name: str, **path_params: typing.Any) -> str:
         router = self._scope["router"]

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -18,9 +18,30 @@ class ClientDisconnect(Exception):
     pass
 
 
-class State:
-    def __init__(self, state_dict={}):
-        self.__dict__.update(state_dict)
+class State(object):
+    def __init__(self, state={}):
+        self._state = state
+
+    def __setattr__(self, key, value: typing.Any) -> None:
+        if key == '_state':
+            super(State, self).__setattr__(key, value)
+        else:
+            self._state[key] = value
+
+    def __getattr__(self, key) -> typing.Any:
+        if key == '_state':
+            super(State, self).__getattr__(key)
+        else:
+            if key in self._state:
+                return self._state[key]
+            else:
+                raise AttributeError("'{}' object has no attribute '{}'".format(self.__class__.__name__, key))
+
+    def __delattr__(self, key) -> None:
+        if key == '_state':
+            super(State, self).__delattr__(key)
+        else:
+            del self._state[key]
 
 
 class HTTPConnection(Mapping):

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -34,9 +34,7 @@ class State(object):
             )
 
     def __delattr__(self, key: typing.Any) -> None:
-        if key == "_state":
-            super(State, self).__delattr__(key)
-        else:
+        if hasattr(self, "_state"):
             del self._state[key]
 
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -34,8 +34,7 @@ class State(object):
             )
 
     def __delattr__(self, key: typing.Any) -> None:
-        if hasattr(self, "_state"):
-            del self._state[key]
+        del self._state[key]
 
 
 class HTTPConnection(Mapping):

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -13,20 +13,16 @@ def test_custom_middleware():
             response.headers["Custom-Header"] = "Example"
             return response
 
-
     app = Starlette()
     app.add_middleware(CustomMiddleware)
-
 
     @app.route("/")
     def homepage(request):
         return PlainTextResponse("Homepage")
 
-
     @app.route("/exc")
     def exc(request):
         raise Exception()
-
 
     @app.route("/no-response")
     class NoResponse:
@@ -38,7 +34,6 @@ def test_custom_middleware():
 
         async def dispatch(self):
             pass
-
 
     @app.websocket_route("/ws")
     async def websocket_endpoint(session):
@@ -84,9 +79,10 @@ def test_middleware_decorator():
     assert response.text == "Homepage"
     assert response.headers["Custom"] == "Example"
 
+
 def test_state_data_across_multiple_middlewares():
-    expected_value1 = 'foo'
-    expected_value2 = 'bar'
+    expected_value1 = "foo"
+    expected_value2 = "bar"
 
     class aMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -6,47 +6,46 @@ from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
 
 
-class CustomMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request, call_next):
-        response = await call_next(request)
-        response.headers["Custom-Header"] = "Example"
-        return response
-
-
-app = Starlette()
-app.add_middleware(CustomMiddleware)
-
-
-@app.route("/")
-def homepage(request):
-    return PlainTextResponse("Homepage")
-
-
-@app.route("/exc")
-def exc(request):
-    raise Exception()
-
-
-@app.route("/no-response")
-class NoResponse:
-    def __init__(self, scope, receive, send):
-        pass
-
-    def __await__(self):
-        return self.dispatch().__await__()
-
-    async def dispatch(self):
-        pass
-
-
-@app.websocket_route("/ws")
-async def websocket_endpoint(session):
-    await session.accept()
-    await session.send_text("Hello, world!")
-    await session.close()
-
-
 def test_custom_middleware():
+    class CustomMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            response = await call_next(request)
+            response.headers["Custom-Header"] = "Example"
+            return response
+
+
+    app = Starlette()
+    app.add_middleware(CustomMiddleware)
+
+
+    @app.route("/")
+    def homepage(request):
+        return PlainTextResponse("Homepage")
+
+
+    @app.route("/exc")
+    def exc(request):
+        raise Exception()
+
+
+    @app.route("/no-response")
+    class NoResponse:
+        def __init__(self, scope, receive, send):
+            pass
+
+        def __await__(self):
+            return self.dispatch().__await__()
+
+        async def dispatch(self):
+            pass
+
+
+    @app.websocket_route("/ws")
+    async def websocket_endpoint(session):
+        await session.accept()
+        await session.send_text("Hello, world!")
+        await session.close()
+
     client = TestClient(app)
     response = client.get("/")
     assert response.headers["Custom-Header"] == "Example"
@@ -84,3 +83,31 @@ def test_middleware_decorator():
     response = client.get("/homepage")
     assert response.text == "Homepage"
     assert response.headers["Custom"] == "Example"
+
+def test_state_data_across_multiple_middlewares():
+    expected_value = 'yes'
+
+    class aMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            request.state.show_me = expected_value
+            response = await call_next(request)
+            return response
+
+    class bMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            response = await call_next(request)
+            response.headers["X-State-Show-Me"] = request.state.show_me
+            return response
+
+    app = Starlette()
+    app.add_middleware(aMiddleware)
+    app.add_middleware(bMiddleware)
+
+    @app.route("/")
+    def homepage(request):
+        return PlainTextResponse("OK")
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.text == "OK"
+    assert response.headers["X-State-Show-Me"] == expected_value

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -93,19 +93,23 @@ def test_state_data_across_multiple_middlewares():
     class aMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):
             request.state.foo = expected_value1
+            print("a", dict(request))
             response = await call_next(request)
             return response
 
     class bMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):
             request.state.bar = expected_value2
+            print("b", dict(request))
             response = await call_next(request)
             response.headers["X-State-Foo"] = request.state.foo
             return response
 
     class cMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):
+            print("c", dict(request))
             response = await call_next(request)
+            print("c", dict(request))
             response.headers["X-State-Bar"] = request.state.bar
             return response
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from starlette.requests import ClientDisconnect, Request
+from starlette.requests import ClientDisconnect, Request, State
 from starlette.responses import JSONResponse, Response
 from starlette.testclient import TestClient
 
@@ -174,8 +174,8 @@ def test_request_scope_interface():
     """
     request = Request({"type": "http", "method": "GET", "path": "/abc/"})
     assert request["method"] == "GET"
-    assert dict(request) == {"type": "http", "method": "GET", "path": "/abc/"}
-    assert len(request) == 3
+    assert dict(request) == {"type": "http", "method": "GET", "path": "/abc/", "state": {}}
+    assert len(request) == 4
 
 
 def test_request_without_setting_receive():
@@ -240,11 +240,23 @@ def test_request_is_disconnected():
     assert disconnected_after_response
 
 
+def test_request_state_object():
+    s = State({'old': 'foo'})
+    s.new = 'value'           # test __setattr__
+    assert s.new == 'value'   # test __getattr__
+
+    delattr(s, 'new')         # test __delattr__
+
+    try:
+        assert s.new == 'value' # will bombed with AttributeError
+    except AttributeError as e:
+        assert str(e) == "'State' object has no attribute 'new'"
+
 def test_request_state():
     async def app(scope, receive, send):
         request = Request(scope, receive)
         request.state.example = 123
-        response = JSONResponse({"state.example": request["state"].example})
+        response = JSONResponse({"state.example": request.state.example})
         await response(scope, receive, send)
 
     client = TestClient(app)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -241,19 +241,24 @@ def test_request_is_disconnected():
 
 
 def test_request_state_object():
-    s = State({'old': 'foo'})
+    scope = {'state': {'old': 'foo'}}
+
+    s = State(scope['state'])
+    assert s._state == scope['state']
+    assert getattr(s, '_state') == scope['state']
+
     s.new = 'value'                   # test __setattr__
     assert s.new == 'value'           # test __getattr__
     assert s._state['new'] == 'value' # test if inner _state dict is updated.
 
-    delattr(s, 'new') # test __delattr__
+    del s.new # test __delattr__
 
     try:
         assert s.new == 'value' # will bombed with AttributeError
     except AttributeError as e:
         assert str(e) == "'State' object has no attribute 'new'"
 
-    delattr(s, '_state') # Deleting _state dict should not bombed.
+    del s._state # Deleting _state dict should not bombed.
 
 
 def test_request_state():

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -242,15 +242,19 @@ def test_request_is_disconnected():
 
 def test_request_state_object():
     s = State({'old': 'foo'})
-    s.new = 'value'           # test __setattr__
-    assert s.new == 'value'   # test __getattr__
+    s.new = 'value'                   # test __setattr__
+    assert s.new == 'value'           # test __getattr__
+    assert s._state['new'] == 'value' # test if inner _state dict is updated.
 
-    delattr(s, 'new')         # test __delattr__
+    delattr(s, 'new') # test __delattr__
 
     try:
         assert s.new == 'value' # will bombed with AttributeError
     except AttributeError as e:
         assert str(e) == "'State' object has no attribute 'new'"
+
+    delattr(s, '_state') # Deleting _state dict should not bombed.
+
 
 def test_request_state():
     async def app(scope, receive, send):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -174,7 +174,12 @@ def test_request_scope_interface():
     """
     request = Request({"type": "http", "method": "GET", "path": "/abc/"})
     assert request["method"] == "GET"
-    assert dict(request) == {"type": "http", "method": "GET", "path": "/abc/", "state": {}}
+    assert dict(request) == {
+        "type": "http",
+        "method": "GET",
+        "path": "/abc/",
+        "state": {},
+    }
     assert len(request) == 4
 
 
@@ -241,24 +246,24 @@ def test_request_is_disconnected():
 
 
 def test_request_state_object():
-    scope = {'state': {'old': 'foo'}}
+    scope = {"state": {"old": "foo"}}
 
-    s = State(scope['state'])
-    assert s._state == scope['state']
-    assert getattr(s, '_state') == scope['state']
+    s = State(scope["state"])
+    assert s._state == scope["state"]
+    assert getattr(s, "_state") == scope["state"]
 
-    s.new = 'value'                   # test __setattr__
-    assert s.new == 'value'           # test __getattr__
-    assert s._state['new'] == 'value' # test if inner _state dict is updated.
+    s.new = "value"  # test __setattr__
+    assert s.new == "value"  # test __getattr__
+    assert s._state["new"] == "value"  # test if inner _state dict is updated.
 
-    del s.new # test __delattr__
+    del s.new  # test __delattr__
 
     try:
-        assert s.new == 'value' # will bombed with AttributeError
+        assert s.new == "value"  # will bombed with AttributeError
     except AttributeError as e:
         assert str(e) == "'State' object has no attribute 'new'"
 
-    del s._state # Deleting _state dict should not bombed.
+    del s._state  # Deleting _state dict should not bombed.
 
 
 def test_request_state():

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -252,18 +252,16 @@ def test_request_state_object():
     assert s._state == scope["state"]
     assert getattr(s, "_state") == scope["state"]
 
-    s.new = "value"  # test __setattr__
-    assert s.new == "value"  # test __getattr__
+    s.new = "value"
+    assert s.new == "value"
     assert s._state["new"] == "value"  # test if inner _state dict is updated.
 
-    del s.new  # test __delattr__
+    del s.new
 
     try:
         assert s.new == "value"  # will bombed with AttributeError
     except AttributeError as e:
         assert str(e) == "'State' object has no attribute 'new'"
-
-    del s._state  # Deleting _state dict should not bombed.
 
 
 def test_request_state():

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -174,13 +174,8 @@ def test_request_scope_interface():
     """
     request = Request({"type": "http", "method": "GET", "path": "/abc/"})
     assert request["method"] == "GET"
-    assert dict(request) == {
-        "type": "http",
-        "method": "GET",
-        "path": "/abc/",
-        "state": {},
-    }
-    assert len(request) == 4
+    assert dict(request) == {"type": "http", "method": "GET", "path": "/abc/"}
+    assert len(request) == 3
 
 
 def test_request_without_setting_receive():
@@ -249,19 +244,14 @@ def test_request_state_object():
     scope = {"state": {"old": "foo"}}
 
     s = State(scope["state"])
-    assert s._state == scope["state"]
-    assert getattr(s, "_state") == scope["state"]
 
     s.new = "value"
     assert s.new == "value"
-    assert s._state["new"] == "value"  # test if inner _state dict is updated.
 
     del s.new
 
-    try:
-        assert s.new == "value"  # will bombed with AttributeError
-    except AttributeError as e:
-        assert str(e) == "'State' object has no attribute 'new'"
+    with pytest.raises(AttributeError):
+        s.new
 
 
 def test_request_state():

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -8,11 +8,11 @@ from starlette.background import BackgroundTask
 from starlette.requests import Request
 from starlette.responses import (
     FileResponse,
+    JSONResponse,
     RedirectResponse,
     Response,
     StreamingResponse,
     UJSONResponse,
-    JSONResponse,
 )
 from starlette.testclient import TestClient
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -281,10 +281,5 @@ def test_websocket_scope_interface():
         send=mock_send,
     )
     assert websocket["type"] == "websocket"
-    assert dict(websocket) == {
-        "type": "websocket",
-        "path": "/abc/",
-        "headers": [],
-        "state": {},
-    }
-    assert len(websocket) == 4
+    assert dict(websocket) == {"type": "websocket", "path": "/abc/", "headers": []}
+    assert len(websocket) == 3

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -281,5 +281,5 @@ def test_websocket_scope_interface():
         send=mock_send,
     )
     assert websocket["type"] == "websocket"
-    assert dict(websocket) == {"type": "websocket", "path": "/abc/", "headers": []}
-    assert len(websocket) == 3
+    assert dict(websocket) == {"type": "websocket", "path": "/abc/", "headers": [], 'state': {}}
+    assert len(websocket) == 4

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -281,5 +281,10 @@ def test_websocket_scope_interface():
         send=mock_send,
     )
     assert websocket["type"] == "websocket"
-    assert dict(websocket) == {"type": "websocket", "path": "/abc/", "headers": [], 'state': {}}
+    assert dict(websocket) == {
+        "type": "websocket",
+        "path": "/abc/",
+        "headers": [],
+        "state": {},
+    }
     assert len(websocket) == 4


### PR DESCRIPTION
Follow up to #552

Adds `request.scope` and `request.state`.
Middleware now passes scope in-place.

Closes #545 
Closes #551
Closes #552

At a later point we'll also want to start moving towards deprecating the request-as-dict interface, in favor of `request.scope`.