### PR TITLE
Use format_exception instead of format_tb

### DIFF
--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -231,7 +231,7 @@ class ServerErrorMiddleware:
         return TEMPLATE.format(styles=STYLES, js=JS, error=error, exc_html=exc_html)
 
     def generate_plain_text(self, exc: Exception) -> str:
-        return "".join(traceback.format_tb(exc.__traceback__))
+        return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
 
     def debug_response(self, request: Request, exc: Exception) -> Response:
         accept = request.headers.get("accept", "")

--- a/tests/middleware/test_errors.py
+++ b/tests/middleware/test_errors.py
@@ -28,7 +28,7 @@ def test_debug_text():
     response = client.get("/")
     assert response.status_code == 500
     assert response.headers["content-type"].startswith("text/plain")
-    assert "RuntimeError" in response.text
+    assert "RuntimeError: Something went wrong" in response.text
 
 
 def test_debug_html():


### PR DESCRIPTION
This gives much more information about the exception, including causes, and the exception message itself, in addition to the trackback