### PR TITLE
fix: add more type hints

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -38,14 +38,16 @@ class Starlette:
     def __init__(
         self,
         debug: bool = False,
-        routes: typing.Sequence[BaseRoute] = None,
-        middleware: typing.Sequence[Middleware] = None,
-        exception_handlers: typing.Dict[
-            typing.Union[int, typing.Type[Exception]], typing.Callable
+        routes: typing.Optional[typing.Sequence[BaseRoute]] = None,
+        middleware: typing.Optional[typing.Sequence[Middleware]] = None,
+        exception_handlers: typing.Optional[
+            typing.Dict[typing.Union[int, typing.Type[Exception]], typing.Callable]
         ] = None,
-        on_startup: typing.Sequence[typing.Callable] = None,
-        on_shutdown: typing.Sequence[typing.Callable] = None,
-        lifespan: typing.Callable[["Starlette"], typing.AsyncGenerator] = None,
+        on_startup: typing.Optional[typing.Sequence[typing.Callable]] = None,
+        on_shutdown: typing.Optional[typing.Sequence[typing.Callable]] = None,
+        lifespan: typing.Optional[
+            typing.Callable[["Starlette"], typing.AsyncGenerator]
+        ] = None,
     ) -> None:
         # The lifespan context function is a newer style that replaces
         # on_startup / on_shutdown handlers. Use one or the other, not both.
@@ -55,7 +57,7 @@ class Starlette:
 
         self._debug = debug
         self.state = State()
-        self.router = Router(
+        self.router: Router = Router(
             routes, on_startup=on_startup, on_shutdown=on_shutdown, lifespan=lifespan
         )
         self.exception_handlers = (
@@ -115,10 +117,10 @@ class Starlette:
     def on_event(self, event_type: str) -> typing.Callable:
         return self.router.on_event(event_type)
 
-    def mount(self, path: str, app: ASGIApp, name: str = None) -> None:
+    def mount(self, path: str, app: ASGIApp, name: typing.Optional[str] = None) -> None:
         self.router.mount(path, app=app, name=name)
 
-    def host(self, host: str, app: ASGIApp, name: str = None) -> None:
+    def host(self, host: str, app: ASGIApp, name: typing.Optional[str] = None) -> None:
         self.router.host(host, app=app, name=name)
 
     def add_middleware(self, middleware_class: type, **options: typing.Any) -> None:
@@ -140,8 +142,8 @@ class Starlette:
         self,
         path: str,
         route: typing.Callable,
-        methods: typing.List[str] = None,
-        name: str = None,
+        methods: typing.Optional[typing.List[str]] = None,
+        name: typing.Optional[str] = None,
         include_in_schema: bool = True,
     ) -> None:
         self.router.add_route(
@@ -149,7 +151,7 @@ class Starlette:
         )
 
     def add_websocket_route(
-        self, path: str, route: typing.Callable, name: str = None
+        self, path: str, route: typing.Callable, name: typing.Optional[str] = None
     ) -> None:
         self.router.add_websocket_route(path, route, name=name)
 
@@ -165,8 +167,8 @@ class Starlette:
     def route(
         self,
         path: str,
-        methods: typing.List[str] = None,
-        name: str = None,
+        methods: typing.Optional[typing.List[str]] = None,
+        name: typing.Optional[str] = None,
         include_in_schema: bool = True,
     ) -> typing.Callable:
         def decorator(func: typing.Callable) -> typing.Callable:
@@ -181,7 +183,9 @@ class Starlette:
 
         return decorator
 
-    def websocket_route(self, path: str, name: str = None) -> typing.Callable:
+    def websocket_route(
+        self, path: str, name: typing.Optional[str] = None
+    ) -> typing.Callable:
         def decorator(func: typing.Callable) -> typing.Callable:
             self.router.add_websocket_route(path, func, name=name)
             return func

--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -19,7 +19,7 @@ def has_required_scope(conn: HTTPConnection, scopes: typing.Sequence[str]) -> bo
 def requires(
     scopes: typing.Union[str, typing.Sequence[str]],
     status_code: int = 403,
-    redirect: str = None,
+    redirect: typing.Optional[str] = None,
 ) -> typing.Callable:
     scopes_list = [scopes] if isinstance(scopes, str) else list(scopes)
 
@@ -102,7 +102,7 @@ class AuthenticationBackend:
 
 
 class AuthCredentials:
-    def __init__(self, scopes: typing.Sequence[str] = None):
+    def __init__(self, scopes: typing.Optional[typing.Sequence[str]] = None):
         self.scopes = [] if scopes is None else list(scopes)
 
 

--- a/starlette/config.py
+++ b/starlette/config.py
@@ -48,7 +48,7 @@ environ = Environ()
 class Config:
     def __init__(
         self,
-        env_file: typing.Union[str, Path] = None,
+        env_file: typing.Optional[typing.Union[str, Path]] = None,
         environ: typing.Mapping[str, str] = environ,
     ) -> None:
         self.environ = environ
@@ -57,12 +57,18 @@ class Config:
             self.file_values = self._read_file(env_file)
 
     def __call__(
-        self, key: str, cast: typing.Callable = None, default: typing.Any = undefined,
+        self,
+        key: str,
+        cast: typing.Optional[typing.Callable] = None,
+        default: typing.Any = undefined,
     ) -> typing.Any:
         return self.get(key, cast, default)
 
     def get(
-        self, key: str, cast: typing.Callable = None, default: typing.Any = undefined,
+        self,
+        key: str,
+        cast: typing.Optional[typing.Callable] = None,
+        default: typing.Any = undefined,
     ) -> typing.Any:
         if key in self.environ:
             value = self.environ[key]
@@ -87,7 +93,10 @@ class Config:
         return file_values
 
     def _perform_cast(
-        self, key: str, value: typing.Any, cast: typing.Callable = None,
+        self,
+        key: str,
+        value: typing.Any,
+        cast: typing.Optional[typing.Callable] = None,
     ) -> typing.Any:
         if cast is None or value is None:
             return value

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -13,7 +13,10 @@ Address = namedtuple("Address", ["host", "port"])
 
 class URL:
     def __init__(
-        self, url: str = "", scope: Scope = None, **components: typing.Any
+        self,
+        url: str = "",
+        scope: typing.Optional[Scope] = None,
+        **components: typing.Any,
     ) -> None:
         if scope is not None:
             assert not url, 'Cannot set both "url" and "scope".'
@@ -425,7 +428,10 @@ class UploadFile:
     spool_max_size = 1024 * 1024
 
     def __init__(
-        self, filename: str, file: typing.IO = None, content_type: str = ""
+        self,
+        filename: str,
+        file: typing.Optional[typing.IO] = None,
+        content_type: str = "",
     ) -> None:
         self.filename = filename
         self.content_type = content_type
@@ -491,9 +497,9 @@ class Headers(typing.Mapping[str, str]):
 
     def __init__(
         self,
-        headers: typing.Mapping[str, str] = None,
-        raw: typing.List[typing.Tuple[bytes, bytes]] = None,
-        scope: Scope = None,
+        headers: typing.Optional[typing.Mapping[str, str]] = None,
+        raw: typing.Optional[typing.List[typing.Tuple[bytes, bytes]]] = None,
+        scope: typing.Optional[Scope] = None,
     ) -> None:
         self._list = []  # type: typing.List[typing.Tuple[bytes, bytes]]
         if headers is not None:
@@ -656,7 +662,7 @@ class State(object):
     Used for `request.state` and `app.state`.
     """
 
-    def __init__(self, state: typing.Dict = None):
+    def __init__(self, state: typing.Optional[typing.Dict] = None):
         if state is None:
             state = {}
         super(State, self).__setattr__("_state", state)

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -9,7 +9,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 class HTTPException(Exception):
-    def __init__(self, status_code: int, detail: str = None) -> None:
+    def __init__(self, status_code: int, detail: typing.Optional[str] = None) -> None:
         if detail is None:
             detail = http.HTTPStatus(status_code).phrase
         self.status_code = status_code
@@ -22,7 +22,7 @@ class HTTPException(Exception):
 
 class ExceptionMiddleware:
     def __init__(
-        self, app: ASGIApp, handlers: dict = None, debug: bool = False
+        self, app: ASGIApp, handlers: typing.Optional[dict] = None, debug: bool = False
     ) -> None:
         self.app = app
         self.debug = debug  # TODO: We ought to handle 404 cases if debug is set.

--- a/starlette/middleware/authentication.py
+++ b/starlette/middleware/authentication.py
@@ -16,8 +16,8 @@ class AuthenticationMiddleware:
         self,
         app: ASGIApp,
         backend: AuthenticationBackend,
-        on_error: typing.Callable[
-            [HTTPConnection, AuthenticationError], Response
+        on_error: typing.Optional[
+            typing.Callable[[HTTPConnection, AuthenticationError], Response]
         ] = None,
     ) -> None:
         self.app = app

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -12,7 +12,9 @@ DispatchFunction = typing.Callable[
 
 
 class BaseHTTPMiddleware:
-    def __init__(self, app: ASGIApp, dispatch: DispatchFunction = None) -> None:
+    def __init__(
+        self, app: ASGIApp, dispatch: typing.Optional[DispatchFunction] = None
+    ) -> None:
         self.app = app
         self.dispatch_func = self.dispatch if dispatch is None else dispatch
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -60,7 +60,7 @@ class HTTPConnection(Mapping):
     any functionality that is common to both `Request` and `WebSocket`.
     """
 
-    def __init__(self, scope: Scope, receive: Receive = None) -> None:
+    def __init__(self, scope: Scope, receive: typing.Optional[Receive] = None) -> None:
         assert scope["type"] in ("http", "websocket")
         self.scope = scope
 

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -38,9 +38,9 @@ class Response:
         self,
         content: typing.Any = None,
         status_code: int = 200,
-        headers: dict = None,
-        media_type: str = None,
-        background: BackgroundTask = None,
+        headers: typing.Optional[dict] = None,
+        media_type: typing.Optional[str] = None,
+        background: typing.Optional[BackgroundTask] = None,
     ) -> None:
         self.status_code = status_code
         if media_type is not None:
@@ -56,7 +56,9 @@ class Response:
             return content
         return content.encode(self.charset)
 
-    def init_headers(self, headers: typing.Mapping[str, str] = None) -> None:
+    def init_headers(
+        self, headers: typing.Optional[typing.Mapping[str, str]] = None
+    ) -> None:
         if headers is None:
             raw_headers = []  # type: typing.List[typing.Tuple[bytes, bytes]]
             populate_content_length = True
@@ -93,10 +95,10 @@ class Response:
         self,
         key: str,
         value: str = "",
-        max_age: int = None,
-        expires: int = None,
+        max_age: typing.Optional[int] = None,
+        expires: typing.Optional[int] = None,
         path: str = "/",
-        domain: str = None,
+        domain: typing.Optional[str] = None,
         secure: bool = False,
         httponly: bool = False,
         samesite: str = "lax",
@@ -125,7 +127,9 @@ class Response:
         cookie_val = cookie.output(header="").strip()
         self.raw_headers.append((b"set-cookie", cookie_val.encode("latin-1")))
 
-    def delete_cookie(self, key: str, path: str = "/", domain: str = None) -> None:
+    def delete_cookie(
+        self, key: str, path: str = "/", domain: typing.Optional[str] = None
+    ) -> None:
         self.set_cookie(key, expires=0, max_age=0, path=path, domain=domain)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -176,8 +180,8 @@ class RedirectResponse(Response):
         self,
         url: typing.Union[str, URL],
         status_code: int = 307,
-        headers: dict = None,
-        background: BackgroundTask = None,
+        headers: typing.Optional[dict] = None,
+        background: typing.Optional[BackgroundTask] = None,
     ) -> None:
         super().__init__(
             content=b"", status_code=status_code, headers=headers, background=background
@@ -190,9 +194,9 @@ class StreamingResponse(Response):
         self,
         content: typing.Any,
         status_code: int = 200,
-        headers: dict = None,
-        media_type: str = None,
-        background: BackgroundTask = None,
+        headers: typing.Optional[dict] = None,
+        media_type: typing.Optional[str] = None,
+        background: typing.Optional[BackgroundTask] = None,
     ) -> None:
         if inspect.isasyncgen(content):
             self.body_iterator = content
