### PR TITLE
Fix middleware traceback fetching on Python 3.8+, fix ResourceWarnings in TestClient, fix CI build

### DIFF
--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -217,15 +217,15 @@ class ServerErrorMiddleware:
         traceback_obj = traceback.TracebackException.from_exception(
             exc, capture_locals=True
         )
-        frames = inspect.getinnerframes(
-            traceback_obj.exc_traceback, limit  # type: ignore
-        )
 
         exc_html = ""
         is_collapsed = False
-        for frame in reversed(frames):
-            exc_html += self.generate_frame_html(frame, is_collapsed)
-            is_collapsed = True
+        exc_traceback = exc.__traceback__
+        if exc_traceback is not None:
+            frames = inspect.getinnerframes(exc_traceback, limit)
+            for frame in reversed(frames):
+                exc_html += self.generate_frame_html(frame, is_collapsed)
+                is_collapsed = True
 
         # escape error class and text
         error = (


### PR DESCRIPTION
This would ideally be 3 separate PRs, but all of these issues have broken the build on master so it'd be difficult to demonstrate them working separately. Still, let me know if you'd like me to split things up.

The issues are:
1. Mypy 0.800 has some changes w.r.t module discovery. The mypy run was failing because mypy wanted the test functions in `tests/middleware/*` to have type annotations, despite this being disabled for `tests` submodules. Mypy was not correctly identifying that these tests were submodules due to the lack of an `__init__.py` file. See somebody having a similar problem in python/mypy#9974. An alternative (or something we could _also_ do) would be to add `namespace_packages = True` to the config. Since we have `__init__.py` files everywhere else, I went with that option for now.
2. Something in a dependency (pytest? Python itself?) changed so that we were having a bunch more `ResourceWarning`s detected due to unclosed sockets. These (Unix) sockets I believe were setup by the asyncio event loop as part of its internal machinery. In the `TestClient`, in the `WebSocketTestSession` we weren't closing the event loop used by the worker thread there. I changed the loop creation to be done inside the thread (since it is only used by the thread, and can never be used again once the thread has completed) and closed the loop at the end of its use (also in the thread). Possibly fixes #1050 
3. In `ServerErrorMiddleware` we were using the undocumented `exc_traceback` attribute of `TracebackError`. This attribute was removed for [bpo42482](https://bugs.python.org/issue42482) in Python 3.9.1 & 3.8.7. I switched to using the `__traceback__` attribute of exceptions which I think should have the same value (it at least produces the same HTML for the test case we have). I also added a check that the exception actually had a traceback, which we weren't doing previously but probably should've been. Fixes #1131, #1126