### PR TITLE
Performantly build large request bodies

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -161,7 +161,7 @@ class URLPath(str):
     Used by the routing to return `url_path_for` matches.
     """
 
-    def __new__(cls, path: str, protocol: str = "", host: str = "") -> str:
+    def __new__(cls, path: str, protocol: str = "", host: str = "") -> "URLPath":
         assert protocol in ("http", "websocket", "")
         return str.__new__(cls, path)  # type: ignore
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -178,10 +178,10 @@ class Request(HTTPConnection):
 
     async def body(self) -> bytes:
         if not hasattr(self, "_body"):
-            body = b""
+            chunks = []
             async for chunk in self.stream():
-                body += chunk
-            self._body = body
+                chunks.append(chunk)
+            self._body = b"".join(chunks)
         return self._body
 
     async def json(self) -> typing.Any:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -382,7 +382,7 @@ class TestClient(requests.Session):
         self.app = asgi_app
         self.base_url = base_url
 
-    def request(
+    def request(  # type: ignore
         self,
         method: str,
         url: str,


### PR DESCRIPTION
This PR replaces the quadratically-scaling `body += chunk` with the linearly-scaling `body = b"".join(chunks)`.

This leads to a speed up of `20x` in the script from #651 (which involves a 100MB payload). (The time currently scales quadratically with the payload size, so this large factor makes sense.)

Even for payloads as small as 5MB, in my testing, this change causes the server to handle the request ~15-20% faster.