### PR TITLE
Fix GH Action "Publish": Install dependencies first

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: "actions/setup-python@v1"
         with:
           python-version: 3.7
+      - name: "Install dependencies"
+        run: "scripts/install"
       - name: "Publish"
         run: "scripts/publish"
         env:


### PR DESCRIPTION
Building the docs requires the package to have been installed first. 

Include install script in "publish" action (see github actions in [httpx project](https://github.com/encode/httpx/blob/655773e1c1b75895eda927d5a9d22a3b5b8f572d/.github/workflows/publish.yml#L19) for reference).

This is to fix the failure in this step:

```
ERROR   -  Error reading page 'applications.md': Could not import module 'starlette.applications'. 
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/mkautodoc/extension.py", line 20, in import_from_string
    module = importlib.import_module(module_str)
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 965, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'starlette'
```