### PR TITLE
handle kwargs if args is None

### DIFF
--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -42,8 +42,8 @@ def requires(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> None:
                 websocket = kwargs.get("websocket")
-                if websocket == None:
-                    websocket =  args[idx]
+                if websocket is None:
+                    websocket = args[idx]
 
                 assert isinstance(websocket, WebSocket)
 
@@ -61,8 +61,8 @@ def requires(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> Response:
                 request = kwargs.get("request")
-                if request == None:
-                    request =  args[idx]
+                if request is None:
+                    request = args[idx]
 
                 assert isinstance(request, Request)
 
@@ -79,9 +79,8 @@ def requires(
             @functools.wraps(func)
             def sync_wrapper(*args: typing.Any, **kwargs: typing.Any) -> Response:
                 request = kwargs.get("request")
-                if request == None:
-                    request =  args[idx]
-                    
+                if request is None:
+                    request = args[idx]
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):

--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -41,7 +41,10 @@ def requires(
             async def websocket_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> None:
-                websocket = kwargs.get("websocket", args[idx])
+                websocket = kwargs.get("websocket")
+                if websocket == None:
+                    websocket =  args[idx]
+
                 assert isinstance(websocket, WebSocket)
 
                 if not has_required_scope(websocket, scopes_list):
@@ -57,7 +60,10 @@ def requires(
             async def async_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> Response:
-                request = kwargs.get("request", args[idx])
+                request = kwargs.get("request")
+                if request == None:
+                    request =  args[idx]
+
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):
@@ -72,7 +78,10 @@ def requires(
             # Handle sync request/response functions.
             @functools.wraps(func)
             def sync_wrapper(*args: typing.Any, **kwargs: typing.Any) -> Response:
-                request = kwargs.get("request", args[idx])
+                request = kwargs.get("request")
+                if request == None:
+                    request =  args[idx]
+                    
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):


### PR DESCRIPTION
Make it possible to use starlette authentication decorators with fastapi

When using fastap (which is build on top of starlette) request is in kwargs and args is None when using the @ requires decorator. However args[0] is evaluated when the kwargs.get() is invoked and this results in a IndexError: tuple index out of range. 
Changing the evaluation of kwargs and args