### PR TITLE
Request path regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,129 @@
-*.pyc
-test.db
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
 .pytest_cache/
-.mypy_cache/
-starlette.egg-info/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
 venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+
+# Custom project settings
+test.db
+starlette.egg-info/

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -52,6 +52,13 @@ Query parameters are exposed as an immutable multi-dict.
 
 For example: `request.query_params['search']`
 
+#### Path regex
+
+Regular expresion of triggered route. Represented as a string.
+
+For example: `GET /users/unitto` => `request.path_re`
+will return something like a `/users/{username}` 
+
 #### Path Parameters
 
 Router path parameters are exposed as a dictionary interface.

--- a/starlette/background.py
+++ b/starlette/background.py
@@ -21,8 +21,8 @@ class BackgroundTask:
 
 
 class BackgroundTasks(BackgroundTask):
-    def __init__(self, tasks: typing.Sequence[BackgroundTask] = []):
-        self.tasks = list(tasks)
+    def __init__(self, tasks: typing.Sequence[BackgroundTask] = None):
+        self.tasks = list(tasks or [])
 
     def add_task(
         self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -78,7 +78,7 @@ class HTTPConnection(Mapping):
         return self._query_params
 
     @property
-    def path_params(self) -> dict:
+    def path_params(self) -> typing.Dict[str, typing.Any]:
         return self.scope.get("path_params", {})
 
     @property

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -82,6 +82,10 @@ class HTTPConnection(Mapping):
         return self.scope.get("path_params", {})
 
     @property
+    def path_re(self) -> str:
+        return self.scope.get("path_re", "")
+
+    @property
     def cookies(self) -> typing.Dict[str, str]:
         if not hasattr(self, "_cookies"):
             cookies = {}

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -176,7 +176,11 @@ class Route(BaseRoute):
                     matched_params[key] = self.param_convertors[key].convert(value)
                 path_params = dict(scope.get("path_params", {}))
                 path_params.update(matched_params)
-                child_scope = {"endpoint": self.endpoint, "path_params": path_params}
+                child_scope = {
+                    "endpoint": self.endpoint,
+                    "path_params": path_params,
+                    "path_re": self.path,
+                }
                 if self.methods and scope["method"] not in self.methods:
                     return Match.PARTIAL, child_scope
                 return Match.FULL, child_scope
@@ -244,7 +248,11 @@ class WebSocketRoute(BaseRoute):
                     matched_params[key] = self.param_convertors[key].convert(value)
                 path_params = dict(scope.get("path_params", {}))
                 path_params.update(matched_params)
-                child_scope = {"endpoint": self.endpoint, "path_params": path_params}
+                child_scope = {
+                    "endpoint": self.endpoint,
+                    "path_params": path_params,
+                    "path_re": self.path,
+                }
                 return Match.FULL, child_scope
         return Match.NONE, {}
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -163,7 +163,7 @@ class Route(BaseRoute):
         else:
             self.methods = set([method.upper() for method in methods])
             if "GET" in self.methods:
-                self.methods |= set(["HEAD"])
+                self.methods |= {"HEAD"}
 
         self.path_regex, self.path_format, self.param_convertors = compile_path(path)
 
@@ -179,8 +179,7 @@ class Route(BaseRoute):
                 child_scope = {"endpoint": self.endpoint, "path_params": path_params}
                 if self.methods and scope["method"] not in self.methods:
                     return Match.PARTIAL, child_scope
-                else:
-                    return Match.FULL, child_scope
+                return Match.FULL, child_scope
         return Match.NONE, {}
 
     def url_path_for(self, name: str, **path_params: str) -> URLPath:
@@ -231,8 +230,9 @@ class WebSocketRoute(BaseRoute):
             # Endpoint is a class. Treat it as ASGI.
             self.app = endpoint
 
-        regex = "^" + path + "$"
-        regex = re.sub("{([a-zA-Z_][a-zA-Z0-9_]*)}", r"(?P<\1>[^/]+)", regex)
+        # FIXME: unused variables
+        # regex = "^" + path + "$"
+        # regex = re.sub("{([a-zA-Z_][a-zA-Z0-9_]*)}", r"(?P<\1>[^/]+)", regex)
         self.path_regex, self.path_format, self.param_convertors = compile_path(path)
 
     def matches(self, scope: Scope) -> typing.Tuple[Match, Scope]:
@@ -577,6 +577,7 @@ class Router:
             scope["router"] = self
 
         partial = None
+        partial_scope: typing.MutableMapping[str, typing.Any] = {}
 
         for route in self.routes:
             match, child_scope = route.matches(scope)

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -145,15 +145,14 @@ class StaticFiles:
     async def lookup_path(
         self, path: str
     ) -> typing.Tuple[str, typing.Optional[os.stat_result]]:
-        stat_result = None
         for directory in self.all_directories:
             full_path = os.path.join(directory, path)
             try:
                 stat_result = await aio_stat(full_path)
-                return (full_path, stat_result)
+                return full_path, stat_result
             except FileNotFoundError:
                 pass
-        return ("", None)
+        return "", None
 
     def file_response(
         self,

--- a/starlette/status.py
+++ b/starlette/status.py
@@ -40,6 +40,7 @@ HTTP_414_REQUEST_URI_TOO_LONG = 414
 HTTP_415_UNSUPPORTED_MEDIA_TYPE = 415
 HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE = 416
 HTTP_417_EXPECTATION_FAILED = 417
+HTTP_418_IM_TEAPOT = 418
 HTTP_422_UNPROCESSABLE_ENTITY = 422
 HTTP_423_LOCKED = 423
 HTTP_424_FAILED_DEPENDENCY = 424
@@ -55,6 +56,35 @@ HTTP_504_GATEWAY_TIMEOUT = 504
 HTTP_505_HTTP_VERSION_NOT_SUPPORTED = 505
 HTTP_507_INSUFFICIENT_STORAGE = 507
 HTTP_511_NETWORK_AUTHENTICATION_REQUIRED = 511
+
+
+def is_informational(code: int) -> bool:
+    return 100 <= code <= 199
+
+
+def is_success(code: int) -> bool:
+    return 200 <= code <= 299
+
+
+def is_redirect(code: int) -> bool:
+    return 300 <= code <= 399
+
+
+def is_client_error(code: int) -> bool:
+    return 400 <= code <= 499
+
+
+def is_server_error(code: int) -> bool:
+    return 500 <= code <= 599
+
+
+def is_teapot(code: int) -> bool:
+    """
+    ...
+    And RFC 7168 - https://tools.ietf.org/html/rfc7168
+    And RFC 2324 - https://tools.ietf.org/html/rfc2324
+    """
+    return code == HTTP_418_IM_TEAPOT
 
 
 """

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -54,6 +54,12 @@ def all_users_page(request):
     return PlainTextResponse("Hello, everyone!")
 
 
+@users.route("/pages/{num}")
+def pages(request):
+    path_re = request.path_re
+    return PlainTextResponse(f"Handled by re: {path_re!r}")
+
+
 @users.route("/{username}")
 def user_page(request):
     username = request.path_params["username"]
@@ -113,6 +119,12 @@ def test_class_route():
     response = client.get("/class")
     assert response.status_code == 200
     assert response.text == "Hello, world!"
+
+
+def test_path_re():
+    response = client.get("/users/pages/2")
+    assert response.status_code == 200
+    assert response.text == "Handled by re: '/pages/{num}'"
 
 
 def test_mounted_route():
@@ -181,6 +193,7 @@ def test_routes():
             app=Router(
                 routes=[
                     Route("/", endpoint=all_users_page),
+                    Route("/pages/{num}", endpoint=pages),
                     Route("/{username}", endpoint=user_page),
                 ]
             ),

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,42 @@
+from starlette.status import (
+    is_client_error,
+    is_informational,
+    is_redirect,
+    is_server_error,
+    is_success,
+    is_teapot,
+)
+
+
+def test_is_informational():
+    assert is_informational(102)
+    assert not is_informational(204)
+
+
+def test_is_success():
+    assert is_success(201)
+    assert not is_success(302)
+
+
+def test_is_redirect():
+    assert is_redirect(301)
+    assert not is_redirect(200)
+
+
+def test_is_client_error():
+    assert is_client_error(404)
+    assert not is_client_error(500)
+
+
+def test_is_server_error():
+    assert is_server_error(500)
+    assert not is_server_error(401)
+
+
+def test_is_teapot():
+    """ Of course test is not a teapot. Nothing is teapot except for teapot. """
+    assert is_teapot(418)
+    assert not is_teapot(200)
+    assert not is_teapot(301)
+    assert not is_teapot(404)
+    assert not is_teapot(500)


### PR DESCRIPTION
Hey, guys!

Currently, I making the starlette middleware for the data dog tracing.
I faced the problem that I can't get the route path (regex) for using as an endpoint in statistics views.

For example:
We have user pages `/users/{username}`. When somebody visits the page we want to see the trace, but trace endpoint not should be exact (as `/users/user1` or `/users/user2`) but should be a template string as we set in route (`/users/{username}`). So I proxying with this value to the scope and then to the request object (near `path_params`). I think it will be useful.

Also, I add the status code checking functions from the DRF, and two more RFCs =)
Hope to merge it and release a new path for the framework, then I will continue with my TraceMiddleware.