### PR TITLE
Strip whitespace on response headers

### DIFF
--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -120,7 +120,7 @@ class WSGIResponder:
             status_code_string, _ = status.split(" ", 1)
             status_code = int(status_code_string)
             headers = [
-                (name.encode("ascii"), value.encode("ascii"))
+                (name.strip().encode("ascii"), value.strip().encode("ascii"))
                 for name, value in response_headers
             ]
             self.send_queue.append(


### PR DESCRIPTION
Strip leading/trailing whitespace on response headers.
Closes #664