### PR TITLE
Proposal: Custom Request Classes using type annotations

### DIFF
--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -85,7 +85,13 @@ class ExceptionMiddleware:
                 msg = "Caught handled exception, but response already started."
                 raise RuntimeError(msg) from exc
 
-            request = Request(scope, receive=receive)
+            request_class = handler.__annotations__.get("request", Request)
+            if not issubclass(request_class, Request):
+                raise TypeError(
+                    "Custom Request classes must subclass `starlette.requests.Request`"
+                )
+
+            request = request_class(scope, receive=receive)
             if asyncio.iscoroutinefunction(handler):
                 response = await handler(request, exc)
             else:

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -21,7 +21,13 @@ class BaseHTTPMiddleware:
             await self.app(scope, receive, send)
             return
 
-        request = Request(scope, receive=receive)
+        request_class = self.dispatch_func.__annotations__.get("request", Request)
+        if not issubclass(request_class, Request):
+            raise TypeError(
+                "Custom Request classes must subclass `starlette.requests.Request`"
+            )
+
+        request = request_class(scope, receive=receive)
         response = await self.dispatch_func(request, self.call_next)
         await response(scope, receive, send)
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -36,7 +36,13 @@ def request_response(func: typing.Callable) -> ASGIApp:
     is_coroutine = asyncio.iscoroutinefunction(func)
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request(scope, receive=receive, send=send)
+        request_class = func.__annotations__.get("request", Request)
+        if not issubclass(request_class, Request):
+            raise TypeError(
+                "Custom Request classes must subclass `starlette.requests.Request`"
+            )
+
+        request = request_class(scope, receive=receive, send=send)
         if is_coroutine:
             response = await func(request)
         else:


### PR DESCRIPTION
This PR is a proof-of-concept exploring support for custom request classes in Starlette (related issues: #715, #388). I wanted to open this PR as a discussion point: there are certainly other ways to implement custom request classes in Starlette. 

To use a custom request class under the changes here, you can simply provide a custom request class type annotation for your request handler.

Here's an example:

```python
class CustomRequest(Request):
    @property
    def custom(self):
        return "Something Custom"


app = Starlette()


@app.route("/regular")
async def reqular_req(request):
    return PlainTextResponse(request.__class__.__name__)


@app.route("/custom")
async def custom(request: CustomRequest):
    return PlainTextResponse(f"{request.__class__.__name__}: {request.custom}")
```

Results can be seen here:

```
In [1]: import requests                                                                        

In [2]: requests.get("http://localhost:8000/regular").content                                  
Out[2]: b'Request'

In [3]: requests.get("http://localhost:8000/custom").content                                   
Out[3]: b'CustomRequest: Something Custom'
```

## Changes

- Use `request` arg type annotation to instantiate custom request classes.
- Add tests for the above.

## Notes

- The module `starlette.middleware.errors` has not been changed.
- No documentation changes have been made here; this PR is for gathering feedback.
- This code will throw a `TypeError` if there _is_ a type annotation for the `request` arg and that annotation _is not_ a subclass of `starlette.requests.Request`.

## Discussion

I am unsure how people will respond to this proposal. I had a couple of other ideas, but this one seemed ergonomic for end users because it's a small code change, and allows adding any custom request class _for any particular endpoint_ where one is desired. I have tried to break down some of the pros and cons below.

### Pros

- Small code change for users: add a type annotation where a custom request class is desired.
- Allows custom-request classes _per handler_ instead of globally.
- Makes explicit the request class being used for a particular handler.
- Does not affect existing users or anyone who doesn't care about having custom request classes (this seems like a requirement for any solution to this problem).

### Cons

- Potentially surprising and unpythonic: runtime behavior changes based on a type annotation (although, to be fair, other libraries are doing things like this now: [Pydantic](https://pydantic-docs.helpmanual.io/) and [ecological](https://pypi.org/project/ecological/) come to mind).
- Looks for annotation _specifically_ for the arg named `"request"`, which means this wouldn't work: `def a_handler(req: CustomRequest):` because arg-name is not "request". (We could alternately look at first arg and pull annotation for it)
- Doesn't handle the bug where someone types `def a_handler(req: List[str])` or something that's not callable; another way to say this is that it takes advantage of the fact that the type annotation _is_ a class definition.
- Does not globally change requests: some users may wish to have a single place to swap the Request class for _all_ handlers (this can be solved in other ways, I think).