### PR TITLE
Fix code highlight

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,8 +35,8 @@ nav:
 markdown_extensions:
   - mkautodoc
   - admonition
-  - pymdownx.highlight
-  - pymdownx.superfences
+  - codehilite:
+      css_class: highlight
 
 extra_javascript:
   - 'js/chat.js'


### PR DESCRIPTION
oups, just pushed this PR because httpx/uvicorn are doing the same and see it exists already in https://github.com/encode/starlette/pull/1136

so not sure it's relevant, but in current state docs are not highlighted, locally with this PR it is, so maybe it's because docs from master aren't "live", not sure