### PR TITLE
Add "raw_path" to TestClient request scope

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -134,7 +134,7 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
             scope = {
                 "type": "websocket",
                 "path": unquote(path),
-                "raw_path": path,
+                "raw_path": path.encode(),
                 "root_path": self.root_path,
                 "scheme": scheme,
                 "query_string": query.encode(),
@@ -151,7 +151,7 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
             "http_version": "1.1",
             "method": request.method,
             "path": unquote(path),
-            "raw_path": path,
+            "raw_path": path.encode(),
             "root_path": self.root_path,
             "scheme": scheme,
             "query_string": query.encode(),

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -134,6 +134,7 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
             scope = {
                 "type": "websocket",
                 "path": unquote(path),
+                "raw_path": path,
                 "root_path": self.root_path,
                 "scheme": scheme,
                 "query_string": query.encode(),
@@ -150,6 +151,7 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
             "http_version": "1.1",
             "method": request.method,
             "path": unquote(path),
+            "raw_path": path,
             "root_path": self.root_path,
             "scheme": scheme,
             "query_string": query.encode(),

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -188,7 +188,7 @@ def test_request_raw_path():
 
     client = TestClient(app)
     response = client.get("/he%2Fllo")
-    assert response.text == "/he/llo, /he%2Fllo"
+    assert response.text == "/he/llo, b'/he%2Fllo'"
 
 
 def test_request_without_setting_receive():

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 
 from starlette.requests import ClientDisconnect, Request, State
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.testclient import TestClient
 
 
@@ -176,6 +176,19 @@ def test_request_scope_interface():
     assert request["method"] == "GET"
     assert dict(request) == {"type": "http", "method": "GET", "path": "/abc/"}
     assert len(request) == 3
+
+
+def test_request_raw_path():
+    async def app(scope, receive, send):
+        request = Request(scope, receive)
+        path = request.scope["path"]
+        raw_path = request.scope["raw_path"]
+        response = PlainTextResponse(f"{path}, {raw_path}")
+        await response(scope, receive, send)
+
+    client = TestClient(app)
+    response = client.get("/he%2Fllo")
+    assert response.text == "/he/llo, /he%2Fllo"
 
 
 def test_request_without_setting_receive():


### PR DESCRIPTION
`raw_path` was missing in `TestClient` request's scope, whereas `uvicorn` has `raw_path` in request's scope. This problem makes it impossible to write tests, when parsing raw path is necessary.

I've created this app to prove this:
```
> cat example.py
from starlette.applications import Starlette
from starlette.responses import PlainTextResponse
from starlette.routing import Route
from starlette.testclient import TestClient


async def value(request):
    value = request.path_params['value']
    path = request.scope['path']
    raw_path = request.scope['raw_path']
    return PlainTextResponse(
        f'value: {value}\npath: {path}\nraw_path: {raw_path}\n'
    )


app = Starlette(debug=True, routes=[
    Route('/{value:path}', value),
])


def test_app():
    client = TestClient(app)
    response = client.get('/hel%2Flo')  # /hel/lo
    result = "value: hel/lo\npath: /hel/lo\nraw_path: /hel%2Flo\n"
    assert response.text == result
```

Launch the app with `uvicorn`:

```
> env/bin/uvicorn example:app
```

Test it with `curl`:

```
> curl localhost:8000/hel%2flo
value: hel/lo
path: /hel/lo
raw_path: b'/hel%2flo'
```

Test app with `TestClient`:

```
> env/bin/python -c "import example; example.test_app()"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/justas/work/tilaajavastuu/starlette_test/example.py", line 28, in test_app
    response = client.get('/hel%2Flo')  # /hel/lo
<...>
  File "/Users/justas/work/tilaajavastuu/starlette_test/example.py", line 14, in value
    raw_path = request.scope['raw_path']
KeyError: 'raw_path'
```
