### PR TITLE
Add link to EarlyDataMiddleware

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -226,3 +226,7 @@ Access can be restricted to specific users or to members of specific GitHub orga
 #### [PrometheusMiddleware](https://github.com/perdy/starlette-prometheus)
 
 A middleware class for capturing Prometheus metrics related to requests and responses, including in progress requests, timing...
+
+#### [EarlyDataMiddleware](https://github.com/HarrySky/starlette-early-data)
+
+Middleware and decorator for detecting and denying [TLSv1.3 early data](https://tools.ietf.org/html/rfc8470) requests.


### PR DESCRIPTION
Add link to EarlyDataMiddleware in `Third party middleware` section. Probably will need merge from master after #665 is merged.

( Related #660 )