### PR TITLE
Fix endpoints doc page example

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -141,7 +141,7 @@ class Echo(WebSocketEndpoint):
 
 routes = [
     Route("/", Homepage),
-    WebSocketRoute("/ws", WebSocketEndpoint)
+    WebSocketRoute("/ws", Echo)
 ]
 
 app = Starlette(routes=routes)


### PR DESCRIPTION
The example isn't working because the wrong class was being used as the WS route.