### PR TITLE
Simple support for range headers

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -300,7 +300,7 @@ class FileResponse(Response):
         if self.send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
         else:
-            async with aiofiles.threadpool.open(self.path, mode='rb') as file:
+            async with aiofiles.threadpool.open(self.path, mode="rb") as file:
                 await file.seek(self.offset)
                 more_body = True
                 while more_body:

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -235,7 +235,7 @@ class FileResponse(Response):
 
     def __init__(
         self,
-        path: str,
+        path: typing.Union[str, "os.PathLike[str]"],
         status_code: int = 200,
         headers: dict = None,
         media_type: str = None,
@@ -243,7 +243,7 @@ class FileResponse(Response):
         filename: str = None,
         stat_result: os.stat_result = None,
         method: str = None,
-        offset: int = 0
+        offset: int = 0,
     ) -> None:
         assert aiofiles is not None, "'aiofiles' must be installed to use FileResponse"
         self.path = path
@@ -300,7 +300,10 @@ class FileResponse(Response):
         if self.send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
         else:
-            async with aiofiles.threadpool.open(self.path, mode="rb") as file:
+            # Tentatively ignoring type checking failure to work around the wrong type
+            # definitions for aiofile that come with typeshed. See
+            # https://github.com/python/typeshed/pull/4650
+            async with aiofiles.threadpool.open(self.path, mode="rb") as file:  # type: ignore
                 await file.seek(self.offset)
                 more_body = True
                 while more_body:

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -20,6 +20,7 @@ http.cookies.Morsel._reserved["samesite"] = "SameSite"  # type: ignore
 try:
     import aiofiles
     from aiofiles.os import stat as aio_stat
+    from aiofiles.threadpool import open as aio_open
 except ImportError:  # pragma: nocover
     aiofiles = None  # type: ignore
     aio_stat = None  # type: ignore
@@ -303,7 +304,7 @@ class FileResponse(Response):
             # Tentatively ignoring type checking failure to work around the wrong type
             # definitions for aiofile that come with typeshed. See
             # https://github.com/python/typeshed/pull/4650
-            async with aiofiles.threadpool.open(self.path, mode="rb") as file:  # type: ignore
+            async with aio_open(self.path, mode="rb") as file:  # type: ignore
                 await file.seek(self.offset)
                 more_body = True
                 while more_body:

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -244,6 +244,19 @@ def test_file_response_with_chinese_filename(tmpdir):
     assert response.headers["content-disposition"] == expected_disposition
 
 
+def test_file_response_with_offset(tmpdir):
+    content = b"000 111 222 333 444 555"
+    filename = "offset"
+    path = os.path.join(tmpdir, filename)
+    with open(path, "wb") as f:
+        f.write(content)
+    for offset in range(0,24,4): # skip blocks of 4
+        app = FileResponse(path=path, offset=offset)
+        client = TestClient(app)
+        response = client.get("/")
+        assert response.content == content[offset:]
+
+
 def test_set_cookie():
     async def app(scope, receive, send):
         response = Response("Hello, world!", media_type="text/plain")

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -250,7 +250,7 @@ def test_file_response_with_offset(tmpdir):
     path = os.path.join(tmpdir, filename)
     with open(path, "wb") as f:
         f.write(content)
-    for offset in range(0,24,4): # skip blocks of 4
+    for offset in range(0, 24, 4):  # skip blocks of 4
         app = FileResponse(path=path, offset=offset)
         client = TestClient(app)
         response = client.get("/")


### PR DESCRIPTION
With this change `FileResponse` can be used to serve media that use the range header such as HTML5 `audio` and `video` tags.

For example, using FastAPI app container you can support range like this:
```python
@app.get("/media/{file_path}")
async def media(file_path: str, range_header: Optional[str] = Header('bytes=0-', alias="Range")):
    full_path = os.path.join('media', file_path)
    start, end = range_header.strip('bytes=').split('-')
    size = os.stat(full_path)[6]
    end = min(size-1, int(start)+1024)
    return FileResponse(full_path, status_code=206, offset=int(start), headers={
        'Accept-Ranges': 'bytes',
        'Content-Range': 'bytes %s-%s/%s' % (start, end, size),
        'Content-Length': str(size)
    })
```

with HTML:
```html
<!DOCTYPE html>
<html>
  <body>
    <audio preload="auto" tabindex="0" controls="" type="audio/mp3">
      <source src="media/tunes.mp3">
    </audio>
  </body>
</html>
```