### PR TITLE
[docs] update RedirectResponse status code

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -113,7 +113,7 @@ async def app(scope, receive, send):
 
 ### RedirectResponse
 
-Returns an HTTP redirect. Uses a 302 status code by default.
+Returns an HTTP redirect. Uses a 307 status code by default.
 
 ```python
 from starlette.responses import PlainTextResponse, RedirectResponse


### PR DESCRIPTION
The redirect response changed the status code it returns by default but the docs were not updated to reflect the change. Small fix to keep up to date.
https://github.com/encode/starlette/commit/3f702238247c99089eac76880965b32bd050f3cb