### PR TITLE
Use cached property to simplify property logic

### DIFF
--- a/starlette/cached_property.py
+++ b/starlette/cached_property.py
@@ -1,0 +1,43 @@
+try:
+    from functools import cached_property  # type: ignore
+except ImportError:  # pragma: no cover
+    import typing
+
+    class cached_property:  # type: ignore
+        def __init__(
+            self, func: typing.Callable, attrname: typing.Optional[str] = None
+        ) -> None:
+            self.func = func
+            self.attrname = attrname
+            self.__doc__ = func.__doc__
+
+        def __set_name__(self, owner: typing.Any, name: str) -> None:
+            if self.attrname is None:
+                self.attrname = name
+
+            elif name != self.attrname:
+                raise TypeError(
+                    "Cannot assign the same cached_property to two different names "
+                    f"({self.attrname!r} and {name!r})."
+                )
+
+        def __get__(self, instance: typing.Any, owner: typing.Any = None) -> typing.Any:
+            if instance is None:
+                return self
+
+            if self.attrname is None:
+                raise TypeError(
+                    "Cannot use cached_property instance without calling __set_name__ on it."
+                )
+
+            try:
+                instance.__dict__
+            except AttributeError:
+                raise TypeError(
+                    f"No '__dict__' attribute on {type(instance).__name__!r}"
+                ) from None
+
+            value = self.func(instance)
+            instance.__dict__[self.attrname] = value
+
+            return value

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from shlex import shlex
 from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit
 
+from starlette.cached_property import cached_property
 from starlette.concurrency import run_in_threadpool
 from starlette.types import Scope
 
@@ -49,11 +50,9 @@ class URL:
 
         self._url = url
 
-    @property
+    @cached_property
     def components(self) -> SplitResult:
-        if not hasattr(self, "_components"):
-            self._components = urlsplit(self._url)
-        return self._components
+        return urlsplit(self._url)
 
     @property
     def scheme(self) -> str:

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -10,6 +10,7 @@ from mimetypes import guess_type
 from urllib.parse import quote, quote_plus
 
 from starlette.background import BackgroundTask
+from starlette.cached_property import cached_property
 from starlette.concurrency import iterate_in_threadpool, run_until_first_complete
 from starlette.datastructures import URL, MutableHeaders
 from starlette.types import Receive, Scope, Send
@@ -83,11 +84,9 @@ class Response:
 
         self.raw_headers = raw_headers
 
-    @property
+    @cached_property
     def headers(self) -> MutableHeaders:
-        if not hasattr(self, "_headers"):
-            self._headers = MutableHeaders(raw=self.raw_headers)
-        return self._headers
+        return MutableHeaders(raw=self.raw_headers)
 
     def set_cookie(
         self,

--- a/tests/test_cached_property.py
+++ b/tests/test_cached_property.py
@@ -1,0 +1,72 @@
+from pytest import raises
+
+from starlette.cached_property import cached_property
+
+
+def test_cached_property_cache_attributes():
+    class _Class:
+        @cached_property
+        def prop(self):
+            return []
+
+    obj = _Class()
+    assert obj.prop is obj.prop
+
+    other = _Class()
+    # different instances of same class must has different cached properties
+    assert obj.prop is not other.prop
+
+
+def test_get_cached_property_on_class():
+    @cached_property
+    def prop(instance):  # pragma: no cover
+        pass
+
+    class _Class:
+        foo = prop
+
+    assert _Class.foo is prop
+
+
+def test_cached_property_set_name_twice():
+    with raises(RuntimeError):
+
+        class _Class:
+            @cached_property
+            def prop(self):  # pragma: no cover
+                pass
+
+            another_prop = prop
+
+
+def test_get_cached_property_without_attrname():
+    class _Class:
+        pass
+
+    @cached_property
+    def prop(instance):  # pragma: no coverage
+        pass
+
+    _Class.prop = prop
+
+    obj = _Class()
+
+    with raises(
+        TypeError,
+        match="Cannot use cached_property instance without calling __set_name__ on it.",
+    ):
+        obj.prop
+
+
+def test_get_cached_property_on_class_without_dict():
+    class _Class:
+        __slots__ = ()
+
+        @cached_property
+        def prop(self):  # pragma: no coverage
+            pass
+
+    obj = _Class()
+
+    with raises(TypeError, match=f"No '__dict__' attribute on.*"):
+        obj.prop


### PR DESCRIPTION
Use `cached_property` in order to simplify the logic of properties which should be cached.

From python 3.8 there is a builtin `cached_property` class at `functools` module.
For lower python versions backport class was written.