### PR TITLE
Support app configuration on initialization.

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -18,10 +18,12 @@ class Starlette:
         exception_handlers: typing.Dict[
             typing.Union[int, typing.Type[Exception]], typing.Callable
         ] = None,
+        on_startup: typing.List[typing.Callable] = None,
+        on_shutdown: typing.List[typing.Callable] = None,
     ) -> None:
         self._debug = debug
         self.state = State()
-        self.router = Router(routes)
+        self.router = Router(routes, on_startup=on_startup, on_shutdown=on_shutdown)
         self.exception_handlers = (
             {} if exception_handlers is None else dict(exception_handlers)
         )

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -2,6 +2,7 @@ import typing
 
 from starlette.datastructures import State, URLPath
 from starlette.exceptions import ExceptionMiddleware
+from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.routing import BaseRoute, Router
@@ -10,15 +11,49 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 class Starlette:
     def __init__(
-        self, debug: bool = False, routes: typing.List[BaseRoute] = None
+        self,
+        debug: bool = False,
+        routes: typing.List[BaseRoute] = None,
+        middleware: typing.List[Middleware] = None,
+        exception_handlers: typing.Dict[
+            typing.Union[int, typing.Type[Exception]], typing.Callable
+        ] = None,
     ) -> None:
         self._debug = debug
         self.state = State()
         self.router = Router(routes)
