### PR TITLE
Update/fix type for (Immutable)MultiDict's `*args`

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -237,11 +237,13 @@ class CommaSeparatedStrings(Sequence):
 class ImmutableMultiDict(typing.Mapping):
     def __init__(
         self,
-        *args: typing.Optional[typing.Union[
-            "ImmutableMultiDict",
-            typing.Mapping,
-            typing.List[typing.Tuple[typing.Any, typing.Any]],
-        ]],
+        *args: typing.Optional[
+            typing.Union[
+                "ImmutableMultiDict",
+                typing.Mapping,
+                typing.List[typing.Tuple[typing.Any, typing.Any]],
+            ]
+        ],
         **kwargs: typing.Any,
     ) -> None:
         assert len(args) < 2, "Too many arguments."
@@ -364,11 +366,13 @@ class MultiDict(ImmutableMultiDict):
 
     def update(
         self,
-        *args: typing.Optional[typing.Union[
-            "MultiDict",
-            typing.Mapping,
-            typing.List[typing.Tuple[typing.Any, typing.Any]],
-        ]],
+        *args: typing.Optional[
+            typing.Union[
+                "MultiDict",
+                typing.Mapping,
+                typing.List[typing.Tuple[typing.Any, typing.Any]],
+            ]
+        ],
         **kwargs: typing.Any,
     ) -> None:
         value = MultiDict(*args, **kwargs)

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -237,11 +237,11 @@ class CommaSeparatedStrings(Sequence):
 class ImmutableMultiDict(typing.Mapping):
     def __init__(
         self,
-        *args: typing.Union[
+        *args: typing.Optional[typing.Union[
             "ImmutableMultiDict",
             typing.Mapping,
             typing.List[typing.Tuple[typing.Any, typing.Any]],
-        ],
+        ]],
         **kwargs: typing.Any,
     ) -> None:
         assert len(args) < 2, "Too many arguments."
@@ -364,11 +364,11 @@ class MultiDict(ImmutableMultiDict):
 
     def update(
         self,
-        *args: typing.Union[
+        *args: typing.Optional[typing.Union[
             "MultiDict",
             typing.Mapping,
             typing.List[typing.Tuple[typing.Any, typing.Any]],
-        ],
+        ]],
         **kwargs: typing.Any,
     ) -> None:
         value = MultiDict(*args, **kwargs)


### PR DESCRIPTION
Tested/used in https://github.com/encode/starlette/blob/c80558e0/tests/test_datastructures.py#L325

Not included in https://github.com/encode/starlette/pull/777 since this is not clear to me.

Fixes:

> tests/test_datastructures.py:326: error: Argument 1 to "update" of "MultiDict" has incompatible type "None"; expected "Union[MultiDict, Mapping[Any, Any], List[Tuple[Any, Any]]]"
