### PR TITLE
Added 3rd party package to docs

### DIFF
--- a/docs/third-party-packages.md
+++ b/docs/third-party-packages.md
@@ -63,6 +63,13 @@ type annotations.
 
 The ultimate Python library in building OAuth and OpenID Connect clients and servers. Check out how to integrate with [Starlette](https://docs.authlib.org/en/latest/client/starlette.html).
 
+### Starlette OAuth2 API
+
+<a href="https://gitlab.com/jorgecarleitao/starlette-oauth2-api" target="_blank">Gitlab</a>
+
+A starlette middleware to add authentication and authorization through JWTs.
+It relies solely on an auth provider to issue access and/or id tokens to clients.
+
 ## Frameworks
 
 ### Responder


### PR DESCRIPTION
This adds a new section in 3rd parties with a package to require an authorization header with a valid OAuth2 JWT token. Disclaimer: I am its author.

The main difference in comparison to authlib is that this solves a simpler task than what authlib offers: here we just require and validate JWT tokens issued by external providers (e.g. microsoft, auth0), where the OAuth2 flow was performed elsewhere (e.g. on a SPA, native app, service account).

I am using the same practices as Starlette of 100% coverage, integration tests, and separation of concerns. I am not proposing this to be in this repo as it may not be relevant to every user of starlette and has an external dependency (´python-jose´). I would be fine to have this code in starlette itself though.