### PR TITLE
Switch to a more lenient cookie parsing method

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -1,5 +1,5 @@
 import asyncio
-import http.cookies
+from http import cookies as http_cookies
 import json
 import typing
 from collections.abc import Mapping
@@ -21,6 +21,33 @@ SERVER_PUSH_HEADERS_TO_COPY = {
     "cache-control",
     "user-agent",
 }
+
+
+def cookie_parser(cookie_string: str) -> typing.Dict[str, str]:
+    """
+    This function parses a ``Cookie`` HTTP header into a dict of key/value pairs.
+
+    It attempts to mimic browser cookie parsing behavior: browsers and web servers
+    frequently disregard the spec (RFC 6265) when setting and reading cookies,
+    so we attempt to suit the common scenarios here.
+
+    This function has been adapted from Django 3.1.0.
+    Note: we are explicitly _NOT_ using `SimpleCookie.load` because it is based
+    on an outdated spec and will fail on lots of input we want to support
+    """
+    cookie_dict: typing.Dict[str, str] = {}
+    for chunk in cookie_string.split(";"):
+        if "=" in chunk:
+            key, val = chunk.split("=", 1)
+        else:
+            # Assume an empty name per
+            # https://bugzilla.mozilla.org/show_bug.cgi?id=169091
+            key, val = "", chunk
+        key, val = key.strip(), val.strip()
+        if key or val:
+            # unquote using Python's algorithm.
+            cookie_dict[key] = http_cookies._unquote(val)  # type: ignore
+    return cookie_dict
 
 
 class ClientDisconnect(Exception):
@@ -87,16 +114,11 @@ class HTTPConnection(Mapping):
     @property
     def cookies(self) -> typing.Dict[str, str]:
         if not hasattr(self, "_cookies"):
-            cookies = {}
+            cookies: typing.Dict[str, str] = {}
             cookie_header = self.headers.get("cookie")
+
             if cookie_header:
-                cookie = http.cookies.SimpleCookie()  # type: http.cookies.BaseCookie
-                try:
-                    cookie.load(cookie_header)
-                except http.cookies.CookieError:
-                    pass
-                for key, morsel in cookie.items():
-                    cookies[key] = morsel.value
+                cookies = cookie_parser(cookie_header)
             self._cookies = cookies
         return self._cookies
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -371,7 +371,7 @@ def test_cookies_edge_cases(set_cookie, expected):
         # Unicode characters. The spec only allows ASCII.
         # ("saint=André Bessette", {"saint": "André Bessette"}),
         # Browsers don't send extra whitespace or semicolons in Cookie headers,
-        # but parse_cookie() should parse whitespace the same way
+        # but cookie_parser() should parse whitespace the same way
         # document.cookie parses whitespace.
         # ("  =  b  ;  ;  =  ;   c  =  ;  ", {"": "b", "c": ""}),
     ],


### PR DESCRIPTION
This PR is for issue #898, requesting a more lenient cookie-parsing technique for Starlette. @tomchristie requested a failing test to start, so that's what has been included here. I reused the example from my issue. Happy to modify or update as desired by the maintainers.