### PR TITLE
Add masked property to URL and Secret

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -56,16 +56,24 @@ other code introspection.
 To get the value of a `Secret` instance, you must explicitly cast it to a string.
 You should only do this at the point at which the value is used.
 
+In case you need to use the masked value e.g. in logs just to show that the secret 
+was used you may use the `masked` propery. 
+
 ```python
 >>> from myproject import settings
 >>> settings.SECRET_KEY
 Secret('**********')
 >>> str(settings.SECRET_KEY)
 '98n349$%8b8-7yjn0n8y93T$23r'
+>>> settings.SECRET_KEY.masked
+'**********'
 ```
 
 Similarly, the `URL` class will hide any password component
-in their representations.
+in their representations. 
+
+And it also provides the `masked` property which can be even
+more useful in this case.
 
 ```python
 >>> from myproject import settings
@@ -73,6 +81,8 @@ in their representations.
 URL('postgresql://admin:**********@192.168.0.8/my-application')
 >>> str(settings.DATABASE_URL)
 'postgresql://admin:Fkjh348htGee4t3@192.168.0.8/my-application'
+>>> settings.DATABASE_URL.masked
+'postgresql://admin:**********@192.168.0.8/my-application'
 ```
 
 ## CommaSeparatedStrings

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,13 +11,13 @@ import databases
 
 from starlette.applications import Starlette
 from starlette.config import Config
-from starlette.datastructures import CommaSeparatedStrings, Secret
+from starlette.datastructures import CommaSeparatedStrings, Secret, URL
 
 # Config will be read from environment variables and/or ".env" files.
 config = Config(".env")
 
 DEBUG = config('DEBUG', cast=bool, default=False)
-DATABASE_URL = config('DATABASE_URL', cast=databases.DatabaseURL)
+DATABASE_URL = config('DATABASE_URL', cast=URL)
 SECRET_KEY = config('SECRET_KEY', cast=Secret)
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=CommaSeparatedStrings)
 
@@ -70,7 +70,7 @@ in their representations.
 ```python
 >>> from myproject import settings
 >>> settings.DATABASE_URL
-DatabaseURL('postgresql://admin:**********@192.168.0.8/my-application')
+URL('postgresql://admin:**********@192.168.0.8/my-application')
 >>> str(settings.DATABASE_URL)
 'postgresql://admin:Fkjh348htGee4t3@192.168.0.8/my-application'
 ```

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -95,6 +95,13 @@ class URL:
     def is_secure(self) -> bool:
         return self.scheme in ("https", "wss")
 
+    @property
+    def masked(self) -> str:
+        url = str(self)
+        if self.password:
+            url = str(self.replace(password="********"))
+        return url
+
     def replace(self, **kwargs: typing.Any) -> "URL":
         if (
             "username" in kwargs

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -199,12 +199,16 @@ class Secret:
     You should cast the value to `str` at the point it is required.
     """
 
+    @property
+    def masked(self) -> str:
+        return '**********'
+
     def __init__(self, value: str):
         self._value = value
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
-        return f"{class_name}('**********')"
+        return f"{class_name}({repr(self.masked)})"
 
     def __str__(self) -> str:
         return self._value

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -201,7 +201,7 @@ class Secret:
 
     @property
     def masked(self) -> str:
-        return '**********'
+        return "**********"
 
     def __init__(self, value: str):
         self._value = value

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -156,10 +156,7 @@ class URL:
         return self._url
 
     def __repr__(self) -> str:
-        url = str(self)
-        if self.password:
-            url = str(self.replace(password="********"))
-        return f"{self.__class__.__name__}({repr(url)})"
+        return f"{self.__class__.__name__}({repr(self.masked)})"
 
 
 class URLPath(str):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,8 +30,12 @@ def test_config(tmpdir, monkeypatch):
     assert DATABASE_URL.path == "/dbname"
     assert DATABASE_URL.password == "pass"
     assert DATABASE_URL.username == "user"
+    assert DATABASE_URL.masked == "postgres://user:********@localhost/dbname"
+    assert repr(DATABASE_URL) == "URL('postgres://user:********@localhost/dbname')"
+    assert str(DATABASE_URL) == "postgres://user:pass@localhost/dbname"
     assert REQUEST_TIMEOUT == 10
     assert REQUEST_HOSTNAME == "example.com"
+    assert SECRET_KEY.masked == "**********"
     assert repr(SECRET_KEY) == "Secret('**********')"
     assert str(SECRET_KEY) == "12345"
 


### PR DESCRIPTION
This can be useful for cases when you would like to put a masked value in the log etc.

Example usage:
`logger.info(f"Database initialized with {settings.DATABASE_URL.masked}")`