### PR TITLE
Tweak exception debug HTML

### DIFF
--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -101,7 +101,7 @@ FRAME_TEMPLATE = """
     <p class="frame-filename"><span class="debug-filename frame-line">File {frame_filename}</span>,
     line <i>{frame_lineno}</i>,
     in <b>{frame_name}</b>
-    <span class="collapse-btn" data-frame-id="{frame_filename}-{frame_lineno}" onclick="collapse(this)">&#8210;</span>
+    <span class="collapse-btn" data-frame-id="{frame_filename}-{frame_lineno}" onclick="collapse(this)">{collapse_button}</span>
     </p>
     <div id="{frame_filename}-{frame_lineno}" class="source-code {collapsed}">{code_context}</div>
 </div>
@@ -199,7 +199,8 @@ class ServerErrorMiddleware:
             "frame_lineno": frame.lineno,
             "frame_name": frame.function,
             "code_context": code_context,
-            "collapsed": "collapsed" if is_collapsed else ""
+            "collapsed": "collapsed" if is_collapsed else "",
+            "collapse_button": "+" if is_collapsed else "&#8210;",
         }
         return FRAME_TEMPLATE.format(**values)
 

--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -188,7 +188,9 @@ class ServerErrorMiddleware:
             return LINE.format(**values)
         return CENTER_LINE.format(**values)
 
-    def generate_frame_html(self, frame: inspect.FrameInfo, center_lineno: int, is_collapsed: bool) -> str:
+    def generate_frame_html(
+        self, frame: inspect.FrameInfo, center_lineno: int, is_collapsed: bool
+    ) -> str:
         code_context = "".join(
             self.format_line(context_position, line, frame.lineno, center_lineno)
             for context_position, line in enumerate(frame.code_context)


### PR DESCRIPTION
* Expand first frame, collapse others.
* Use fixed-width font for source code blocks.

![Screenshot 2019-07-09 at 14 48 30](https://user-images.githubusercontent.com/647359/60893339-a88ac800-a258-11e9-9c92-138f4599e9b4.png)
