### PR TITLE
Security patch: Updating CORS origin regex to use a full regex match

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -87,7 +87,7 @@ class CORSMiddleware:
         if self.allow_all_origins:
             return True
 
-        if self.allow_origin_regex is not None and self.allow_origin_regex.match(
+        if self.allow_origin_regex is not None and self.allow_origin_regex.fullmatch(
             origin
         ):
             return True

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -191,7 +191,10 @@ def test_cors_allow_origin_regex_fullmatch():
     response = client.get("/", headers=headers)
     assert response.status_code == 200
     assert response.text == "Homepage"
-    assert response.headers["access-control-allow-origin"] == "https://subdomain.example.org"
+    assert (
+        response.headers["access-control-allow-origin"]
+        == "https://subdomain.example.org"
+    )
 
     # Test diallowed standard response
     headers = {"Origin": "https://subdomain.example.org.hacker.com"}

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -122,7 +122,7 @@ def test_cors_allow_origin_regex():
     app.add_middleware(
         CORSMiddleware,
         allow_headers=["X-Example", "Content-Type"],
-        allow_origin_regex="https://*",
+        allow_origin_regex="https://.*",
     )
 
     @app.route("/")
@@ -168,6 +168,36 @@ def test_cors_allow_origin_regex():
     response = client.options("/", headers=headers)
     assert response.status_code == 400
     assert response.text == "Disallowed CORS origin"
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_cors_allow_origin_regex_fullmatch():
+    app = Starlette()
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_headers=["X-Example", "Content-Type"],
+        allow_origin_regex="https://.*\.example.org",
+    )
+
+    @app.route("/")
+    def homepage(request):
+        return PlainTextResponse("Homepage", status_code=200)
+
+    client = TestClient(app)
+
+    # Test standard response
+    headers = {"Origin": "https://subdomain.example.org"}
+    response = client.get("/", headers=headers)
+    assert response.status_code == 200
+    assert response.text == "Homepage"
+    assert response.headers["access-control-allow-origin"] == "https://subdomain.example.org"
+
+    # Test diallowed standard response
+    headers = {"Origin": "https://subdomain.example.org.hacker.com"}
+    response = client.get("/", headers=headers)
+    assert response.status_code == 200
+    assert response.text == "Homepage"
     assert "access-control-allow-origin" not in response.headers
 
 


### PR DESCRIPTION
This patches a security vulnerability with CORS Middleware. By using a regular expression `match`, it leaves it to the implementer to ensure that the passed-in regex properly handles start/end of the string. The example documentation shows `https://.*\.example\.org`, which, when used with `match`, would return True for `https://.*\.example\.org.evil.com`.

Closes #800