### PR TITLE
Added timeout to WebSocketTestSession.receive() methods

### DIFF
--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -80,9 +80,9 @@ May raise `starlette.websockets.WebSocketDisconnect` if the application does not
 
 #### Receiving data
 
-* `.receive_text()` - Wait for incoming text sent by the application and return it.
-* `.receive_bytes()` - Wait for incoming bytestring sent by the application and return it.
-* `.receive_json(mode="text")` - Wait for incoming json data sent by the application and return it. Use `mode="binary"` to send JSON over binary data frames.
+* `.receive_text(timeout=None)` - Wait for incoming text sent by the application and return it.
+* `.receive_bytes(timeout=None)` - Wait for incoming bytestring sent by the application and return it.
+* `.receive_json(mode="text", timeout=None)` - Wait for incoming json data sent by the application and return it. Use `mode="binary"` to send JSON over binary data frames.
 
 May raise `starlette.websockets.WebSocketDisconnect`.
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -335,25 +335,25 @@ class WebSocketTestSession:
     def close(self, code: int = 1000) -> None:
         self.send({"type": "websocket.disconnect", "code": code})
 
-    def receive(self) -> Message:
-        message = self._send_queue.get()
+    def receive(self, timeout: float = None) -> Message:
+        message = self._send_queue.get(timeout=timeout)
         if isinstance(message, BaseException):
             raise message
         return message
 
-    def receive_text(self) -> str:
-        message = self.receive()
+    def receive_text(self, timeout: float = None) -> str:
+        message = self.receive(timeout)
         self._raise_on_close(message)
         return message["text"]
 
-    def receive_bytes(self) -> bytes:
-        message = self.receive()
+    def receive_bytes(self, timeout: float = None) -> bytes:
+        message = self.receive(timeout)
         self._raise_on_close(message)
         return message["bytes"]
 
-    def receive_json(self, mode: str = "text") -> typing.Any:
+    def receive_json(self, mode: str = "text", timeout: float = None) -> typing.Any:
         assert mode in ["text", "binary"]
-        message = self.receive()
+        message = self.receive(timeout)
         self._raise_on_close(message)
         if mode == "text":
             text = message["text"]


### PR DESCRIPTION
The purpose of this PR is to make testing websockets easier.