@@ -241,12 +245,12 @@ class FileResponse(Response):
         self,
         path: str,
         status_code: int = 200,
-        headers: dict = None,
-        media_type: str = None,
-        background: BackgroundTask = None,
-        filename: str = None,
-        stat_result: os.stat_result = None,
-        method: str = None,
+        headers: typing.Optional[dict] = None,
+        media_type: typing.Optional[str] = None,
+        background: typing.Optional[BackgroundTask] = None,
+        filename: typing.Optional[str] = None,
+        stat_result: typing.Optional[os.stat_result] = None,
+        method: typing.Optional[str] = None,
     ) -> None:
         assert aiofiles is not None, "'aiofiles' must be installed to use FileResponse"
         self.path = path

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -69,7 +69,7 @@ def replace_params(
     path: str,
     param_convertors: typing.Dict[str, Convertor],
     path_params: typing.Dict[str, str],
-) -> typing.Tuple[str, dict]:
+) -> typing.Tuple[str, typing.Dict[str, str]]:
     for key, value in list(path_params.items()):
         if "{" + key + "}" in path:
             convertor = param_convertors[key]
@@ -85,7 +85,7 @@ PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?}")
 
 def compile_path(
     path: str,
-) -> typing.Tuple[typing.Pattern, str, typing.Dict[str, Convertor]]:
+) -> typing.Tuple[typing.Pattern[str], str, typing.Dict[str, Convertor]]:
     """
     Given a path string, like: "/{username:str}", return a three-tuple
     of (regex, format, {param_name:convertor}).
@@ -159,8 +159,8 @@ class Route(BaseRoute):
         path: str,
         endpoint: typing.Callable,
         *,
-        methods: typing.List[str] = None,
-        name: str = None,
+        methods: typing.Optional[typing.List[str]] = None,
+        name: typing.Optional[str] = None,
         include_in_schema: bool = True,
     ) -> None:
         assert path.startswith("/"), "Routed paths must start with '/'"
@@ -237,7 +237,7 @@ class Route(BaseRoute):
 
 class WebSocketRoute(BaseRoute):
     def __init__(
-        self, path: str, endpoint: typing.Callable, *, name: str = None
+        self, path: str, endpoint: typing.Callable, *, name: typing.Optional[str] = None
     ) -> None:
         assert path.startswith("/"), "Routed paths must start with '/'"
         self.path = path
@@ -294,9 +294,9 @@ class Mount(BaseRoute):
     def __init__(
         self,
         path: str,
-        app: ASGIApp = None,
-        routes: typing.Sequence[BaseRoute] = None,
-        name: str = None,
+        app: typing.Optional[ASGIApp] = None,
+        routes: typing.Optional[typing.Sequence[BaseRoute]] = None,
+        name: typing.Optional[str] = None,
     ) -> None:
         assert path == "" or path.startswith("/"), "Routed paths must start with '/'"
         assert (
@@ -313,7 +313,7 @@ class Mount(BaseRoute):
         )
 
     @property
-    def routes(self) -> typing.List[BaseRoute]:
+    def routes(self) -> typing.Optional[typing.List[BaseRoute]]:
         return getattr(self.app, "routes", None)
 
     def matches(self, scope: Scope) -> typing.Tuple[Match, Scope]:
@@ -384,7 +384,9 @@ class Mount(BaseRoute):
 
 
 class Host(BaseRoute):
-    def __init__(self, host: str, app: ASGIApp, name: str = None) -> None:
+    def __init__(
+        self, host: str, app: ASGIApp, name: typing.Optional[str] = None
+    ) -> None:
         self.host = host
         self.app = app
         self.name = name
@@ -450,12 +452,14 @@ class Host(BaseRoute):
 class Router:
     def __init__(
         self,
-        routes: typing.Sequence[BaseRoute] = None,
+        routes: typing.Optional[typing.Sequence[BaseRoute]] = None,
         redirect_slashes: bool = True,
-        default: ASGIApp = None,
-        on_startup: typing.Sequence[typing.Callable] = None,
-        on_shutdown: typing.Sequence[typing.Callable] = None,
-        lifespan: typing.Callable[[typing.Any], typing.AsyncGenerator] = None,
+        default: typing.Optional[ASGIApp] = None,
+        on_startup: typing.Optional[typing.Sequence[typing.Callable]] = None,
+        on_shutdown: typing.Optional[typing.Sequence[typing.Callable]] = None,
+        lifespan: typing.Optional[
+            typing.Callable[[typing.Any], typing.AsyncGenerator]
+        ] = None,
     ) -> None:
         self.routes = [] if routes is None else list(routes)
         self.redirect_slashes = redirect_slashes
@@ -599,11 +603,11 @@ class Router:
 
     # The following usages are now discouraged in favour of configuration
     #  during Router.__init__(...)
-    def mount(self, path: str, app: ASGIApp, name: str = None) -> None:
+    def mount(self, path: str, app: ASGIApp, name: typing.Optional[str] = None) -> None:
         route = Mount(path, app=app, name=name)
         self.routes.append(route)
 
-    def host(self, host: str, app: ASGIApp, name: str = None) -> None:
+    def host(self, host: str, app: ASGIApp, name: typing.Optional[str] = None) -> None:
         route = Host(host, app=app, name=name)
         self.routes.append(route)
 
@@ -611,8 +615,8 @@ class Router:
         self,
         path: str,
         endpoint: typing.Callable,
-        methods: typing.List[str] = None,
-        name: str = None,
+        methods: typing.Optional[typing.List[str]] = None,
+        name: typing.Optional[str] = None,
         include_in_schema: bool = True,
     ) -> None:
         route = Route(
@@ -625,7 +629,7 @@ class Router:
         self.routes.append(route)
 
     def add_websocket_route(
-        self, path: str, endpoint: typing.Callable, name: str = None
+        self, path: str, endpoint: typing.Callable, name: typing.Optional[str] = None
     ) -> None:
         route = WebSocketRoute(path, endpoint=endpoint, name=name)
         self.routes.append(route)
@@ -633,8 +637,8 @@ class Router:
     def route(
         self,
         path: str,
-        methods: typing.List[str] = None,
-        name: str = None,
+        methods: typing.Optional[typing.List[str]] = None,
+        name: typing.Optional[str] = None,
         include_in_schema: bool = True,
     ) -> typing.Callable:
         def decorator(func: typing.Callable) -> typing.Callable:
@@ -649,7 +653,9 @@ class Router:
 
         return decorator
 
-    def websocket_route(self, path: str, name: str = None) -> typing.Callable:
+    def websocket_route(
+        self, path: str, name: typing.Optional[str] = None
+    ) -> typing.Callable:
         def decorator(func: typing.Callable) -> typing.Callable:
             self.add_websocket_route(path, func, name=name)
             return func

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -41,8 +41,8 @@ class StaticFiles:
     def __init__(
         self,
         *,
-        directory: str = None,
-        packages: typing.List[str] = None,
+        directory: typing.Optional[str] = None,
+        packages: typing.Optional[typing.List[str]] = None,
         html: bool = False,
         check_dir: bool = True,
     ) -> None:
@@ -55,7 +55,9 @@ class StaticFiles:
             raise RuntimeError(f"Directory '{directory}' does not exist")
 
     def get_directories(
-        self, directory: str = None, packages: typing.List[str] = None
+        self,
+        directory: typing.Optional[str] = None,
+        packages: typing.Optional[typing.List[str]] = None,
     ) -> typing.List[str]:
         """
         Given `directory` and `packages` arguments, return a list of all the

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -18,9 +18,9 @@ class _TemplateResponse(Response):
         template: typing.Any,
         context: dict,
         status_code: int = 200,
