### PR TITLE
feat: documentation for 3rd party response types: SSEResponse

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -176,3 +176,10 @@ async def app(scope, receive, send):
     response = FileResponse('statics/favicon.ico')
     await response(scope, receive, send)
 ```
+
+## Third party middleware
+
+### [SSEResponse(EventSourceResponse)](https://github.com/sysid/sse-starlette)
+
+Server Sent Response implements the ServerSentEvent Protocol: https://www.w3.org/TR/2009/WD-eventsource-20090421.  
+It enables event streaming from the server to the client without the complexity of websockets.


### PR DESCRIPTION
As per our discussion: [SSE Response](https://github.com/encode/starlette/pull/757#issuecomment-590249776).

Pull request for update of response documentation to include link to 3rd party response types.