### PR TITLE
Docs: Update middleware.md - CORS max_age 600

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -73,7 +73,7 @@ The following arguments are supported:
 * `allow_headers` - A list of HTTP request headers that should be supported for cross-origin requests. Defaults to `[]`. You can use `['*']` to allow all headers. The `Accept`, `Accept-Language`, `Content-Language` and `Content-Type` headers are always allowed for CORS requests.
 * `allow_credentials` - Indicate that cookies should be supported for cross-origin requests. Defaults to `False`.
 * `expose_headers` - Indicate any response headers that should be made accessible to the browser. Defaults to `[]`.
-* `max_age` - Sets a maximum time in seconds for browsers to cache CORS responses. Defaults to `60`.
+* `max_age` - Sets a maximum time in seconds for browsers to cache CORS responses. Defaults to `600`.
 
 The middleware responds to two particular types of HTTP request...
 


### PR DESCRIPTION
Update max_age documentation from 60 to the actual default value of 600.
https://github.com/encode/starlette/blob/master/starlette/middleware/cors.py#L23