### PR TITLE
Ensure pyyaml is installed before actually using it

### DIFF
--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -89,6 +89,8 @@ class BaseSchemaGenerator:
         if not docstring:
             return {}
 
+        assert yaml is not None, "`pyyaml` must be installed to use parse_docstring."
+
         # We support having regular docstrings before the schema
         # definition. Here we return just the schema part from
         # the docstring.

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,6 +1,3 @@
-import pytest
-
-import starlette.schemas
 from starlette.applications import Starlette
 from starlette.endpoints import HTTPEndpoint
 from starlette.schemas import SchemaGenerator
@@ -221,23 +218,3 @@ def test_schema_endpoint():
     response = client.get("/schema")
     assert response.headers["Content-Type"] == "application/vnd.oai.openapi"
     assert response.text.strip() == EXPECTED_SCHEMA.strip()
-
-
-def test_schema_docstring_parsing_without_yaml(monkeypatch):
-    # Simulate the fact that yaml cannot be imported
-    monkeypatch.setattr(starlette.schemas, "yaml", None)
-
-    def dummy():
-        """
-        responses:
-          200:
-            description: This is a description.
-        """
-        pass  # pragma: no cover
-
-    with pytest.raises(AssertionError) as exception_info:
-        schemas.parse_docstring(dummy)
-    assert (
-        str(exception_info.value)
-        == "`pyyaml` must be installed to use parse_docstring."
-    )


### PR DESCRIPTION
To avoid non user-friendly error message (NoneType does not have attribute whatever)