### PR TITLE
Fix optional route bug

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -117,7 +117,12 @@ def compile_path(
 
         idx = match.end()
 
-    path_regex += re.escape(path[idx:]) + "$"
+    # Prevent the escape of ? for route ending with ?
+    if path[-1] == "?":
+        path_regex += re.escape(path[idx:-1]) + "?$"
+    else:
+        path_regex += re.escape(path[idx:]) + "$"
+
     path_format += path[idx:]
 
     return re.compile(path_regex), path_format, param_convertors

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -90,6 +90,12 @@ def path_with_parentheses(request):
     return JSONResponse({"int": number})
 
 
+# Route with chars that conflict with regex meta chars
+@app.route("/optional-path/?", name="optional-path")
+def optional_path(request):
+    return Response("Optional path reached.", media_type="text/plain")
+
+
 @app.websocket_route("/ws")
 async def websocket_endpoint(session):
     await session.accept()
@@ -161,6 +167,15 @@ def test_route_converters():
         app.url_path_for("path-with-parentheses", param=7)
         == "/path-with-parentheses(7)"
     )
+
+    # Test optional path
+    response = client.get("/optional-path")
+    assert response.status_code == 200
+    assert response.text == "Optional path reached."
+
+    response = client.get("/optional-path/")
+    assert response.status_code == 200
+    assert response.text == "Optional path reached."
 
     # Test float conversion
     response = client.get("/float/25.5")


### PR DESCRIPTION
Optional routes are not working anymore because the `?` gets escaped by the change introduced in: https://github.com/encode/starlette/commit/f12e237da5ff4e19531d71340b2208f613206882

This code handle that scenario by looking at the last character of the path before doing the escape.
When the last character is a `?` it will do the escape on the path and prevent the escape of the needed `?`.

I've added test to verify that optional routes are now working alongside the regexp meta character in path changes. 

If you feel this change is not welcome, please close the PR but since it was a "very clearly well identified bug" It felt appropriate.

This PR fixes https://github.com/encode/starlette/issues/1008