### PR TITLE
Added check for missing static files with ".html" when in HTML mode

### DIFF
--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -114,6 +114,9 @@ class StaticFiles:
             return PlainTextResponse("Not Found", status_code=404)
 
         full_path, stat_result = await self.lookup_path(path)
+        
+        if stat_result is None and self.html:
+            full_path, stat_result = await self.lookup_path(path+".html")
 
         if stat_result and stat.S_ISREG(stat_result.st_mode):
             # We have a static file to serve.
@@ -133,6 +136,7 @@ class StaticFiles:
                 return self.file_response(full_path, stat_result, scope)
 
         if self.html:
+
             # Check for '404.html' if we're in HTML mode.
             full_path, stat_result = await self.lookup_path("404.html")
             if stat_result is not None and stat.S_ISREG(stat_result.st_mode):
@@ -151,11 +155,7 @@ class StaticFiles:
                 stat_result = await aio_stat(full_path)
                 return (full_path, stat_result)
             except FileNotFoundError:
-                if os.path.isfile(full_path+".html"):
-                    stat_result = await aio_stat(full_path+".html")
-                    return (full_path+".html", stat_result)
-                else:
-                    pass
+                pass
         return ("", None)
 
     def file_response(

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -114,9 +114,11 @@ class StaticFiles:
             return PlainTextResponse("Not Found", status_code=404)
 
         full_path, stat_result = await self.lookup_path(path)
-        
+
         if stat_result is None and self.html:
-            full_path, stat_result = await self.lookup_path(path+".html")
+            # We're in HTML mode, and were given a path which does not exist.
+            # Check if we have a '.html' file which is otherwise at the same path.
+            full_path, stat_result = await self.lookup_path(path + ".html")
 
         if stat_result and stat.S_ISREG(stat_result.st_mode):
             # We have a static file to serve.
@@ -136,7 +138,6 @@ class StaticFiles:
                 return self.file_response(full_path, stat_result, scope)
 
         if self.html:
-
             # Check for '404.html' if we're in HTML mode.
             full_path, stat_result = await self.lookup_path("404.html")
             if stat_result is not None and stat.S_ISREG(stat_result.st_mode):

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -151,7 +151,11 @@ class StaticFiles:
                 stat_result = await aio_stat(full_path)
                 return (full_path, stat_result)
             except FileNotFoundError:
-                pass
+                if os.path.isfile(full_path+".html"):
+                    stat_result = await aio_stat(full_path+".html")
+                    return (full_path+".html", stat_result)
+                else:
+                    pass
         return ("", None)
 
     def file_response(


### PR DESCRIPTION
Similar to how the StaticFiles object treats unspecified "index.html" and "404.html" requests when in HTML mode, this change would additionally account for the scenario when a request is made for a static file without specifying a ".html" extension. It would only be active when the developer chooses to be in HTML mode, and the '.html' extension would only checked for in the event that the initially-provided path ended with a "FileNotFoundError".

Without this update (or something similar to it), it would not be practical to use Starlette as a backend to serve static files developed with an SSG such as NextJS.