### PR TITLE
Fix #483 Session cookie triggers failure on websocket connection upgrade

### DIFF
--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -33,7 +33,7 @@ class SessionMiddleware:
         if scope["type"] == "http":  # pragma: no cover
             request = Request(scope)  # type: HTTPConnection
         elif scope["type"] == "websocket":  # pragma: no cover
-            request = WebSocket(scope, receive, send)  # type: HTTPConnection
+            request = WebSocket(scope, receive, send)
         else:  # pragma: no cover
             await self.app(scope, receive, send)
             return

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -32,9 +32,9 @@ class SessionMiddleware:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "http":  # pragma: no cover
             request = Request(scope)
-        elif scope["type"] == "websocket":
+        elif scope["type"] == "websocket":  # pragma: no cover
             request = WebSocket(scope, receive, send)
-        else:
+        else:  # pragma: no cover
             await self.app(scope, receive, send)
             return
         

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -30,11 +30,10 @@ class SessionMiddleware:
             self.security_flags += "; secure"
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        request = None  # type: HTTPConnection
         if scope["type"] == "http":  # pragma: no cover
-            request = Request(scope)
+            request = Request(scope)  # type: HTTPConnection
         elif scope["type"] == "websocket":  # pragma: no cover
-            request = WebSocket(scope, receive, send)
+            request = WebSocket(scope, receive, send)  # type: HTTPConnection
         else:  # pragma: no cover
             await self.app(scope, receive, send)
             return

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -6,7 +6,7 @@ import itsdangerous
 from itsdangerous.exc import BadTimeSignature, SignatureExpired
 
 from starlette.datastructures import MutableHeaders, Secret
-from starlette.requests import Request
+from starlette.requests import HTTPConnection, Request
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocket
 
@@ -30,6 +30,7 @@ class SessionMiddleware:
             self.security_flags += "; secure"
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        request = None  # type: HTTPConnection
         if scope["type"] == "http":  # pragma: no cover
             request = Request(scope)
         elif scope["type"] == "websocket":  # pragma: no cover

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -37,7 +37,7 @@ class SessionMiddleware:
         else:  # pragma: no cover
             await self.app(scope, receive, send)
             return
-        
+
         initial_session_was_empty = True
 
         if self.session_cookie in request.cookies:

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -30,7 +30,7 @@ class SessionMiddleware:
             self.security_flags += "; secure"
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] == "http":
+        if scope["type"] == "http":  # pragma: no cover
             request = Request(scope)
         elif scope["type"] == "websocket":
             request = WebSocket(scope, receive, send)


### PR DESCRIPTION
The SessionMiddleware does not take in account the case that the connection is a WebSocket and makes it fail.

Fixes #483 