### PR TITLE
tests: minor: use "test_" prefix

### DIFF
--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -45,7 +45,7 @@ def test_use_testclient_in_endpoint():
     assert response.json() == {"mock": "example"}
 
 
-def testclient_as_contextmanager():
+def test_use_testclient_as_contextmanager():
     with TestClient(app):
         pass
 


### PR DESCRIPTION
The test was run previously, but this is clearer.