### PR TITLE
Dropping double square brackets in install script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -1,12 +1,12 @@
 #!/bin/sh -e
 
 # Use the Python executable provided from the `-p` option, or a default.
-[[ $1 = "-p" ]] && PYTHON=$2 || PYTHON="python3"
+[ $1 = "-p" ] && PYTHON=$2 || PYTHON="python3"
 
 MIN_VERSION="(3, 6)"
 VERSION_OK=`"$PYTHON" -c "import sys; print(sys.version_info[0:2] >= $MIN_VERSION and '1' or '');"`
 
-if [[ -z "$VERSION_OK" ]] ; then
+if [ -z "$VERSION_OK" ] ; then
     PYTHON_VERSION=`"$PYTHON" -c "import sys; print('%s.%s' % sys.version_info[0:2]);"`
     DISP_MIN_VERSION=`"$PYTHON" -c "print('%s.%s' % $MIN_VERSION)"`
     echo "ERROR: Python $PYTHON_VERSION detected, but $DISP_MIN_VERSION+ is required."


### PR DESCRIPTION
The install script works with `sh` but contains double square brackets tests which aren't implemented in `sh` and result in an error. This pull request changes the bracket tests to single bracket.