### PR TITLE
Fix naive debugger line numbers in ServerErrorMiddleware

### DIFF
--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -178,23 +178,21 @@ class ServerErrorMiddleware:
             raise exc from None
 
     def format_line(
-        self, position: int, line: str, frame_lineno: int, center_lineno: int
+        self, index: int, line: str, frame_lineno: int, frame_index: int
     ) -> str:
         values = {
             "line": line.replace(" ", "&nbsp"),
-            "lineno": frame_lineno + (position - center_lineno),
+            "lineno": (frame_lineno - frame_index) + index,
         }
 
-        if position != center_lineno:
+        if index != frame_index:
             return LINE.format(**values)
         return CENTER_LINE.format(**values)
 
-    def generate_frame_html(
-        self, frame: inspect.FrameInfo, center_lineno: int, is_collapsed: bool
-    ) -> str:
+    def generate_frame_html(self, frame: inspect.FrameInfo, is_collapsed: bool) -> str:
         code_context = "".join(
-            self.format_line(context_position, line, frame.lineno, center_lineno)
-            for context_position, line in enumerate(frame.code_context or [])
+            self.format_line(index, line, frame.lineno, frame.index)  # type: ignore
+            for index, line in enumerate(frame.code_context or [])
         )
 
         values = {
@@ -215,11 +213,10 @@ class ServerErrorMiddleware:
             traceback_obj.exc_traceback, limit  # type: ignore
         )
 
-        center_lineno = int((limit - 1) / 2)
         exc_html = ""
         is_collapsed = False
         for frame in reversed(frames):
-            exc_html += self.generate_frame_html(frame, center_lineno, is_collapsed)
+            exc_html += self.generate_frame_html(frame, is_collapsed)
             is_collapsed = True
 
         error = f"{traceback_obj.exc_type.__name__}: {html.escape(str(traceback_obj))}"


### PR DESCRIPTION
Previously the error middleware in debug mode would naively calculate the line numbers without knowledge of the position in the file. This meant that if the exception occurred near the top or bottom of the file, the line numbers and the highlighted line would be incorrect. The named tuple returned by `inspect.getinnerframes` contains an `index` field which is not naive and will result in correct line numbers. This change also simplifies the code somewhat.

Below is a short demonstration of the problem:

```python
def error(): return 4/0                                 # 1
import uvicorn                                          # 2
from starlette.applications import Starlette            # 3
                                                        # 4
app = Starlette(debug=True)                             # 5
                                                        # 6
@app.route("/")                                         # 7
async def route(_):                                     # 8
        error()                                         # 9
                                                        # 10
uvicorn.run(app, port=2351, debug=True)                 # 11
```
![screenshot](http://i.imgur.com/nGDIZPW.png)

I didn't open an issue for this since I thought it's a pretty simple bug-fix. I also haven't added any tests - I'm not sure they're really necessary, but correct me if I'm wrong.