### PR TITLE
Add space so example is copy-pastable

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -11,7 +11,7 @@ async def homepage(request):
     return PlainTextResponse("Homepage")
 
 async def about(request):
-   return PlainTextResponse("About")
+    return PlainTextResponse("About")
 
 
 routes = [


### PR DESCRIPTION
This change adds a space character to the routing docs so the example is copy-pastable.