-        self.exception_middleware = ExceptionMiddleware(self.router, debug=debug)
-        self.error_middleware = ServerErrorMiddleware(
-            self.exception_middleware, debug=debug
+        self.exception_handlers = (
+            {} if exception_handlers is None else dict(exception_handlers)
         )
+        self.user_middleware = list(middleware or [])
+        self.middleware_stack = self.build_middleware_stack()
+
+    def build_middleware_stack(self) -> ASGIApp:
+        debug = self.debug
+        error_handler = None
+        exception_handlers = {}
+
+        for key, value in self.exception_handlers.items():
+            if key in (500, Exception):
+                error_handler = value
+            else:
+                exception_handlers[key] = value
+
+        server_errors = Middleware(
+            ServerErrorMiddleware, options={"handler": error_handler, "debug": debug},
+        )
+        exceptions = Middleware(
+            ExceptionMiddleware,
+            options={"handlers": exception_handlers, "debug": debug},
+        )
+
+        middleware = [server_errors] + self.user_middleware + [exceptions]
+
+        app = self.router
+        for cls, options, enabled in reversed(middleware):
+            if enabled:
+                app = cls(app=app, **options)
+        return app
 
     @property
     def routes(self) -> typing.List[BaseRoute]:
@@ -31,8 +66,7 @@ class Starlette:
     @debug.setter
     def debug(self, value: bool) -> None:
         self._debug = value
-        self.exception_middleware.debug = value
-        self.error_middleware.debug = value
+        self.middleware_stack = self.build_middleware_stack()
 
     def on_event(self, event_type: str) -> typing.Callable:
         return self.router.lifespan.on_event(event_type)
@@ -44,21 +78,16 @@ class Starlette:
         self.router.host(host, app=app, name=name)
 
     def add_middleware(self, middleware_class: type, **kwargs: typing.Any) -> None:
-        self.error_middleware.app = middleware_class(
-            self.error_middleware.app, **kwargs
-        )
+        self.user_middleware.insert(0, Middleware(middleware_class, options=kwargs))
+        self.middleware_stack = self.build_middleware_stack()
 
     def add_exception_handler(
         self,
         exc_class_or_status_code: typing.Union[int, typing.Type[Exception]],
         handler: typing.Callable,
     ) -> None:
-        if exc_class_or_status_code in (500, Exception):
-            self.error_middleware.handler = handler
-        else:
-            self.exception_middleware.add_exception_handler(
-                exc_class_or_status_code, handler
-            )
+        self.exception_handlers[exc_class_or_status_code] = handler
+        self.middleware_stack = self.build_middleware_stack()
 
     def add_event_handler(self, event_type: str, func: typing.Callable) -> None:
         self.router.lifespan.add_event_handler(event_type, func)
@@ -131,4 +160,4 @@ class Starlette:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope["app"] = self
-        await self.error_middleware(scope, receive, send)
+        await self.middleware_stack(scope, receive, send)

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -21,13 +21,18 @@ class HTTPException(Exception):
 
 
 class ExceptionMiddleware:
-    def __init__(self, app: ASGIApp, debug: bool = False) -> None:
+    def __init__(
+        self, app: ASGIApp, handlers: dict = None, debug: bool = False
+    ) -> None:
         self.app = app
         self.debug = debug  # TODO: We ought to handle 404 cases if debug is set.
         self._status_handlers = {}  # type: typing.Dict[int, typing.Callable]
         self._exception_handlers = {
             HTTPException: self.http_exception
         }  # type: typing.Dict[typing.Type[Exception], typing.Callable]
+        if handlers is not None:
+            for key, value in handlers.items():
+                self.add_exception_handler(key, value)
 
     def add_exception_handler(
         self,

--- a/starlette/middleware/__init__.py
+++ b/starlette/middleware/__init__.py
@@ -1,0 +1,20 @@
+import typing
+
+
+class Middleware:
+    def __init__(
+        self, cls: type, options: dict = None, enabled: typing.Any = True
+    ) -> None:
+        self.cls = cls
+        self.options = dict(options) if options else {}
+        self.enabled = bool(enabled)
+
+    def __iter__(self) -> typing.Iterator:
+        as_tuple = (self.cls, self.options, self.enabled)
+        return iter(as_tuple)
+
+    def __repr__(self) -> str:
+        class_name = self.__class__.__name__
+        options_repr = "" if not self.options else f", options={self.options!r}"
+        enabled_repr = "" if self.enabled else ", enabled=False"
+        return f"{class_name}({self.cls.__name__}{options_repr}{enabled_repr})"


### PR DESCRIPTION
This pull request adds support for fully configuring the application on initialization.

This would allow us to *start* moving away from advocating/documenting the decorater based approach, in preference of this kind of style instead...

```python
routes = [
    Route("/", endpoints.dashboard, name="dashboard", methods=["GET", "POST"]),
    Route("/tables/{table_id}", endpoints.table, methods=["GET", "POST"], name="table"),
    Route(
        "/tables/{table_id}/columns",
        endpoints.columns,
        methods=["GET", "POST"],
        name="columns",
    ),
    Route(
        "/tables/{table_id}/delete",
        endpoints.delete_table,
        methods=["POST"],
        name="delete-table",
    ),
    Route(
        "/tables/{table_id}/upload", endpoints.upload, methods=["POST"], name="upload"
    ),
    Route(
        "/tables/{table_id}/columns/{column_id}/delete",
        endpoints.delete_column,
        methods=["POST"],
        name="delete-column",
    ),
    Route(
        "/tables/{table_id}/{row_uuid}",
        endpoints.detail,
        methods=["GET", "POST"],
        name="detail",
    ),
    Route(
        "/tables/{table_id}/{row_uuid}/delete",
        endpoints.delete_row,
        methods=["POST"],
        name="delete-row",
    ),
    Route("/500", endpoints.error),
    Mount("/static", statics, name="static"),
]

middleware = [
    Middleware(SentryAsgiMiddleware, enabled=settings.SENTRY_DSN),
    Middleware(HTTPSRedirectMiddleware, enabled=settings.HTTPS_ONLY),
]

exception_handlers = {
    404: endpoints.not_found,
    500: endpoints.server_error,
}

app = Starlette(
    debug=settings.DEBUG,
    routes=routes,
    middleware=middleware,
    exception_handlers=exception_handlers,
    on_startup=[database.connect],
    on_shutdown=[database.disconnect]
)
```

Refs https://github.com/encode/starlette/issues/396
