### PR TITLE
Add check on content being falsy before dumping the content into JSON / UJSON dumps

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -143,6 +143,8 @@ class JSONResponse(Response):
     media_type = "application/json"
 
     def render(self, content: typing.Any) -> bytes:
+        if not content:
+            return b""
         return json.dumps(
             content,
             ensure_ascii=False,
@@ -156,6 +158,8 @@ class UJSONResponse(JSONResponse):
     media_type = "application/json"
 
     def render(self, content: typing.Any) -> bytes:
+        if not content:
+            return b""
         assert ujson is not None, "ujson must be installed to use UJSONResponse"
         return ujson.dumps(content, ensure_ascii=False).encode("utf-8")
 


### PR DESCRIPTION
json.dumps(None) results to "null" and encodes to b"null" which is not the correct return value.