### PR TITLE
ci: Travis: use py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: pip
 python:
     - "3.6"
     - "3.7"
-    - "3.8-dev"
+    - "3.8"
 
 install:
     - pip install -U -r requirements.txt


### PR DESCRIPTION
Note that "3.9-dev" appears to not be available yet.