### PR TITLE
Fix memory leaks that may be caused by default parameters in BackgroundTasks

### DIFF
--- a/starlette/background.py
+++ b/starlette/background.py
@@ -21,8 +21,8 @@ class BackgroundTask:
 
 
 class BackgroundTasks(BackgroundTask):
-    def __init__(self, tasks: typing.Sequence[BackgroundTask] = []):
-        self.tasks = list(tasks)
+    def __init__(self, tasks: typing.Sequence[BackgroundTask] = None):
+        self.tasks = list(tasks or [])
 
     def add_task(
         self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any


### PR DESCRIPTION
Fix memory leaks that may be caused by default parameters in `BackgroundTasks`.
