### PR TITLE
request.body() up to 6 times faster, using content length header

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -226,7 +226,7 @@ class Request(HTTPConnection):
                         chunk_length = len(chunk)
                         body_bytes[body_index : body_index + chunk_length] = chunk
                         body_index += chunk_length
-                    self._body = bytes(body_bytes)
+                    self._body = bytes(body_bytes[:body_index])
                     return self._body
 
             # If the header is not present, reading the chunks until the stream ends.

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -232,7 +232,6 @@ class Request(HTTPConnection):
             chunks = []
             async for chunk in self.stream():
                 chunks.append(chunk)
-
             self._body = b"".join(chunks)
         return self._body
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -222,9 +222,9 @@ class Request(HTTPConnection):
 
     async def body(self) -> bytes:
         if not hasattr(self, "_body"):
-            content_length = self.headers.get('content-length')
+            content_length = self.headers.get('Content-Length')
             if content_length:
-                # Allocating a bytearray with a size that matches "content-length" header.
+                # Allocating a bytearray with a size that matches "Content-Length" header.
                 body_bytes = bytearray(int(content_length))
                 body_index = 0
                 async for chunk in self.stream():

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -13,7 +13,6 @@ try:
 except ImportError:  # pragma: nocover
     parse_options_header = None
 
-
 SERVER_PUSH_HEADERS_TO_COPY = {
     "accept",
     "accept-encoding",
@@ -130,21 +129,21 @@ class HTTPConnection(Mapping):
     @property
     def session(self) -> dict:
         assert (
-            "session" in self.scope
+                "session" in self.scope
         ), "SessionMiddleware must be installed to access request.session"
         return self.scope["session"]
 
     @property
     def auth(self) -> typing.Any:
         assert (
-            "auth" in self.scope
+                "auth" in self.scope
         ), "AuthenticationMiddleware must be installed to access request.auth"
         return self.scope["auth"]
 
     @property
     def user(self) -> typing.Any:
         assert (
-            "user" in self.scope
+                "user" in self.scope
         ), "AuthenticationMiddleware must be installed to access request.user"
         return self.scope["user"]
 
@@ -173,7 +172,7 @@ async def empty_send(message: Message) -> None:
 
 class Request(HTTPConnection):
     def __init__(
-        self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send
+            self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send
     ):
         super().__init__(scope)
         assert scope["type"] == "http"
@@ -221,6 +220,28 @@ class Request(HTTPConnection):
             self._body = b"".join(chunks)
         return self._body
 
+    async def body(self) -> bytes:
+        if not hasattr(self, "_body"):
+            content_length = self.headers.get('content-length')
+            if content_length:
+                # Allocating a bytearray with a size that matches "content-length" header.
+                body_bytes = bytearray(int(content_length))
+                body_index = 0
+                async for chunk in self.stream():
+                    chunk_length = len(chunk)
+                    body_bytes[body_index:body_index + chunk_length] = chunk
+                    body_index += chunk_length
+                self._body = body_bytes
+                return self._body
+            else:
+                # If the header is not present, reading the chunks until the stream ends.
+                chunks = []
+                async for chunk in self.stream():
+                    chunks.append(chunk)
+                self._body = b"".join(chunks)
+
+        return self._body
+
     async def json(self) -> typing.Any:
         if not hasattr(self, "_json"):
             body = await self.body()
@@ -230,7 +251,7 @@ class Request(HTTPConnection):
     async def form(self) -> FormData:
         if not hasattr(self, "_form"):
             assert (
-                parse_options_header is not None
+                    parse_options_header is not None
             ), "The `python-multipart` library must be installed to use form parsing."
             content_type_header = self.headers.get("Content-Type")
             content_type, options = parse_options_header(content_type_header)

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -13,7 +13,6 @@ try:
 except ImportError:  # pragma: nocover
     parse_options_header = None
 
-
 SERVER_PUSH_HEADERS_TO_COPY = {
     "accept",
     "accept-encoding",
@@ -229,9 +228,7 @@ class Request(HTTPConnection):
                     return self._body
 
             # If the header is not present, reading the chunks until the stream ends.
-            chunks = []
-            async for chunk in self.stream():
-                chunks.append(chunk)
+            chunks = [chunk async for chunk in self.stream()]
             self._body = b"".join(chunks)
         return self._body
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -13,7 +13,6 @@ try:
 except ImportError:  # pragma: nocover
     parse_options_header = None
 
-
 SERVER_PUSH_HEADERS_TO_COPY = {
     "accept",
     "accept-encoding",
@@ -130,21 +129,21 @@ class HTTPConnection(Mapping):
     @property
     def session(self) -> dict:
         assert (
-            "session" in self.scope
+                "session" in self.scope
         ), "SessionMiddleware must be installed to access request.session"
         return self.scope["session"]
 
     @property
     def auth(self) -> typing.Any:
         assert (
-            "auth" in self.scope
+                "auth" in self.scope
         ), "AuthenticationMiddleware must be installed to access request.auth"
         return self.scope["auth"]
 
     @property
     def user(self) -> typing.Any:
         assert (
-            "user" in self.scope
+                "user" in self.scope
         ), "AuthenticationMiddleware must be installed to access request.user"
         return self.scope["user"]
 
@@ -173,7 +172,7 @@ async def empty_send(message: Message) -> None:
 
 class Request(HTTPConnection):
     def __init__(
-        self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send
+            self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send
     ):
         super().__init__(scope)
         assert scope["type"] == "http"
@@ -225,7 +224,7 @@ class Request(HTTPConnection):
                         chunk_length = len(chunk)
                         body_bytes[body_index:body_index + chunk_length] = chunk
                         body_index += chunk_length
-                    self._body = body_bytes
+                    self._body = bytes(body_bytes)
                     return self._body
 
             # If the header is not present, reading the chunks until the stream ends.
@@ -244,7 +243,7 @@ class Request(HTTPConnection):
     async def form(self) -> FormData:
         if not hasattr(self, "_form"):
             assert (
-                parse_options_header is not None
+                    parse_options_header is not None
             ), "The `python-multipart` library must be installed to use form parsing."
             content_type_header = self.headers.get("Content-Type")
             content_type, options = parse_options_header(content_type_header)

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -218,8 +218,7 @@ class Request(HTTPConnection):
             if hasattr(self, "_headers"):
                 content_length = self.headers.get("Content-Length")
                 if content_length:
-                    # Allocating a bytearray with a fixed size,
-                    # that matches "content-length" header.
+                    # Allocating a bytearray large enough to fit "content-length" bytes.
                     body_bytes = bytearray(int(content_length))
                     body_index = 0
                     async for chunk in self.stream():

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -216,14 +216,14 @@ class Request(HTTPConnection):
     async def body(self) -> bytes:
         if not hasattr(self, "_body"):
             if hasattr(self, "_headers"):
-                content_length = self.headers.get('Content-Length')
+                content_length = self.headers.get("Content-Length")
                 if content_length:
                     # Allocating a bytearray with a size that matches "content-length" header.
                     body_bytes = bytearray(int(content_length))
                     body_index = 0
                     async for chunk in self.stream():
                         chunk_length = len(chunk)
-                        body_bytes[body_index:body_index + chunk_length] = chunk
+                        body_bytes[body_index : body_index + chunk_length] = chunk
                         body_index += chunk_length
                     self._body = bytes(body_bytes)
                     return self._body

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -215,24 +215,25 @@ class Request(HTTPConnection):
 
     async def body(self) -> bytes:
         if not hasattr(self, "_body"):
-            content_length = self.headers.get('Content-Length')
-            if content_length:
-                # Allocating a bytearray with a size that matches "content-length" header.
-                body_bytes = bytearray(int(content_length))
-                body_index = 0
-                async for chunk in self.stream():
-                    chunk_length = len(chunk)
-                    body_bytes[body_index:body_index + chunk_length] = chunk
-                    body_index += chunk_length
-                self._body = body_bytes
-                return self._body
-            else:
-                # If the header is not present, reading the chunks until the stream ends.
-                chunks = []
-                async for chunk in self.stream():
-                    chunks.append(chunk)
-                self._body = b"".join(chunks)
+            if hasattr(self, "_headers"):
+                content_length = self.headers.get('Content-Length')
+                if content_length:
+                    # Allocating a bytearray with a size that matches "content-length" header.
+                    body_bytes = bytearray(int(content_length))
+                    body_index = 0
+                    async for chunk in self.stream():
+                        chunk_length = len(chunk)
+                        body_bytes[body_index:body_index + chunk_length] = chunk
+                        body_index += chunk_length
+                    self._body = body_bytes
+                    return self._body
 
+            # If the header is not present, reading the chunks until the stream ends.
+            chunks = []
+            async for chunk in self.stream():
+                chunks.append(chunk)
+
+            self._body = b"".join(chunks)
         return self._body
 
     async def json(self) -> typing.Any:

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -13,6 +13,7 @@ try:
 except ImportError:  # pragma: nocover
     parse_options_header = None
 
+
 SERVER_PUSH_HEADERS_TO_COPY = {
     "accept",
     "accept-encoding",
@@ -129,21 +130,21 @@ class HTTPConnection(Mapping):
     @property
     def session(self) -> dict:
         assert (
-                "session" in self.scope
+            "session" in self.scope
         ), "SessionMiddleware must be installed to access request.session"
         return self.scope["session"]
 
     @property
     def auth(self) -> typing.Any:
         assert (
-                "auth" in self.scope
+            "auth" in self.scope
         ), "AuthenticationMiddleware must be installed to access request.auth"
         return self.scope["auth"]
 
     @property
     def user(self) -> typing.Any:
         assert (
-                "user" in self.scope
+            "user" in self.scope
         ), "AuthenticationMiddleware must be installed to access request.user"
         return self.scope["user"]
 
@@ -172,7 +173,7 @@ async def empty_send(message: Message) -> None:
 
 class Request(HTTPConnection):
     def __init__(
-            self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send
+        self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send
     ):
         super().__init__(scope)
         assert scope["type"] == "http"
@@ -214,17 +215,9 @@ class Request(HTTPConnection):
 
     async def body(self) -> bytes:
         if not hasattr(self, "_body"):
-            chunks = []
-            async for chunk in self.stream():
-                chunks.append(chunk)
-            self._body = b"".join(chunks)
-        return self._body
-
-    async def body(self) -> bytes:
-        if not hasattr(self, "_body"):
             content_length = self.headers.get('Content-Length')
             if content_length:
-                # Allocating a bytearray with a size that matches "Content-Length" header.
+                # Allocating a bytearray with a size that matches "content-length" header.
                 body_bytes = bytearray(int(content_length))
                 body_index = 0
                 async for chunk in self.stream():
@@ -251,7 +244,7 @@ class Request(HTTPConnection):
     async def form(self) -> FormData:
         if not hasattr(self, "_form"):
             assert (
-                    parse_options_header is not None
+                parse_options_header is not None
             ), "The `python-multipart` library must be installed to use form parsing."
             content_type_header = self.headers.get("Content-Type")
             content_type, options = parse_options_header(content_type_header)

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -223,9 +223,9 @@ class Request(HTTPConnection):
                     body_bytes = bytearray(int(content_length))
                     body_index = 0
                     async for chunk in self.stream():
-                        chunk_length = len(chunk)
-                        body_bytes[body_index : body_index + chunk_length] = chunk
-                        body_index += chunk_length
+                        chunk_end_index = body_index + len(chunk)
+                        body_bytes[body_index:chunk_end_index] = chunk
+                        body_index = chunk_end_index
                     self._body = bytes(body_bytes[:body_index])
                     return self._body
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -13,6 +13,7 @@ try:
 except ImportError:  # pragma: nocover
     parse_options_header = None
 
+
 SERVER_PUSH_HEADERS_TO_COPY = {
     "accept",
     "accept-encoding",
@@ -129,21 +130,21 @@ class HTTPConnection(Mapping):
     @property
     def session(self) -> dict:
         assert (
-                "session" in self.scope
+            "session" in self.scope
         ), "SessionMiddleware must be installed to access request.session"
         return self.scope["session"]
 
     @property
     def auth(self) -> typing.Any:
         assert (
-                "auth" in self.scope
+            "auth" in self.scope
         ), "AuthenticationMiddleware must be installed to access request.auth"
         return self.scope["auth"]
 
     @property
     def user(self) -> typing.Any:
         assert (
-                "user" in self.scope
+            "user" in self.scope
         ), "AuthenticationMiddleware must be installed to access request.user"
         return self.scope["user"]
 
@@ -172,7 +173,7 @@ async def empty_send(message: Message) -> None:
 
 class Request(HTTPConnection):
     def __init__(
-            self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send
+        self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send
     ):
         super().__init__(scope)
         assert scope["type"] == "http"
@@ -243,7 +244,7 @@ class Request(HTTPConnection):
     async def form(self) -> FormData:
         if not hasattr(self, "_form"):
             assert (
-                    parse_options_header is not None
+                parse_options_header is not None
             ), "The `python-multipart` library must be installed to use form parsing."
             content_type_header = self.headers.get("Content-Type")
             content_type, options = parse_options_header(content_type_header)

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -229,7 +229,7 @@ class Request(HTTPConnection):
                     self._body = bytes(body_bytes[:body_index])
                     return self._body
 
-            # If the header is not present, reading the chunks until the stream ends.
+            # If the header is not present, read the chunks until the stream ends.
             chunks = [chunk async for chunk in self.stream()]
             self._body = b"".join(chunks)
         return self._body

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -218,7 +218,8 @@ class Request(HTTPConnection):
             if hasattr(self, "_headers"):
                 content_length = self.headers.get("Content-Length")
                 if content_length:
-                    # Allocating a bytearray with a size that matches "content-length" header.
+                    # Allocating a bytearray with a fixed size,
+                    # that matches "content-length" header.
                     body_bytes = bytearray(int(content_length))
                     body_index = 0
                     async for chunk in self.stream():


### PR DESCRIPTION
I ran into a huge performance overhead when HTTP payloads are big.
The bottleneck is ` request.body()` awaitable, which is used in every POST request.

What did I add?
I used the http header "Content-Length", to allocate a bytearray() with the exact size, and wrote the requests bytes into that bytearray buffer.

It appeared to be much more efficient, because the previous code used bytes.append() for every chunk.
These append() calls caused a duplication of the bytes array by the python interpreter, every time it reached it's half capacity, and it is not the best practice when working with bytes.

Whenever Content-Length is present (it should be present in every valid post request),
by pre-allocating the buffer we significantly decreasing the time it takes to `await request.body()`to join the chunks.
Up to 6 times faster than current request.body().
