### PR TITLE
TestClient: save event loop when entering context manager

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -455,11 +455,11 @@ class TestClient(requests.Session):
         self.receive_queue = asyncio.Queue()  # type: asyncio.Queue
         self.task = loop.create_task(self.lifespan())
         loop.run_until_complete(self.wait_startup())
+        self.loop = loop
         return self
 
     def __exit__(self, *args: typing.Any) -> None:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.wait_shutdown())
+        self.loop.run_until_complete(self.wait_shutdown())
 
     async def lifespan(self) -> None:
         scope = {"type": "lifespan"}


### PR DESCRIPTION
While running test, asyncio.get_event_loop() in `__exit__` method
can return loop, that differs from that one, that is used in `__enter__` method.

As result it may lead to RuntimeError: got Future <Future pending> attached to a different loop.

Here is error report from my usecase:

```
___________________________________________________________________________________ ERROR at teardown of test_nulled_ratings[shiningforces] ____________________________________________________________________________________

    @fixture(scope="session")
    def test_cli():
        from qllr import app
    
        class PatchedTestClient(TestClient):
            def __enter__(self):
                r = super(PatchedTestClient, self).__enter__()
                self.loop = asyncio.get_event_loop()
                return r
    
            def __exit__(self, *args):
                self.loop.run_until_complete(self.wait_shutdown())
    
        with TestClient(app, raise_server_exceptions=False) as client:
>           yield client

tests/conftest.py:168: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/local/lib/python3.6/site-packages/starlette/testclient.py:462: in __exit__
    loop.run_until_complete(self.wait_shutdown())
/usr/local/lib/python3.6/asyncio/base_events.py:488: in run_until_complete
    return future.result()
/usr/local/lib/python3.6/site-packages/starlette/testclient.py:487: in wait_shutdown
    message = await self.send_queue.get()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Queue at 0x7f5d4f7f2208 maxsize=0 tasks=1>

    @coroutine
    def get(self):
        """Remove and return an item from the queue.
    
        If queue is empty, wait until an item is available.
    
        This method is a coroutine.
        """
        while self.empty():
            getter = self._loop.create_future()
            self._getters.append(getter)
            try:
>               yield from getter
E               RuntimeError: Task <Task pending coro=<TestClient.wait_shutdown() running at /usr/local/lib/python3.6/site-packages/starlette/testclient.py:487> cb=[_run_until_complete_cb() at /usr/local/lib/python3.6/asyncio/base_events.py:200]> got Future <Future pending> attached to a different loop

/usr/local/lib/python3.6/asyncio/queues.py:167: RuntimeError
```

As you may pay attention, that there is also PatchedTestClient with fix, that looks like in this PR. If I use it instead of original TestClient, no error happens.