### PR TITLE
Make 307 the default redirect status code

### DIFF
--- a/starlette/middleware/httpsredirect.py
+++ b/starlette/middleware/httpsredirect.py
@@ -13,7 +13,7 @@ class HTTPSRedirectMiddleware:
             redirect_scheme = {"http": "https", "ws": "wss"}[url.scheme]
             netloc = url.hostname if url.port in (80, 443) else url.netloc
             url = url.replace(scheme=redirect_scheme, netloc=netloc)
-            response = RedirectResponse(url, status_code=301)
+            response = RedirectResponse(url, status_code=308)
             await response(scope, receive, send)
         else:
             await self.app(scope, receive, send)

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -161,7 +161,7 @@ class UJSONResponse(JSONResponse):
 
 class RedirectResponse(Response):
     def __init__(
-        self, url: typing.Union[str, URL], status_code: int = 302, headers: dict = None
+        self, url: typing.Union[str, URL], status_code: int = 307, headers: dict = None
     ) -> None:
         super().__init__(content=b"", status_code=status_code, headers=headers)
         self.headers["location"] = quote_plus(str(url), safe=":/%#?&=@[]!$&'()*+,;")

--- a/tests/middleware/test_https_redirect.py
+++ b/tests/middleware/test_https_redirect.py
@@ -19,20 +19,20 @@ def test_https_redirect_middleware():
 
     client = TestClient(app)
     response = client.get("/", allow_redirects=False)
-    assert response.status_code == 301
+    assert response.status_code == 308
     assert response.headers["location"] == "https://testserver/"
 
     client = TestClient(app, base_url="http://testserver:80")
     response = client.get("/", allow_redirects=False)
-    assert response.status_code == 301
+    assert response.status_code == 308
     assert response.headers["location"] == "https://testserver/"
 
     client = TestClient(app, base_url="http://testserver:443")
     response = client.get("/", allow_redirects=False)
-    assert response.status_code == 301
+    assert response.status_code == 308
     assert response.headers["location"] == "https://testserver/"
 
     client = TestClient(app, base_url="http://testserver:123")
     response = client.get("/", allow_redirects=False)
-    assert response.status_code == 301
+    assert response.status_code == 308
     assert response.headers["location"] == "https://testserver:123/"


### PR DESCRIPTION
:recycle: Make 307 the default redirect status code respecting HTTP method, and use 308 for HTTPS redirects (equivalently for 301).

This should fix #464.

---

I'm leaving `307` as the default, which is the equivalent of the current default `302`.

And I'm setting explicit `308` in the places where a `301` was used (HTTPS redirect middleware).

This also means that when using `redirect_slashes` it would use a `307`, as the equivalent of the currently used `302`. Although the discussion in that issue talks about only `308`, not `307`.