### PR TITLE
Correct type of AuthenticationBackend.authenticate parameter

### DIFF
--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -96,7 +96,7 @@ class AuthenticationError(Exception):
 
 class AuthenticationBackend:
     async def authenticate(
-        self, conn: HTTPConnection
+        self, conn: Request
     ) -> typing.Optional[typing.Tuple["AuthCredentials", "BaseUser"]]:
         raise NotImplementedError()  # pragma: no cover
 


### PR DESCRIPTION
As far as I can tell from the examples, this is called with a Request, and not an HTTPConnection.