### PR TITLE
Provide function to use ujson for request body parsing

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -81,7 +81,7 @@ The request body as bytes: `await request.body()`
 
 The request body, parsed as form data or multipart: `await request.form()`
 
-The request body, parsed as JSON: `await request.json()`
+The request body, parsed as JSON: `await request.json()` or, if `ujson` is installed, `await request.ujson()`
 
 You can also access the request body as a stream, using the `async for` syntax:
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -9,6 +9,11 @@ from starlette.formparsers import FormParser, MultiPartParser
 from starlette.types import Message, Receive, Scope, Send
 
 try:
+    import ujson
+except ImportError:  # pragma: nocover
+    ujson = None  # type: ignore
+
+try:
     from multipart.multipart import parse_options_header
 except ImportError:  # pragma: nocover
     parse_options_header = None
@@ -199,7 +204,10 @@ class Request(HTTPConnection):
     async def json(self) -> typing.Any:
         if not hasattr(self, "_json"):
             body = await self.body()
-            self._json = json.loads(body)
+            if ujson is not None:
+                self._json = ujson.loads(body)
+            else:
+                self._json = json.loads(body)
         return self._json
 
     async def form(self) -> FormData:

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -204,10 +204,14 @@ class Request(HTTPConnection):
     async def json(self) -> typing.Any:
         if not hasattr(self, "_json"):
             body = await self.body()
-            if ujson is not None:
-                self._json = ujson.loads(body)
-            else:
-                self._json = json.loads(body)
+            self._json = json.loads(body)
+        return self._json
+
+    async def ujson(self) -> typing.Any:
+        if not hasattr(self, "_json"):
+            assert ujson is not None, "ujson must be installed to use Request.ujson()"
+            body = await self.body()
+            self._json = ujson.loads(body)
         return self._json
 
     async def form(self) -> FormData:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -167,6 +167,18 @@ def test_request_json():
     assert response.json() == {"json": {"a": "123"}}
 
 
+def test_request_ujson():
+    async def app(scope, receive, send):
+        request = Request(scope, receive)
+        data = await request.ujson()
+        response = JSONResponse({"json": data})
+        await response(scope, receive, send)
+
+    client = TestClient(app)
+    response = client.post("/", json={"a": "123"})
+    assert response.json() == {"json": {"a": "123"}}
+
+
 def test_request_scope_interface():
     """
     A Request can be instantiated with a scope, and presents a `Mapping`


### PR DESCRIPTION
Allow users to utilize `ujson` to parse JSON request bodies using `Request.ujson()`

May be redundant as users could simply get the body and parse using ujson themselves, though the same is true for `Request.json()`