### PR TITLE
Middleware should treat `body` in response ASGI messages as an optional key.

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -52,7 +52,7 @@ class BaseHTTPMiddleware:
                 if message is None:
                     break
                 assert message["type"] == "http.response.body"
-                yield message["body"]
+                yield message.get("body", b"")
             task.result()
 
         response = StreamingResponse(

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -294,7 +294,7 @@ class FileResponse(Response):
             }
         )
         if self.send_header_only:
-            await send({"type": "http.response.body"})
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
         else:
             async with aiofiles.open(self.path, mode="rb") as file:
                 more_body = True

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -294,7 +294,7 @@ class FileResponse(Response):
             }
         )
         if self.send_header_only:
-            await send({"type": "http.response.body"})
+            await send({"type": "http.response.body", "body": b'', "more_body": False})
         else:
             async with aiofiles.open(self.path, mode="rb") as file:
                 more_body = True

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -294,7 +294,7 @@ class FileResponse(Response):
             }
         )
         if self.send_header_only:
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
+            await send({"type": "http.response.body"})
         else:
             async with aiofiles.open(self.path, mode="rb") as file:
                 more_body = True

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -294,7 +294,7 @@ class FileResponse(Response):
             }
         )
         if self.send_header_only:
-            await send({"type": "http.response.body", "body": b'', "more_body": False})
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
         else:
             async with aiofiles.open(self.path, mode="rb") as file:
                 more_body = True

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -24,6 +24,9 @@ def test_staticfiles(tmpdir):
 
 
 def test_staticfiles_head_with_middleware(tmpdir):
+    """
+    see https://github.com/encode/starlette/pull/935
+    """
     path = os.path.join(tmpdir, "example.txt")
     with open(path, "w") as file:
         file.write("x" * 100)

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -26,20 +26,22 @@ def test_staticfiles(tmpdir):
 def test_staticfiles_head_with_middleware(tmpdir):
     path = os.path.join(tmpdir, "example.txt")
     with open(path, "w") as file:
-        file.write("x"*100)
+        file.write("x" * 100)
 
     routes = [
-        Mount('/static', app=StaticFiles(directory=tmpdir), name="static"),
+        Mount("/static", app=StaticFiles(directory=tmpdir), name="static"),
     ]
     app = Starlette(routes=routes)
+
     @app.middleware("http")
     async def does_nothing_middleware(request: Request, call_next):
         response = await call_next(request)
         return response
+
     client = TestClient(app)
     response = client.head("/static/example.txt")
     assert response.status_code == 200
-    assert response.headers.get('content-length') == '100'
+    assert response.headers.get("content-length") == "100"
 
 
 def test_staticfiles_with_package():


### PR DESCRIPTION
Fix for an issue sent on gitter by @tomasbedrich, the test added shows it:

if you try a HEAD on a static file and have a middleware that does nothing you get a KeyError 'body' in https://github.com/encode/starlette/blob/97257515f8806b8cc519d9850ecadd783b3008f9/starlette/middleware/base.py#L55

