### PR TITLE
Add "UploadFile.copy(dest)" method

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -1,3 +1,4 @@
+import shutil
 import tempfile
 import typing
 from collections import namedtuple
@@ -441,6 +442,9 @@ class UploadFile:
 
     async def close(self) -> None:
         await run_in_threadpool(self.file.close)
+
+    async def copy(self, dest: typing.IO) -> None:
+        await run_in_threadpool(shutil.copyfileobj, self.file, dest)
 
 
 class FormData(ImmutableMultiDict):


### PR DESCRIPTION
This method allows users to conveniently and efficiently persist an uploaded file without reading all of its contents into memory.