### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Report a bug to help improve this project
+---
+
+### Checklist
+
+<!-- Please make sure you check all these items before submitting your bug report. -->
+
+- [ ] The bug is reproducible against the latest release and/or `master`.
+- [ ] There are no similar issues or pull requests to fix it yet.
+
+### Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+### To reproduce
+
+<!-- Provide a *minimal* example with steps to reproduce the bug locally.
+
+NOTE: try to keep any external dependencies *at an absolute minimum*
+(middleware, servers, proxies, certificates...).
+In other words, remove anything that doesn't make the bug go away.
+-->
+
+### Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+### Actual behavior
+
+<!-- A clear and concise description of what actually happens. -->
+
+### Debugging material
+
+<!-- Any tracebacks, screenshots, etc. that can help understanding the problem.
+
+NOTE:
+- Please list tracebacks in full (don't truncate them).
+- Consider using `<details>` to make tracebacks/logs collapsible if they're very large (see https://gist.github.com/ericclemmons/b146fe5da72ca1f706b2ef72a20ac39d).
+-->
+
+### Environment
+
+- OS: <!-- eg Linux/Windows/macOS. -->
+- Python version: <!-- eg 3.8.5 (get it with `$ python -V`). -->
+- Starlette version: <!-- eg 0.13.8 (get it with `$ pip show starlette`). -->
+
+### Additional context
+
+<!-- Any additional information that can help understanding the problem.
+
+Eg. linked issues, or a description of what you were trying to achieve. -->

--- a/.github/ISSUE_TEMPLATE/3-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/3-feature-request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest an idea for this project.
+---
+
+### Checklist
+
+<!-- Please make sure you check all these items before submitting your feature request. -->
+
+- [ ] There are no similar issues or pull requests for this yet.
+- [ ] I discussed this idea on the [community chat](https://gitter.im/encode/community) and feedback is positive.
+
+### Is your feature related to a problem? Please describe.
+
+<!-- A clear and concise description of what you are trying to achieve.
+
+Eg "I want to be able to [...] but I can't because [...]". -->
+
+## Describe the solution you would like.
+
+<!-- A clear and concise description of what you would want to happen.
+
+For API changes, try to provide a code snippet of what you would like the API to look like.
+-->
+
+## Describe alternatives you considered
+
+<!-- Please describe any alternative solutions or features you've considered to solve
+your problem and why they wouldn't solve it. -->
+
+## Additional context
+
+<!-- Provide any additional context, screenshots, tracebacks, etc. about the feature here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+# Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true
+contact_links:
+- name: Question
+  url: https://gitter.im/encode/community
+  about: >
+    Ask a question


### PR DESCRIPTION
Copying the setup from httpx & uvicorn. `config.yml` and the feature request YAML should be identical to httpx, but the bug template was adapted slightly for Starlette.

