### PR TITLE
Fix config doc page examples (starlette==0.13.0)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -128,8 +128,9 @@ application logic separated:
 **myproject/settings.py**:
 
 ```python
+import databases
 from starlette.config import Config
-from starlette.datastructures import URL, Secret
+from starlette.datastructures import Secret
 
 config = Config(".env")
 
@@ -137,7 +138,7 @@ DEBUG = config('DEBUG', cast=bool, default=False)
 TESTING = config('TESTING', cast=bool, default=False)
 SECRET_KEY = config('SECRET_KEY', cast=Secret)
 
-DATABASE_URL = config('DATABASE_URL', cast=URL)
+DATABASE_URL = config('DATABASE_URL', cast=databases.DatabaseURL)
 if TESTING:
     DATABASE_URL = DATABASE_URL.replace(database='test_' + DATABASE_URL.database)
 ```
@@ -160,7 +161,7 @@ organisations = sqlalchemy.Table(
 ```python
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
-from starlette.middleware.session import SessionMiddleware
+from starlette.middleware.sessions import SessionMiddleware
 from starlette.routing import Route
 from myproject import settings
 


### PR DESCRIPTION
Fix two of doc examples (starlette==0.13.0):

- 'URL' (from  starlette.datastructures) object has no attribute 'database'.

- `from starlette.middleware.sessions ...` instead of `from starlette.middleware.session ...`