### PR TITLE
Background Thread created by WebSocketTestSession should exit when close() is called

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -301,7 +301,8 @@ class WebSocketTestSession:
 
     async def _session(self):
         """
-        Execute `app` and wait for it to complete, or `close()` to invoked, whichever comes first.
+        Execute `app` and wait for it to complete,
+        or `close()` to be invoked, whichever comes first.
         """
         scope = self.scope
         receive = self._asgi_receive

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -314,6 +314,8 @@ class WebSocketTestSession:
         # waits for `self._close_event` to be set,
         # which indicates that `close()` was called
         async def wait():
+            # self._close_event.wait() is a blocking operation,
+            # so invoke it in the default executor
             await self._loop.run_in_executor(None, self._close_event.wait)
 
         # wait for app() and wait(), until at least one of them completes

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -320,7 +320,7 @@ class WebSocketTestSession:
 
         # wait for app() and wait(), until at least one of them completes
         coros = app(), wait()
-        tasks = map(asyncio.create_task, coros)
+        tasks = map(self._loop.create_task, coros)
         done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
         # ensure that the executer for wait() doesn't linger

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -312,7 +312,7 @@ class WebSocketTestSession:
             await self.app(scope, receive, send)
 
         # waits for `self._close_event` to be set,
-        # which is an indicates that `close()` was called
+        # which indicates that `close()` was called
         async def wait():
             await self._loop.run_in_executor(None, self._close_event.wait)
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -319,9 +319,9 @@ class WebSocketTestSession:
             await self._loop.run_in_executor(None, self._close_event.wait)
 
         # wait for app() and wait(), until at least one of them completes
-        coros = app(), wait()
-        tasks = map(self._loop.create_task, coros)
-        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        done, pending = await asyncio.wait(
+            [app(), wait()], return_when=asyncio.FIRST_COMPLETED
+        )
 
         # ensure that the executer for wait() doesn't linger
         self._close_event.set()

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -298,6 +298,12 @@ class WebSocketTestSession:
             self._loop.run_until_complete(self._session())
         except BaseException as exc:
             self._send_queue.put(exc)
+        finally:
+            # do full cleanup, for good measure
+            for tsk in asyncio.Task.all_tasks(self._loop):
+                tsk.cancel()
+            self._loop.stop()
+            self._loop.close()
 
     async def _session(self) -> None:
         """

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -299,7 +299,7 @@ class WebSocketTestSession:
         except BaseException as exc:
             self._send_queue.put(exc)
 
-    async def _session(self):
+    async def _session(self) -> None:
         """
         Execute `app` and wait for it to complete,
         or `close()` to be invoked, whichever comes first.
@@ -308,12 +308,12 @@ class WebSocketTestSession:
         receive = self._asgi_receive
         send = self._asgi_send
 
-        async def app():
+        async def app() -> None:
             await self.app(scope, receive, send)
 
         # waits for `self._close_event` to be set,
         # which indicates that `close()` was called
-        async def wait():
+        async def wait() -> None:
             # self._close_event.wait() is a blocking operation,
             # so invoke it in the default executor
             await self._loop.run_in_executor(None, self._close_event.wait)

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -145,8 +145,8 @@ def test_websocket_server_long_running():
             websocket = WebSocket(scope, receive=receive, send=send)
             await websocket.accept()
 
+            # this emulates a long running server
             await asyncio.sleep(5)
-            print()
 
         return asgi
 

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -1,5 +1,5 @@
 import asyncio
-from time import time, sleep
+from time import sleep, time
 
 import pytest
 


### PR DESCRIPTION
Fixes https://github.com/encode/starlette/issues/947