### PR TITLE
Handle trailing slash redirects properly.

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -615,17 +615,21 @@ class Router:
             return
 
         if scope["type"] == "http" and self.redirect_slashes:
-            if not scope["path"].endswith("/"):
-                redirect_scope = dict(scope)
-                redirect_scope["path"] += "/"
+            if scope["path"].endswith("/"):
+                redirect_path = scope["path"].rstrip("/")
+            else:
+                redirect_path = scope["path"] + "/"
 
-                for route in self.routes:
-                    match, child_scope = route.matches(redirect_scope)
-                    if match != Match.NONE:
-                        redirect_url = URL(scope=redirect_scope)
-                        response = RedirectResponse(url=str(redirect_url))
-                        await response(scope, receive, send)
-                        return
+            redirect_scope = dict(scope)
+            redirect_scope["path"] = redirect_path
+
+            for route in self.routes:
+                match, child_scope = route.matches(redirect_scope)
+                if match != Match.NONE:
+                    redirect_url = URL(scope=redirect_scope)
+                    response = RedirectResponse(url=str(redirect_url))
+                    await response(scope, receive, send)
+                    return
 
         if scope["type"] == "lifespan":
             await self.lifespan(scope, receive, send)

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -614,7 +614,7 @@ class Router:
             await partial(scope, receive, send)
             return
 
-        if scope["type"] == "http" and self.redirect_slashes:
+        if scope["type"] == "http" and self.redirect_slashes and scope["path"] != "/":
             if scope["path"].endswith("/"):
                 redirect_path = scope["path"].rstrip("/")
             else:


### PR DESCRIPTION
Currently we have behavior so that if:

* A `/some-path/`route exists.
* A `/some-path` route does not exist.

Then if a request to `/some-path` is made, we'll redirect to the trailing slash case.

We ought to also handle the converse case, so that if...

* A `/some-path`route exists.
* A `/some-path/` route does not exist.

Then if a request to `/some-path/` is made, we'll redirect to the no trailing slash case.

Closes #633