### PR TITLE
allow exceptions in middleware to surface when using TestClient

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -471,6 +471,8 @@ class TestClient(requests.Session):
     async def wait_startup(self) -> None:
         await self.receive_queue.put({"type": "lifespan.startup"})
         message = await self.send_queue.get()
+        if message is None:
+            self.task.result()
         assert message["type"] in (
             "lifespan.startup.complete",
             "lifespan.startup.failed",


### PR DESCRIPTION
Since I hit this again this morning, here's the fix for the `TypeError: 'NoneType' object is not subscriptable` when middleware raises an exception and you're using `TestClient` that I mentioned on #887.

