### PR TITLE
Changing the compression level in GZipMiddleware

### DIFF
--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -6,29 +6,31 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 class GZipMiddleware:
-    def __init__(self, app: ASGIApp, minimum_size: int = 500) -> None:
+    def __init__(self, app: ASGIApp, minimum_size: int = 500, compresslevel: int = 9) -> None:
         self.app = app
         self.minimum_size = minimum_size
+        self.compresslevel = compresslevel
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "http":
             headers = Headers(scope=scope)
             if "gzip" in headers.get("Accept-Encoding", ""):
-                responder = GZipResponder(self.app, self.minimum_size)
+                responder = GZipResponder(self.app, self.minimum_size, self.compresslevel)
                 await responder(scope, receive, send)
                 return
         await self.app(scope, receive, send)
 
 
 class GZipResponder:
-    def __init__(self, app: ASGIApp, minimum_size: int) -> None:
+    def __init__(self, app: ASGIApp, minimum_size: int, compresslevel: int) -> None:
         self.app = app
         self.minimum_size = minimum_size
+        self.compresslevel = compresslevel
         self.send = unattached_send  # type: Send
         self.initial_message = {}  # type: Message
         self.started = False
         self.gzip_buffer = io.BytesIO()
-        self.gzip_file = gzip.GzipFile(mode="wb", fileobj=self.gzip_buffer)
+        self.gzip_file = gzip.GzipFile(mode="wb", fileobj=self.gzip_buffer, compresslevel=self.compresslevel)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         self.send = send

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -6,7 +6,9 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 class GZipMiddleware:
-    def __init__(self, app: ASGIApp, minimum_size: int = 500, compresslevel: int = 9) -> None:
+    def __init__(
+        self, app: ASGIApp, minimum_size: int = 500, compresslevel: int = 9
+    ) -> None:
         self.app = app
         self.minimum_size = minimum_size
         self.compresslevel = compresslevel
@@ -15,7 +17,9 @@ class GZipMiddleware:
         if scope["type"] == "http":
             headers = Headers(scope=scope)
             if "gzip" in headers.get("Accept-Encoding", ""):
-                responder = GZipResponder(self.app, self.minimum_size, self.compresslevel)
+                responder = GZipResponder(
+                    self.app, self.minimum_size, self.compresslevel
+                )
                 await responder(scope, receive, send)
                 return
         await self.app(scope, receive, send)
@@ -30,7 +34,9 @@ class GZipResponder:
         self.initial_message = {}  # type: Message
         self.started = False
         self.gzip_buffer = io.BytesIO()
-        self.gzip_file = gzip.GzipFile(mode="wb", fileobj=self.gzip_buffer, compresslevel=self.compresslevel)
+        self.gzip_file = gzip.GzipFile(
+            mode="wb", fileobj=self.gzip_buffer, compresslevel=self.compresslevel
+        )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         self.send = send


### PR DESCRIPTION
Being one of your users I find the speed of stream compression too slow at times. I strongly believe that adding this feature will benefit a lot of users. It will not interfere with the functionality if not used but will give the users control over the compression level. Sorry for sending this again. This time I made sure it is formatted properly.