### PR TITLE
closes #953 add possibility to ovewrite graphiql html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test.db
 .mypy_cache/
 starlette.egg-info/
 venv/
+.vscode

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -100,3 +100,23 @@ routes = [
 
 app = Starlette(routes=routes)
 ```
+
+## Disable or overwrite Graphiql
+
+Disable graphiql py setting graphiql to False
+
+```python
+GraphQLApp(schema=graphene.Schema(query=Query), graphiql=False)
+```
+
+
+graphiql is rendered via a default template.
+If you want to overwrite it set the you template on app creation. 
+`{{REQUEST_PATH}}` is replaced by current path.
+See `graphql.py` for an example.
+
+ ```python
+graphiql_template = "… {{REQUEST_PATH}} …" # 
+GraphQLApp(schema=graphene.Schema(query=Query), graphiql=graphiql_template)
+```
+

--- a/starlette/graphql.py
+++ b/starlette/graphql.py
@@ -26,7 +26,7 @@ class GraphQLApp:
         schema: "graphene.Schema",
         executor: typing.Any = None,
         executor_class: type = None,
-        graphiql: bool = True,
+        graphiql: typing.Union[bool, str] = True,
     ) -> None:
         self.schema = schema
         self.graphiql = graphiql
@@ -140,11 +140,16 @@ class GraphQLApp:
             )
 
     async def handle_graphiql(self, request: Request) -> Response:
-        text = GRAPHIQL.replace("{{REQUEST_PATH}}", json.dumps(request.url.path))
+        graphiql_temlplate = (
+            GRAPHIQL_DEFAULT if isinstance(self.graphiql, bool) else str(self.graphiql)
+        )
+        text = graphiql_temlplate.replace(
+            "{{REQUEST_PATH}}", json.dumps(request.url.path)
+        )
         return HTMLResponse(text)
 
 
-GRAPHIQL = """
+GRAPHIQL_DEFAULT = """
 <!--
  *  Copyright (c) Facebook, Inc.
  *  All rights reserved.

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -213,13 +213,13 @@ def test_queryparams():
     assert QueryParams(q) == q
 
 
-class TestUploadFile(UploadFile):
+class UploadFileTest(UploadFile):
     spool_max_size = 1024
 
 
 @pytest.mark.asyncio
 async def test_upload_file():
-    big_file = TestUploadFile("big-file")
+    big_file = UploadFileTest("big-file")
     await big_file.write(b"big-data" * 512)
     await big_file.write(b"big-data")
     await big_file.seek(0)

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -108,6 +108,17 @@ def test_graphiql_not_found():
     assert response.status_code == 404
     assert response.text == "Not Found"
 
+def test_graphiql_is_overwritten():
+    """
+    The default graphiql template could be overwritten
+    by using a string instead of boolean on GraphQLApp creation.
+    """
+    app = GraphQLApp(schema=schema, graphiql="overwritten template")
+    client = TestClient(app)
+    response = client.get("/", headers={"accept": "text/html"})
+    assert response.status_code == 200
+    assert response.text == "overwritten template"
+
 
 def test_add_graphql_route():
     app = Starlette()

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -108,6 +108,7 @@ def test_graphiql_not_found():
     assert response.status_code == 404
     assert response.text == "Not Found"
 
+
 def test_graphiql_is_overwritten():
     """
     The default graphiql template could be overwritten


### PR DESCRIPTION
If `graphiql` parameter of app is set to a str, we can use it to overwrite the built in template