### PR TITLE
configure pytest to be stricter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,4 +16,19 @@ profile = black
 combine_as_imports = True
 
 [tool:pytest]
-addopts = --cov-report= --cov=starlette --cov=tests -rxXs
+addopts =
+  --cov-report=term-missing:skip-covered
+  --cov=starlette
+  --cov=tests
+  -rxXs
+  --strict-config
+  --strict-markers
+  --cov-config tests/.ignore_lifespan
+  --cov-fail-under=100
+xfail_strict=True
+filterwarnings=
+    error
+    ignore: "@coroutine" decorator is deprecated.*:DeprecationWarning
+    ignore: Using or importing the ABCs from 'collections' instead of from 'collections\.abc' is deprecated.*:DeprecationWarning
+    ignore: The 'context' alias has been deprecated. Please use 'context_value' instead\.:DeprecationWarning
+    ignore: The 'variables' alias has been deprecated. Please use 'variable_values' instead\.:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,9 @@ addopts =
 xfail_strict=True
 filterwarnings=
     error
+    # https://github.com/Tinche/aiofiles/issues/81
     ignore: "@coroutine" decorator is deprecated.*:DeprecationWarning
+    # https://github.com/graphql-python/graphene/issues/1055
     ignore: Using or importing the ABCs from 'collections' instead of from 'collections\.abc' is deprecated.*:DeprecationWarning
     ignore: The 'context' alias has been deprecated. Please use 'context_value' instead\.:DeprecationWarning
     ignore: The 'variables' alias has been deprecated. Please use 'variable_values' instead\.:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ addopts =
   -rxXs
   --strict-config
   --strict-markers
-  --cov-config tests/.ignore_lifespan
 xfail_strict=True
 filterwarnings=
     # Turn warnings that aren't filtered into exceptions

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ addopts =
   --strict-config
   --strict-markers
   --cov-config tests/.ignore_lifespan
-  --cov-fail-under=100
 xfail_strict=True
 filterwarnings=
     error

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ addopts =
   --cov-config tests/.ignore_lifespan
 xfail_strict=True
 filterwarnings=
+    # Turn warnings that aren't filtered into exceptions
     error
     # https://github.com/Tinche/aiofiles/issues/81
     ignore: "@coroutine" decorator is deprecated.*:DeprecationWarning

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -213,13 +213,13 @@ def test_queryparams():
     assert QueryParams(q) == q
 
 
-class TestUploadFile(UploadFile):
+class _TestUploadFile(UploadFile):
     spool_max_size = 1024
 
 
 @pytest.mark.asyncio
 async def test_upload_file():
-    big_file = TestUploadFile("big-file")
+    big_file = _TestUploadFile("big-file")
     await big_file.write(b"big-data" * 512)
     await big_file.write(b"big-data")
     await big_file.seek(0)

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -213,13 +213,13 @@ def test_queryparams():
     assert QueryParams(q) == q
 
 
-class _TestUploadFile(UploadFile):
+class BigUploadFile(UploadFile):
     spool_max_size = 1024
 
 
 @pytest.mark.asyncio
 async def test_upload_file():
-    big_file = _TestUploadFile("big-file")
+    big_file = BigUploadFile("big-file")
     await big_file.write(b"big-data" * 512)
     await big_file.write(b"big-data")
     await big_file.seek(0)


### PR DESCRIPTION
configure pytest to be stricter and fix all the problems that the increased strictness detects,

eg `tests/test_datastructures::TestUploadFile PytestCollectionWarning`