### PR TITLE
Add type hint for run_in_threadpool return type

### DIFF
--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -8,10 +8,12 @@ try:
 except ImportError:  # pragma: no cover
     contextvars = None  # type: ignore
 
+T = typing.TypeVar("T")
+
 
 async def run_in_threadpool(
-    func: typing.Callable, *args: typing.Any, **kwargs: typing.Any
-) -> typing.Any:
+    func: typing.Callable[..., T], *args: typing.Any, **kwargs: typing.Any
+) -> T:
     loop = asyncio.get_event_loop()
     if contextvars is not None:  # pragma: no cover
         # Ensure we run in the same context


### PR DESCRIPTION
This PR adds a `TypeVar`-based type hint for the return type of `run_in_threadpool` to ensure mypy can type check the results of a `run_in_threadpool` call.

----

I've been caught a couple times when using `run_in_threadpool` after refactors due to a change of a function's return type, and mypy treating it as an `Any`.

This change would ensure that the result of a `run_in_threadpool` call would be treated by mypy as the same as the type `func` would return if it were called outside of the threadpool.