### PR TITLE
change: JSONResponse accepts JSONEncoder class for serialization

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -39,7 +39,7 @@ class Response:
         media_type: str = None,
         background: BackgroundTask = None,
     ) -> None:
-        self.body = self.render(content)
+        self.content = content
         self.status_code = status_code
         if media_type is not None:
             self.media_type = media_type
@@ -79,6 +79,10 @@ class Response:
             raw_headers.append((b"content-type", content_type.encode("latin-1")))
 
         self.raw_headers = raw_headers
+
+    @property
+    def body(self):
+        return self.render(self.content)
 
     @property
     def headers(self) -> MutableHeaders:
@@ -142,6 +146,15 @@ class PlainTextResponse(Response):
 class JSONResponse(Response):
     media_type = "application/json"
 
+    def __init__(
+        self,
+        *args,
+        encoder = json.JSONEncoder,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.encoder = encoder
+
     def render(self, content: typing.Any) -> bytes:
         return json.dumps(
             content,
@@ -149,6 +162,7 @@ class JSONResponse(Response):
             allow_nan=False,
             indent=None,
             separators=(",", ":"),
+            cls=self.encoder
         ).encode("utf-8")
 
 


### PR DESCRIPTION
Hello there!

### Rationale

As of now, it's not possible to pass to JSONResponse a custom JSONEncoder.

Working "hack" is the following.
```python
class MyEncoder(json.JSONEncoder):
    ...

class CustomJSONResponse(JSONResponse):
    media_type = "application/json"
    def __init__(self, *args, encoder: MyEncoder, **kwargs):
        self.encoder = encoder
        super().__init__(*args, **kwargs)
    def render(self, content: typing.Any) -> bytes:
        return json.dumps(
            ...
            cls=self.encoder,
        ).encode("utf-8")
```
To notice: it's mandatory to assign the encoder **before** calling the `super().__init__` because as of now the content is dumped at init time. Afaik, this is not a good practice in terms of inheritance.

### Why this PR

To permit to easily pass a JSONEncoder class at creation time
```python
JSONEncoder(data=myDataclassInstance, encoder=MyEncoder)
```

The changes are working but still in "wip", it's probably missing something about the docs and maybe more test cases.

PS: About the failing test case, I thing it's caused by [this commit](https://github.com/encode/starlette/commit/059b9894946c85366b777b8d3d724e046cd2e875). I could fix that in another PR if necessary