### PR TITLE
Sharing state with submounted Starlette applications

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.py]
+max_line_length = 88

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -84,10 +84,42 @@ generic `app.state` attribute.
 
 For example:
 
-```python
+```pydocstring
 app.state.ADMIN_EMAIL = 'admin@example.org'
+# or
+app.state['ADMIN_EMAIL'] = 'admin@example.org'
 ```
 
-### Acessing the app instance
+### Sharing state with submounted Starlette applications
+
+Include an Starlette app:
+* `app.mount(prefix, subapp)` - via mounted under the given path prefix
+* `app.host(host, subapp)` - via mounted under the given host
+
+```pydocstring
+# root state
+app.state.foo = 'bar'
+app.state.bar = 'baz'
+
+# subapp scoped state
+subapp.state.foo = 'baz'
+subapp.state.baz = 'foo'
+```
+
+```pydocstring
+>>> app.state.foo
+'bar'
+>>> subapp.state.foo
+'baz'
+>>> subapp.state.bar
+'baz'
+>>> app.state.baz
+...
+AttributeError: 'State' object has no attribute 'baz'
+>>> subapp.state.baz
+'foo'
+```
+
+### Accessing the app instance
 
 Where a `request` is available (i.e. endpoints and middleware), the app is available on `request.app`.  For other situations it can be imported from wherever it's instantiated.

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -74,9 +74,13 @@ class Starlette:
         return self.router.lifespan.on_event(event_type)
 
     def mount(self, path: str, app: ASGIApp, name: str = None) -> None:
+        if isinstance(app, self.__class__):
+            app.state.add_parent(self.state)
         self.router.mount(path, app=app, name=name)
 
     def host(self, host: str, app: ASGIApp, name: str = None) -> None:
+        if isinstance(app, self.__class__):
+            app.state.add_parent(self.state)
         self.router.host(host, app=app, name=name)
 
     def add_middleware(self, middleware_class: type, **kwargs: typing.Any) -> None:

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -11,9 +11,6 @@ from starlette.types import Scope
 Address = namedtuple("Address", ["host", "port"])
 
 
-VT_cov = typing.TypeVar("VT_cov", covariant=True)
-
-
 class URL:
     def __init__(
         self, url: str = "", scope: Scope = None, **components: typing.Any

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1,5 +1,7 @@
 import io
 
+import pytest
+
 from starlette.datastructures import (
     URL,
     CommaSeparatedStrings,
@@ -8,6 +10,7 @@ from starlette.datastructures import (
     MultiDict,
     MutableHeaders,
     QueryParams,
+    State,
 )
 
 
@@ -330,3 +333,25 @@ def test_multidict():
     assert q.getlist("a") == ["123"]
     q.update([("a", "456")], a="789", b="123")
     assert q == MultiDict([("a", "456"), ("a", "789"), ("b", "123")])
+
+
+def test_state():
+    with pytest.raises(ValueError):
+        State(1)
+
+    s = State({"a": 1})
+    with pytest.raises(ValueError):
+        s.add_parent(1)
+
+    with pytest.raises(AttributeError):
+        _ = s.b
+
+    with pytest.raises(AttributeError):
+        del s.b
+
+    sc, sp = {"a": 1}, {"a": 2, "b": 3}
+    s = State(sc)
+    s.add_parent(sp)
+    assert s.maps == [sc, sp]
+    assert s["a"] == sc["a"]
+    assert s["b"] == sp["b"]


### PR DESCRIPTION
### Sharing state with submounted Starlette applications

Include an Starlette app:
* `app.mount(prefix, subapp)` - via mounted under the given path prefix
* `app.host(host, subapp)` - via mounted under the given host

```pydocstring
# root state
app.state.foo = 'bar'
app.state.bar = 'baz'
# subapp scoped state
subapp.state.foo = 'baz'
subapp.state.baz = 'foo'
```

```pydocstring
>>> app.state.foo
'bar'
>>> subapp.state.foo
'baz'
>>> subapp.state.bar
'baz'
>>> app.state.baz
...
AttributeError: 'State' object has no attribute 'baz'
>>> subapp.state.baz
'foo'
```
