### PR TITLE
Add support for server push

### DIFF
--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -1,0 +1,34 @@
+
+Starlette includes support for HTTP/2 and HTTP/3 server push, making it
+possible to push resources to the client to speed up page load times.
+
+### `Request.send_push_promise`
+
+Used to initiate a server push for a resource. If server push is not available
+this method does nothing.
+
+Signature: `send_push_promise(path)`
+
+* `path` - A string denoting the path of the resource.
+
+```python
+from starlette.applications import Starlette
+from starlette.responses import HTMLResponse
+from starlette.staticfiles import StaticFiles
+
+app = Starlette()
+
+
+@app.route("/")
+async def homepage(request):
+    """
+    Homepage which uses server push to deliver the stylesheet.
+    """
+    await request.send_push_promise("/static/style.css")
+    return HTMLResponse(
+        '<html><head><link rel="stylesheet" href="/static/style.css"/></head></html>'
+    )
+
+
+app.mount("/static", StaticFiles(directory="static"))
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
     - API Schemas: 'schemas.md'
     - Events: 'events.md'
     - Background Tasks: 'background.md'
+    - Server Push: 'server-push.md'
     - Exceptions: 'exceptions.md'
     - Configuration: 'config.md'
     - Test Client: 'testclient.md'

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -36,7 +36,7 @@ def request_response(func: typing.Callable) -> ASGIApp:
     is_coroutine = asyncio.iscoroutinefunction(func)
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request(scope, receive=receive)
+        request = Request(scope, receive=receive, send=send)
         if is_coroutine:
             response = await func(request)
         else:


### PR DESCRIPTION
This adds support for HTTP/2 and HTTP/3 server push by adding a
`Request.send_push_promise` method, which signals to push-enabled
servers that a push should be sent.