### PR TITLE
docs: fix simple typo, ougoging -> outgoing

### DIFF
--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -38,7 +38,7 @@ class GZipResponder:
         message_type = message["type"]
         if message_type == "http.response.start":
             # Don't send the initial message until we've determined how to
-            # modify the ougoging headers correctly.
+            # modify the outgoing headers correctly.
             self.initial_message = message
         elif message_type == "http.response.body" and not self.started:
             self.started = True


### PR DESCRIPTION
There is a small typo in starlette/middleware/gzip.py.

Should read `outgoing` rather than `ougoging`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md