-        headers: dict = None,
-        media_type: str = None,
-        background: BackgroundTask = None,
+        headers: typing.Optional[dict] = None,
+        media_type: typing.Optional[str] = None,
+        background: typing.Optional[BackgroundTask] = None,
     ):
         self.template = template
         self.context = context
@@ -71,9 +71,9 @@ class Jinja2Templates:
         name: str,
         context: dict,
         status_code: int = 200,
-        headers: dict = None,
-        media_type: str = None,
-        background: BackgroundTask = None,
+        headers: typing.Optional[dict] = None,
+        media_type: typing.Optional[str] = None,
+        background: typing.Optional[BackgroundTask] = None,
     ) -> _TemplateResponse:
         if "request" not in context:
             raise ValueError('context must include a "request" key')

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -69,7 +69,7 @@ class WebSocket(HTTPConnection):
         else:
             raise RuntimeError('Cannot call "send" once a close message has been sent.')
 
-    async def accept(self, subprotocol: str = None) -> None:
+    async def accept(self, subprotocol: typing.Optional[str] = None) -> None:
         if self.client_state == WebSocketState.CONNECTING:
             # If we haven't yet seen the 'connect' message, then wait for it first.
             await self.receive()


### PR DESCRIPTION
missing type hints from mypy --strict mode. 
Reduced from `275` -> `157`

Hey people, I've been playing with hints and `--strict` mode in mypy, this is the result, feel free to merge or reject it.

## Some notes

There are many `Callable` missing the parameters, this errors is present a lot:
```
error: Missing type parameters for generic type "typing.Callable"
```

----------

Importing just the `typing` module adds a lot of noise, I was wondering if it would be better to just import what's needed from it. Let's compare:

```python
exception_handlers: typing.Optional[
    typing.Dict[typing.Union[int, typing.Type[Exception]], typing.Callable]
] = None
```

```python
exception_handlers: Optional[Dict[Union[int, Type[Exception]], Callable]] = None
```
I'd be willing to make some PR in the files I consider have long type definitions if wanted.