### PR TITLE
Ignore gnarly type check in WSGI implementation

### DIFF
--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -88,7 +88,7 @@ class WSGIResponder:
             await run_in_threadpool(self.wsgi, environ, self.start_response)
             self.send_queue.append(None)
             self.send_event.set()
-            await asyncio.wait_for(sender, None)
+            await asyncio.wait_for(sender, None)  # type: ignore
             if self.exc_info is not None:
                 raise self.exc_info[0].with_traceback(
                     self.exc_info[1], self.exc_info[2]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,10 @@
 import os
+from pathlib import Path
 
 import pytest
 
 from starlette.config import Config, Environ, EnvironError
 from starlette.datastructures import URL, Secret
-
-from pathlib import Path
 
 
 def test_config(tmpdir, monkeypatch):
@@ -47,7 +46,7 @@ def test_config(tmpdir, monkeypatch):
         config.get("REQUEST_HOSTNAME", cast=bool)
 
     config = Config(Path(path))
-    REQUEST_HOSTNAME= config("REQUEST_HOSTNAME")
+    REQUEST_HOSTNAME = config("REQUEST_HOSTNAME")
     assert REQUEST_HOSTNAME == "example.com"
 
     config = Config()
@@ -59,6 +58,7 @@ def test_config(tmpdir, monkeypatch):
     monkeypatch.setenv("BOOL_AS_INT", "2")
     with pytest.raises(ValueError):
         config.get("BOOL_AS_INT", cast=bool)
+
 
 def test_environ():
     environ = Environ()


### PR DESCRIPTION
Not going to justify this one.
The mypy checks were passing, and have now started failing, not immediatly obvious what the cleaner fix here is.