### PR TITLE
Fix __init__ code in custom HTTP middleware example

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -170,7 +170,7 @@ attribute on the instance if you do this.
 ```python
 class CustomHeaderMiddleware(BaseHTTPMiddleware):
     def __init__(self, app, header_value='Example'):
-        self.app = app
+        super().__init__(app)
         self.header_value = header_value
 
     async def dispatch(self, request, call_next):


### PR DESCRIPTION
Use `super` in `__init__` to prevent #663 issue when following custom HTTP middleware documentation.