### PR TITLE
ServerErrorMiddleware: generate_html: do not capture locals

### DIFF
--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -208,9 +208,7 @@ class ServerErrorMiddleware:
         return FRAME_TEMPLATE.format(**values)
 
     def generate_html(self, exc: Exception, limit: int = 7) -> str:
-        traceback_obj = traceback.TracebackException.from_exception(
-            exc, capture_locals=True
-        )
+        traceback_obj = traceback.TracebackException.from_exception(exc)
         frames = inspect.getinnerframes(
             traceback_obj.exc_traceback, limit  # type: ignore
         )


### PR DESCRIPTION
This might causes errors via `repr`, and is not necessary/used in the
first place.

Ref: https://bugs.python.org/issue39228