### PR TITLE
Show nicer warning when `ujson` isn't installed

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -156,6 +156,7 @@ class UJSONResponse(JSONResponse):
     media_type = "application/json"
 
     def render(self, content: typing.Any) -> bytes:
+        assert ujson is not None, "ujson must be installed to use UJSONResponse"
         return ujson.dumps(content, ensure_ascii=False).encode("utf-8")
 
 


### PR DESCRIPTION
Copying the pattern used in other places, we should show a warning when `ujson` isn't found when trying to use `UJSONResponse`