### PR TITLE
Fix FormData.get

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -482,7 +482,7 @@ class FormData(ImmutableMultiDict):
         for key, value in self.multi_items():
             if isinstance(value, UploadFile):
                 await value.close()
-    
+
     def get(self, key: typing.Any, default: typing.Any = None) -> typing.Any:
         value = self.getlist(key)
         if len(value) == 0:

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -482,6 +482,14 @@ class FormData(ImmutableMultiDict):
         for key, value in self.multi_items():
             if isinstance(value, UploadFile):
                 await value.close()
+    
+    def get(self, key: typing.Any, default: typing.Any = None) -> typing.Any:
+        value = self.getlist(key)
+        if len(value) == 0:
+            return default
+        elif len(value) == 1:
+            return value[0]
+        return value
 
 
 class Headers(typing.Mapping[str, str]):


### PR DESCRIPTION
FormData can have multiple value for a single key, e.g. multiple file upload. In this case `FormData.get(key)` should return a list not just one element.
```
ipdb> from starlette.datastructures import FormData
ipdb> imd = FormData([(1,1),(2,2), (1,3)])
ipdb> imd.get(1)
[1, 3]
```