### PR TITLE
Add listener task to cancel streaming response in case of an early disconnect

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -1,4 +1,3 @@
-import asyncio
 import hashlib
 import http.cookies
 import inspect


### PR DESCRIPTION
Related to #20

This one is to fix an ongoing stream to an already disconnected client.

All the existing tests are passed, however I'd like to add one to cover a scenario when a `"http.disconnect"` message is sent via the `receive` channel, @tomchristie maybe you could suggest some sort of setup for such a test?