### PR TITLE
Allow path to contain regex meta characters

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -107,7 +107,7 @@ def compile_path(
         ), f"Unknown path convertor '{convertor_type}'"
         convertor = CONVERTOR_TYPES[convertor_type]
 
-        path_regex += path[idx : match.start()]
+        path_regex += re.escape(path[idx : match.start()])
         path_regex += f"(?P<{param_name}>{convertor.regex})"
 
         path_format += path[idx : match.start()]
@@ -117,7 +117,7 @@ def compile_path(
 
         idx = match.end()
 
-    path_regex += path[idx:] + "$"
+    path_regex += re.escape(path[idx:]) + "$"
     path_format += path[idx:]
 
     return re.compile(path_regex), path_format, param_convertors

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -83,16 +83,9 @@ def uuid_converter(request):
     return JSONResponse({"uuid": str(uuid_param)})
 
 
-# OData string entity key
-@app.route("/strentity('{param:str}')", name="strentity")
-def strentity(request):
-    text = request.path_params["param"]
-    return JSONResponse({"str": text})
-
-
-# OData integer entity key
-@app.route("/intentity({param:int})", name="intentity")
-def intentity(request):
+# Route with chars that conflict with regex meta chars
+@app.route("/path-with-parentheses({param:int})", name="path-with-parentheses")
+def path_with_parentheses(request):
     number = request.path_params["param"]
     return JSONResponse({"int": number})
 
@@ -160,17 +153,14 @@ def test_route_converters():
     assert response.json() == {"int": 5}
     assert app.url_path_for("int-convertor", param=5) == "/int/5"
 
-    # Test str for OData style path
-    response = client.get("/strentity('ascii')")
-    assert response.status_code == 200
-    assert response.json() == {"str": "ascii"}
-    assert app.url_path_for("strentity", param="ascii") == "/strentity('ascii')"
-
-    # Test integer for OData style path
-    response = client.get("/intentity(7)")
+    # Test path with parentheses
+    response = client.get("/path-with-parentheses(7)")
     assert response.status_code == 200
     assert response.json() == {"int": 7}
-    assert app.url_path_for("intentity", param=7) == "/intentity(7)"
+    assert (
+        app.url_path_for("path-with-parentheses", param=7)
+        == "/path-with-parentheses(7)"
+    )
 
     # Test float conversion
     response = client.get("/float/25.5")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -83,6 +83,20 @@ def uuid_converter(request):
     return JSONResponse({"uuid": str(uuid_param)})
 
 
+# OData string entity key
+@app.route("/strentity('{param:str}')", name="strentity")
+def strentity(request):
+    text = request.path_params["param"]
+    return JSONResponse({"str": text})
+
+
+# OData integer entity key
+@app.route("/intentity({param:int})", name="intentity")
+def intentity(request):
+    number = request.path_params["param"]
+    return JSONResponse({"int": number})
+
+
 @app.websocket_route("/ws")
 async def websocket_endpoint(session):
     await session.accept()
@@ -145,6 +159,18 @@ def test_route_converters():
     assert response.status_code == 200
     assert response.json() == {"int": 5}
     assert app.url_path_for("int-convertor", param=5) == "/int/5"
+
+    # Test str for OData style path
+    response = client.get("/strentity('ascii')")
+    assert response.status_code == 200
+    assert response.json() == {"str": "ascii"}
+    assert app.url_path_for("strentity", param="ascii") == "/strentity('ascii')"
+
+    # Test integer for OData style path
+    response = client.get("/intentity(7)")
+    assert response.status_code == 200
+    assert response.json() == {"int": 7}
+    assert app.url_path_for("intentity", param=7) == "/intentity(7)"
 
     # Test float conversion
     response = client.get("/float/25.5")


### PR DESCRIPTION
Adds a test that demonstrates the issue, then a fix that escapes regex meta chars in route paths.