### PR TITLE
Docs: fix WebSocket example

### DIFF
--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -10,7 +10,7 @@ Signature: `WebSocket(scope, receive=None, send=None)`
 from starlette.websockets import WebSocket
 
 
-async def app(self, scope, receive, send):
+async def app(scope, receive, send):
     websocket = WebSocket(scope=scope, receive=receive, send=send)
     await websocket.accept()
     await websocket.send_text('Hello, world!')


### PR DESCRIPTION
This example was updated from method to function here: https://github.com/encode/starlette/commit/9e962e79f24d3b09d5e832ad0a4bbf3e5ec917e1

Right now it raises:
```
TypeError: app() missing 1 required positional argument: 'send'
```