### PR TITLE
Added check for missing static files with ".html"

### DIFF
--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -151,7 +151,11 @@ class StaticFiles:
                 stat_result = await aio_stat(full_path)
                 return (full_path, stat_result)
             except FileNotFoundError:
-                pass
+                if os.path.isfile(full_path+".html"):
+                    stat_result = await aio_stat(full_path+".html")
+                    return (full_path+".html", stat_result)
+                else:
+                    pass
         return ("", None)
 
     def file_response(


### PR DESCRIPTION
I have been developing a small web app that combines NextJS+FastAPI, and have been faced with the annoyance that during development all endpoints generated with NextJS have to end without a ".html" extension. But once I export that front end logic to static files, FastApi (using Starlette's static file mounting routine) requires that all of these endpoints do end in ".html". So I have to change them bach-and-forth manually throughout my code when I want to switch between deploying and developing.

This issue is quickly fixed by adding a test in StaticFiles.lookup_path wherein if the method fails to find the originally requested file it can additionally check for the same file but with a ".html" extension. If this file does not exist, then the method can fail out as normal. 