### PR TITLE
minor: fix formatting in test_lifespan

### DIFF
--- a/tests/middleware/test_lifespan.py
+++ b/tests/middleware/test_lifespan.py
@@ -24,7 +24,7 @@ def test_routed_lifespan():
     app = Router(
         on_startup=[run_startup],
         on_shutdown=[run_shutdown],
-        routes=[Route("/", hello_world),],
+        routes=[Route("/", hello_world)],
     )
 
     assert not startup_complete


### PR DESCRIPTION
Fixes flake8 issue:

> E231 missing whitespace after ','