### PR TITLE
add support for query parameters in `Route.url_path_for`

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -126,8 +126,8 @@ class Starlette:
 
         return decorator
 
-    def url_path_for(self, name: str, **path_params: str) -> URLPath:
-        return self.router.url_path_for(name, **path_params)
+    def url_path_for(self, name: str, **path_and_query_params: str) -> URLPath:
+        return self.router.url_path_for(name, **path_and_query_params)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope["app"] = self

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -157,15 +157,22 @@ class URL:
 
 class URLPath(str):
     """
-    A URL path string that may also hold an associated protocol and/or host.
+    A URL path string that may also hold an associated protocol and/or host
+    and/or query_string.
     Used by the routing to return `url_path_for` matches.
     """
 
-    def __new__(cls, path: str, protocol: str = "", host: str = "") -> "URLPath":
+    def __new__(
+        cls, path: str, protocol: str = "", host: str = "", query_string: str = ""
+    ) -> "URLPath":
         assert protocol in ("http", "websocket", "")
-        return str.__new__(cls, path)  # type: ignore
+        return str.__new__(  # type: ignore
+            cls, path if query_string == "" else "?".join((path, query_string))
+        )
 
-    def __init__(self, path: str, protocol: str = "", host: str = "") -> None:
+    def __init__(
+        self, path: str, protocol: str = "", host: str = "", query_string: str = ""
+    ) -> None:
         self.protocol = protocol
         self.host = host
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -149,8 +149,29 @@ def test_route_converters():
 
 def test_url_path_for():
     assert app.url_path_for("homepage") == "/"
+    assert (
+        app.url_path_for("homepage", some_query_param="this")
+        == "/?some_query_param=this"
+    )
+    assert (
+        app.url_path_for("homepage", **{"funky[query_param]": "this"})
+        == "/?funky%5Bquery_param%5D=this"
+    )
     assert app.url_path_for("user", username="tomchristie") == "/users/tomchristie"
     assert app.url_path_for("websocket_endpoint") == "/ws"
+    assert (
+        app.url_path_for("user", username="tomchristie", some_query_param="this")
+        == "/users/tomchristie?some_query_param=this"
+    )
+    assert (
+        app.url_path_for(
+            "user",
+            username="tomchristie",
+            some_query_param="this",
+            another_query_param="that",
+        )
+        == "/users/tomchristie?some_query_param=this&another_query_param=that"
+    )
     with pytest.raises(NoMatchFound):
         assert app.url_path_for("broken")
     with pytest.raises(AssertionError):
@@ -169,6 +190,12 @@ def test_url_for():
             base_url="https://example.org"
         )
         == "https://example.org/users/tomchristie"
+    )
+    assert (
+        app.url_path_for(
+            "user", username="tomchristie", some_query_param="this"
+        ).make_absolute_url(base_url="https://example.org")
+        == "https://example.org/users/tomchristie?some_query_param=this"
     )
     assert (
         app.url_path_for("websocket_endpoint").make_absolute_url(


### PR DESCRIPTION
This PR add support for query parameters when resolving a URL with `request.url_for` and friends

From the added tests:

```
assert (
    app.url_path_for("homepage", some_query_param="this") == "/?some_query_param=this")

assert (
    app.url_path_for("homepage", **{"funky[query_param]": "this"}) =="/?funky%5Bquery_param%5D=this")

```

I find this useful in the context of getting a reproducible URL when generating pagination links for my API.

fixes #560 