### PR TITLE
Tweak redirects and exception debugger

### DIFF
--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -206,7 +206,7 @@ class ServerErrorMiddleware:
         }
         return FRAME_TEMPLATE.format(**values)
 
-    def generate_html(self, exc: Exception, limit: int = 7) -> str:
+    def generate_html(self, exc: Exception, limit: int = 9) -> str:
         traceback_obj = traceback.TracebackException.from_exception(
             exc, capture_locals=True
         )

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -161,7 +161,7 @@ class UJSONResponse(JSONResponse):
 
 class RedirectResponse(Response):
     def __init__(
-        self, url: typing.Union[str, URL], status_code: int = 307, headers: dict = None
+        self, url: typing.Union[str, URL], status_code: int = 303, headers: dict = None
     ) -> None:
         super().__init__(content=b"", status_code=status_code, headers=headers)
         self.headers["location"] = quote_plus(str(url), safe=":/%#?&=@[]!$&'()*+,;")

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -603,7 +603,7 @@ class Router:
                     if match != Match.NONE:
                         redirect_url = URL(scope=redirect_scope)
                         response = RedirectResponse(
-                            url=str(redirect_url), status_code=308
+                            url=str(redirect_url), status_code=307
                         )
                         await response(scope, receive, send)
                         return

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -602,7 +602,9 @@ class Router:
                     match, child_scope = route.matches(redirect_scope)
                     if match != Match.NONE:
                         redirect_url = URL(scope=redirect_scope)
-                        response = RedirectResponse(url=str(redirect_url))
+                        response = RedirectResponse(
+                            url=str(redirect_url), status_code=308
+                        )
                         await response(scope, receive, send)
                         return
 

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -48,18 +48,22 @@ class Jinja2Templates:
     return templates.TemplateResponse("index.html", {"request": request})
     """
 
-    def __init__(self, directory: str) -> None:
+    def __init__(self, directory: str, extensions=None) -> None:
+        if extensions is None:
+            extensions = ()
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
-        self.env = self.get_env(directory)
+        self.env = self.get_env(directory, extensions)
 
-    def get_env(self, directory: str) -> "jinja2.Environment":
+    def get_env(self, directory: str, extensions=None) -> "jinja2.Environment":
         @jinja2.contextfunction
         def url_for(context: dict, name: str, **path_params: typing.Any) -> str:
             request = context["request"]
             return request.url_for(name, **path_params)
 
         loader = jinja2.FileSystemLoader(directory)
-        env = jinja2.Environment(loader=loader, autoescape=True)
+        if extensions is None:
+            extensions = ()
+        env = jinja2.Environment(loader=loader, autoescape=True, extensions=extensions)
         env.globals["url_for"] = url_for
         return env
 


### PR DESCRIPTION
Default redirects actually should be 303 (which is what we want for eg. form redirects)
HTTPS middleware and Router slash redirects should explicitly be 308 (Permanent redirect, preserving method)