### PR TITLE
adding authlib middleware

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -273,3 +273,8 @@ A middleware class for logging exceptions to [Bugsnag](https://www.bugsnag.com/)
 #### [EarlyDataMiddleware](https://github.com/HarrySky/starlette-early-data)
 
 Middleware and decorator for detecting and denying [TLSv1.3 early data](https://tools.ietf.org/html/rfc8470) requests.
+
+#### [AuthlibMiddleware](https://github.com/aogier/starlette-authlib)
+
+A drop-in replacement for Starlette session middleware, using [authlib's jwt](https://docs.authlib.org/en/latest/jose/jwt.html)
+module.


### PR DESCRIPTION
Hello! I'm writing a Starlette-based SSO application that will protect a series of applications written in many languages.  
As such, I've found using authlib's jwt more viable than itsdangerous mainly because developers can consume my claims/data using JWT libraries that already exists for many languages. I'd be glad if you could consider to include my third party middleware to your manual, this PR add a link to the project. What do you think?

Thank you for starlette, and have a nice day! :)