### PR TITLE
Remove "self" argument from websockets example

### DIFF
--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -10,7 +10,7 @@ Signature: `WebSocket(scope, receive=None, send=None)`
 from starlette.websockets import WebSocket
 
 
-async def app(self, scope, receive, send):
+async def app(scope, receive, send):
     websocket = WebSocket(scope=scope, receive=receive, send=send)
     await websocket.accept()
     await websocket.send_text('Hello, world!')


### PR DESCRIPTION
Fix the websockets example by removing the bogus "self" argument from the app
callable.