### PR TITLE
Add support for contextlib-like lifecycle handlers.

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -5,8 +5,9 @@ is shutting down.
 
 ## Registering events
 
-These event handlers can either be `async` coroutines, or regular syncronous
-functions.
+These event handlers can either be `async` coroutines, or regular synchronous
+functions. In case of the startup event, it can also be an `async` generator
+or a regular synchronous generator.
 
 The event handlers should be included on the application like so:
 
@@ -20,13 +21,17 @@ async def some_startup_task():
 async def some_shutdown_task():
     pass
 
+async def some_startup_generator():
+    async with SomeContextManager():
+        yield  # Control is returned when shutdown is initiated.
+
 routes = [
     ...
 ]
 
 app = Starlette(
     routes=routes,
-    on_startup=[some_startup_task],
+    on_startup=[some_startup_task, some_startup_generator],
     on_shutdown=[some_shutdown_task]
 )
 ```

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -535,6 +535,8 @@ class Router:
                     pass
                 else:
                     raise RuntimeError("async generator did not exit")
+                finally:
+                    await typing.cast(typing.AsyncGenerator[None, None], gen).aclose()
             else:
                 try:
                     next(typing.cast(typing.Generator[None, None, None], gen))
@@ -542,6 +544,8 @@ class Router:
                     pass
                 else:
                     raise RuntimeError("generator did not exit")
+                finally:
+                    typing.cast(typing.Generator[None, None, None], gen).close()
 
     async def lifespan(self, scope: Scope, receive: Receive, send: Send) -> None:
         """

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -497,13 +497,13 @@ class Router:
         for handler in self.on_startup:
             if inspect.isasyncgenfunction(handler):
                 gen = handler()
-                await gen.asend(None)
+                await gen.__anext__()
                 self.lifecycle_generators.append(gen)
             elif asyncio.iscoroutinefunction(handler):
                 await handler()
             elif inspect.isgeneratorfunction(handler):
                 gen = handler()
-                gen.send(None)
+                next(gen)
                 self.lifecycle_generators.append(gen)
             else:
                 handler()
@@ -522,14 +522,14 @@ class Router:
             gen = self.lifecycle_generators.pop()
             if inspect.isasyncgen(gen):
                 try:
-                    await typing.cast(typing.AsyncGenerator[None, None], gen).asend(
-                        None
-                    )
+                    await typing.cast(
+                        typing.AsyncGenerator[None, None], gen
+                    ).__anext__()
                 except StopAsyncIteration:
                     pass
             else:
                 try:
-                    typing.cast(typing.Generator[None, None, None], gen).send(None)
+                    next(typing.cast(typing.Generator[None, None, None], gen))
                 except StopIteration:
                     pass
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -462,7 +462,9 @@ class Router:
         self.on_startup = [] if on_startup is None else list(on_startup)
         self.on_shutdown = [] if on_shutdown is None else list(on_shutdown)
         self.lifecycle_generators: typing.List[
-            typing.Union[typing.AsyncIterator[None], typing.Iterator[None]]
+            typing.Union[
+                typing.AsyncGenerator[None, None], typing.Generator[None, None, None]
+            ]
         ] = []
 
     async def not_found(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -520,12 +522,14 @@ class Router:
             gen = self.lifecycle_generators.pop()
             if inspect.isasyncgen(gen):
                 try:
-                    await typing.cast(typing.AsyncIterator[None], gen).__anext__()
+                    await typing.cast(
+                        typing.AsyncGenerator[None, None], gen
+                    ).__anext__()
                 except StopAsyncIteration:
                     pass
             else:
                 try:
-                    next(typing.cast(typing.Iterator[None], gen))
+                    next(typing.cast(typing.Generator[None, None, None], gen))
                 except StopIteration:
                     pass
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -462,9 +462,7 @@ class Router:
         self.on_startup = [] if on_startup is None else list(on_startup)
         self.on_shutdown = [] if on_shutdown is None else list(on_shutdown)
         self.lifecycle_generators: typing.List[
-            typing.Union[
-                typing.AsyncGenerator[None, None], typing.Generator[None, None, None]
-            ]
+            typing.Union[typing.AsyncIterator[None], typing.Iterator[None]]
         ] = []
 
     async def not_found(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -522,14 +520,12 @@ class Router:
             gen = self.lifecycle_generators.pop()
             if inspect.isasyncgen(gen):
                 try:
-                    await typing.cast(
-                        typing.AsyncGenerator[None, None], gen
-                    ).__anext__()
+                    await typing.cast(typing.AsyncIterator[None], gen).__anext__()
                 except StopAsyncIteration:
                     pass
             else:
                 try:
-                    next(typing.cast(typing.Generator[None, None, None], gen))
+                    next(typing.cast(typing.Iterator[None], gen))
                 except StopIteration:
                     pass
 

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -280,3 +280,49 @@ def test_app_add_event_handler():
         assert not cleanup_complete
     assert startup_complete
     assert cleanup_complete
+
+
+def test_app_add_event_handler_generator():
+    startup_complete = False
+    cleanup_complete = False
+    app = Starlette()
+
+    def run_startup():
+        nonlocal startup_complete
+        nonlocal cleanup_complete
+        startup_complete = True
+        yield
+        cleanup_complete = True
+
+    app.add_event_handler("startup", run_startup)
+
+    assert not startup_complete
+    assert not cleanup_complete
+    with TestClient(app):
+        assert startup_complete
+        assert not cleanup_complete
+    assert startup_complete
+    assert cleanup_complete
+
+
+def test_app_add_event_handler_async_generator():
+    startup_complete = False
+    cleanup_complete = False
+    app = Starlette()
+
+    async def run_startup():
+        nonlocal startup_complete
+        nonlocal cleanup_complete
+        startup_complete = True
+        yield
+        cleanup_complete = True
+
+    app.add_event_handler("startup", run_startup)
+
+    assert not startup_complete
+    assert not cleanup_complete
+    with TestClient(app):
+        assert startup_complete
+        assert not cleanup_complete
+    assert startup_complete
+    assert cleanup_complete


### PR DESCRIPTION
These changes allow the startup event handlers to be an (async) generator to which control is returned when the shutdown handlers are called. This can be useful when trying to control another object's lifecycle if that object provides a(n) (asynchronous) context manager.

The control will be returned to perform shutdown operations in reverse order of how the lifecycle generators were added.

f.e.

```
async def prepare_database():
    async with db.ConnectionPool() as pool:
        app.state.pool = pool
        try:
            yield  # Control will be returned during shutdown event.
        finally:
            del app.state.pool

app = Starlette(on_startup=[prepare_database])
````
