### PR TITLE
Fix functools.partial async handlers for classmethods

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -2,7 +2,6 @@ import asyncio
 import functools
 import inspect
 import re
-import sys
 import traceback
 import typing
 from enum import Enum
@@ -35,9 +34,8 @@ def iscoroutinefunction_or_partial(obj: typing.Any) -> bool:
     Correctly determines if an object is a coroutine function,
     with a fix for partials on Python < 3.8.
     """
-    if sys.version_info < (3, 8):  # pragma: no cover
-        while isinstance(obj, functools.partial):
-            obj = obj.func
+    while isinstance(obj, functools.partial):
+        obj = obj.func
     return inspect.iscoroutinefunction(obj)
 
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -32,7 +32,7 @@ class Match(Enum):
 def iscoroutinefunction_or_partial(obj: typing.Any) -> bool:
     """
     Correctly determines if an object is a coroutine function,
-    with a fix for partials on Python < 3.8.
+    by unwrapping functools.partial objects.
     """
     while isinstance(obj, functools.partial):
         obj = obj.func

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -32,7 +32,7 @@ class Match(Enum):
 def iscoroutinefunction_or_partial(obj: typing.Any) -> bool:
     """
     Correctly determines if an object is a coroutine function,
-    by unwrapping functools.partial objects.
+    including those wrapped in functools.partial objects.
     """
     while isinstance(obj, functools.partial):
         obj = obj.func

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -590,16 +590,35 @@ def test_raise_on_shutdown():
             pass  # pragma: nocover
 
 
+class AsyncEndpointClassMethod:
+    @classmethod
+    async def async_endpoint(cls, arg, request):
+        return JSONResponse({"arg": arg})
+
+
 async def _partial_async_endpoint(arg, request):
     return JSONResponse({"arg": arg})
 
 
 partial_async_endpoint = functools.partial(_partial_async_endpoint, "foo")
+partial_cls_async_endpoint = functools.partial(
+    AsyncEndpointClassMethod.async_endpoint, "foo"
+)
 
-partial_async_app = Router(routes=[Route("/", partial_async_endpoint)])
+partial_async_app = Router(
+    routes=[
+        Route("/", partial_async_endpoint),
+        Route("/cls", partial_cls_async_endpoint),
+    ]
+)
 
 
 def test_partial_async_endpoint():
-    response = TestClient(partial_async_app).get("/")
+    test_client = TestClient(partial_async_app)
+    response = test_client.get("/")
     assert response.status_code == 200
     assert response.json() == {"arg": "foo"}
+
+    cls_method_response = test_client.get("/cls")
+    assert cls_method_response.status_code == 200
+    assert cls_method_response.json() == {"arg": "foo"}


### PR DESCRIPTION
This was my fault for not properly checking all of the cases when I added #984. Apparently, on Python 3.8, partials of classmethods are still not correctly identified as coroutines.

An attempt to fix #1107 