### PR TITLE
Document the `request.app` property.

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -80,10 +80,14 @@ exceptions that occur within the application:
 ### Storing state on the app instance
 
 You can store arbitrary extra state on the application instance, using the
-generic `app.state` attribute.  This can then be accessed in middleware or endpoints via `request.app`.
+generic `app.state` attribute.
 
 For example:
 
 ```python
 app.state.ADMIN_EMAIL = 'admin@example.org'
 ```
+
+### Acessing the app instance
+
+Where a `request` is available (i.e. endpoints and middleware), the app is available on `request.app`.  For other situations it can be imported from wherever it's instantiated.

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -80,7 +80,7 @@ exceptions that occur within the application:
 ### Storing state on the app instance
 
 You can store arbitrary extra state on the application instance, using the
-generic `app.state` attribute.
+generic `app.state` attribute.  This can then be accessed in middleware or endpoints via `request.app`.
 
 For example:
 

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -140,6 +140,10 @@ filename = form["upload_file"].filename
 contents = await form["upload_file"].read()
 ```
 
+#### Application
+
+The originating Starlette application can be accessed via `request.app`.
+
 #### Other state
 
 If you want to store additional information on the request you can do so


### PR DESCRIPTION
* Mention it in the Request documentation
* Mention it in the Application documentation in the context of accessing the application state

See #612.