### PR TITLE
Support for default json encoder when using JSONResponse

### DIFF
--- a/starlette/encoders.py
+++ b/starlette/encoders.py
@@ -1,0 +1,3 @@
+def utf8encoder(val):
+    if isinstance(val, bytes):
+        return val.decode('utf-8')

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -38,7 +38,7 @@ class Response:
         headers: dict = None,
         media_type: str = None,
         background: BackgroundTask = None,
-        json_encoder: object = None
+        json_encoder: typing.Callable = None
     ) -> None:
         self.json_encoder = json_encoder
         self.body = self.render(content)

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -38,7 +38,9 @@ class Response:
         headers: dict = None,
         media_type: str = None,
         background: BackgroundTask = None,
+        json_encoder: object = None
     ) -> None:
+        self.json_encoder = json_encoder
         self.body = self.render(content)
         self.status_code = status_code
         if media_type is not None:
@@ -149,6 +151,7 @@ class JSONResponse(Response):
             allow_nan=False,
             indent=None,
             separators=(",", ":"),
+            default=self.json_encoder
         ).encode("utf-8")
 
 


### PR DESCRIPTION
This is something I have wanted in a framework for a while now.  Basically the ability to give a default encoder to the JSONResponse object so that we can set json.dumps(content, default=encoder).  

For example based on this PR we can do the following.


```
from starlette.encoders import utf8encoder
...

@app.route('/', methods=['GET'])
async def homepage(request):
    return JSONResponse({'request': request.__dict__}, json_encoder=utf8encoder)
```

Or alternatively if you are just developing and don't care about the encoding.

```
@app.route('/', methods=['GET'])
async def homepage(request):
    return JSONResponse({'request': request.__dict__}, json_encoder=str)
```

The way devs typically handle this now is to wrap json.dumps with json.loads and their favorite encoder.

```
request_dict = json.loads(json.dumps(content, default=utf8encoder))
return JSONResponse({'request': request_dict})
```

The addition of this PR would eliminate the unnecessary json.loads() step by allowing us to pass the encoder to the final json.dumps call inside JSONResponse.render().