### PR TITLE
fix #794 handle requires when request is in kwargs

### DIFF
--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -57,7 +57,9 @@ def requires(
             async def async_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> Response:
-                request = kwargs.get("request", args[idx])
+                request = kwargs.get("request")
+                if request is None:
+                    request = args[idx]
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):
@@ -72,7 +74,9 @@ def requires(
             # Handle sync request/response functions.
             @functools.wraps(func)
             def sync_wrapper(*args: typing.Any, **kwargs: typing.Any) -> Response:
-                request = kwargs.get("request", args[idx])
+                request = kwargs.get("request")
+                if request is None:
+                    request = args[idx]
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):


### PR DESCRIPTION
the decorator was failing because in the case `request` was in kwargs
it was not in `args`, but we were still executing the line `args[idx]` which was
causing an IndexError exception

@tomchristie  this issue is a bit problematic, because it makes the `@requires` decorator unusable with fastapi (at least) 