### PR TITLE
Remove LifespanContext import

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -59,7 +59,6 @@ startup and shutdown events are called.
 
 ```python
 from example import app
-from starlette.lifespan import LifespanContext
 from starlette.testclient import TestClient
 
 


### PR DESCRIPTION
Since `TestClient `can now be used as a context manager instead of `LifespanContext`, the import of `LifespanContext` was removed from the example on the **Events** documentation page.