### PR TITLE
Fix staticfiles 404 errors

### DIFF
--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -140,11 +140,9 @@ class StaticFiles:
         self, path: str
     ) -> typing.Tuple[str, typing.Optional[os.stat_result]]:
         for directory in self.all_directories:
-            full_path = os.path.join(directory, path)
-            if (
-                os.path.commonprefix([os.path.realpath(full_path), directory])
-                != directory
-            ):
+            full_path = os.path.realpath(os.path.join(directory, path))
+            directory = os.path.realpath(directory)
+            if os.path.commonprefix([full_path, directory]) != directory:
                 # Don't allow misbehaving clients to break out of the static files directory.
                 continue
             try:


### PR DESCRIPTION
Ensure that we use `os.path.realpath` on both the base directory, and the requested path, when ensuring that the requested path exists *within* the base directory.