### PR TITLE
Add Starlette.create_router method

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -48,12 +48,20 @@ class Starlette:
     ) -> None:
         self._debug = debug
         self.state = State()
-        self.router = Router(routes, on_startup=on_startup, on_shutdown=on_shutdown)
+        self.router = self.create_router(routes, on_startup, on_shutdown)
         self.exception_handlers = (
             {} if exception_handlers is None else dict(exception_handlers)
         )
         self.user_middleware = [] if middleware is None else list(middleware)
         self.middleware_stack = self.build_middleware_stack()
+
+    def create_router(
+        self,
+        routes: typing.Sequence[BaseRoute] = None,
+        on_startup: typing.Sequence[typing.Callable] = None,
+        on_shutdown[typing.Callable] = None
+    ) -> Router:
+        return Router(routes, on_startup=on_startup, on_shutdown=on_shutdown)
 
     def build_middleware_stack(self) -> ASGIApp:
         debug = self.debug


### PR DESCRIPTION
This makes it easier to change the `Router` class used by `Starlette`. The specific use case is that I want to be able to use a dependency injection framework by overriding `Router.handle` in a custom router.

The current solution is to create a custom `Starlette` and copy-paste the constructor, which is not the best solution. This would make it much robuster.