### PR TITLE
Make scripts compatible with windows

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -1,9 +1,13 @@
 #!/bin/sh -e
 
 if [ -d 'venv' ] ; then
-    PREFIX="venv/bin/"
+  if [ $OSTYPE == "msys" ] || [ $OSTYPE == "cygwin" ]; then
+    export PREFIX="venv/Scripts/"
+  else
+    export PREFIX="venv/bin/"
+  fi
 else
-    PREFIX=""
+  PREFIX=""
 fi
 
 set -x

--- a/scripts/check
+++ b/scripts/check
@@ -2,7 +2,11 @@
 
 export PREFIX=""
 if [ -d 'venv' ] ; then
+  if [ $OSTYPE == "msys" ] || [ $OSTYPE == "cygwin" ]; then
+    export PREFIX="venv/Scripts/"
+  else
     export PREFIX="venv/bin/"
+  fi
 fi
 export SOURCE_FILES="starlette tests"
 

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -2,7 +2,11 @@
 
 export PREFIX=""
 if [ -d 'venv' ] ; then
+  if [ $OSTYPE == "msys" ] || [ $OSTYPE == "cygwin" ]; then
+    export PREFIX="venv/Scripts/"
+  else
     export PREFIX="venv/bin/"
+  fi
 fi
 
 set -x

--- a/scripts/docs
+++ b/scripts/docs
@@ -2,7 +2,11 @@
 
 export PREFIX=""
 if [ -d 'venv' ] ; then
+  if [ $OSTYPE == "msys" ] || [ $OSTYPE == "cygwin" ]; then
+    export PREFIX="venv/Scripts/"
+  else
     export PREFIX="venv/bin/"
+  fi
 fi
 
 set -x

--- a/scripts/install
+++ b/scripts/install
@@ -1,7 +1,14 @@
 #!/bin/sh -e
 
+DEFAULT=""
+if [ command -v "python3" ]; then
+  DEFAULT="python3"
+else
+  DEFAULT="python"
+fi
+
 # Use the Python executable provided from the `-p` option, or a default.
-[ "$1" = "-p" ] && PYTHON=$2 || PYTHON="python3"
+[ "$1" = "-p" ] && PYTHON=$2 || PYTHON=$DEFAULT
 
 REQUIREMENTS="requirements.txt"
 VENV="venv"
@@ -9,10 +16,14 @@ VENV="venv"
 set -x
 
 if [ -z "$GITHUB_ACTIONS" ]; then
-    "$PYTHON" -m venv "$VENV"
+  "$PYTHON" -m venv "$VENV"
+  if [ $OSTYPE == "msys" ] || [ $OSTYPE == "cygwin" ]; then
+    PIP="$VENV/Scripts/pip"
+  else
     PIP="$VENV/bin/pip"
+  fi
 else
-    PIP="pip"
+  PIP="pip"
 fi
 
 "$PIP" install -r "$REQUIREMENTS"

--- a/scripts/lint
+++ b/scripts/lint
@@ -2,7 +2,11 @@
 
 export PREFIX=""
 if [ -d 'venv' ] ; then
+  if [ $OSTYPE == "msys" ] || [ $OSTYPE == "cygwin" ]; then
+    export PREFIX="venv/Scripts/"
+  else
     export PREFIX="venv/bin/"
+  fi
 fi
 export SOURCE_FILES="starlette tests"
 

--- a/scripts/test
+++ b/scripts/test
@@ -2,7 +2,11 @@
 
 export PREFIX=""
 if [ -d 'venv' ] ; then
+  if [ $OSTYPE == "msys" ] || [ $OSTYPE == "cygwin" ]; then
+    export PREFIX="venv/Scripts/"
+  else
     export PREFIX="venv/bin/"
+  fi
 fi
 
 set -ex


### PR DESCRIPTION
You can run shell scripts on windows via `Git Bash` or `cygwin`. So for the sake of making development easier on windows, i added windows compatibility to the scripts.