### PR TITLE
Run coverage check in CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -29,5 +29,5 @@ jobs:
         run: "scripts/build"
       - name: "Run tests"
         run: "scripts/test"
-      - name: "Check test coverage"
+      - name: "Enforce coverage"
         run: "scripts/coverage"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -29,3 +29,5 @@ jobs:
         run: "scripts/build"
       - name: "Run tests"
         run: "scripts/test"
+      - name: "Check test coverage"
+        run: "scripts/coverage"


### PR DESCRIPTION
`scripts/test` doesn't run `scripts/coverage` when run in CI (it only runs pytest). Run `scripts/coverage` explicitly. 

This looks like it was an oversight in encode/httpcore#91 that I ended up copying over here.