### PR TITLE
Clean up param "workers" in WSGIMiddleware

### DIFF
--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -54,7 +54,7 @@ def build_environ(scope: Scope, body: bytes) -> dict:
 
 
 class WSGIMiddleware:
-    def __init__(self, app: typing.Callable, workers: int = 10) -> None:
+    def __init__(self, app: typing.Callable) -> None:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:


### PR DESCRIPTION
Param `workers` in `WSGIMiddleware.__init__` has not been used
since 0.6.3, which is changed in GH-164, commit 96c51c9.

We formerly used a `ThreadPoolExecutor`, which support setting worker numbers. Later it was changed to used the default executor. 

```python
# 0.5.2 2018-10-17 860fdf6c8b0eb88b9668153fdf2bf0352ec3152a

class WSGIMiddleware:
    def __init__(self, app: typing.Callable, workers: int = 10) -> None:
        self.app = app
        self.executor = ThreadPoolExecutor(max_workers=workers)

    async def __call__(self, receive: Receive, send: Send) -> None:
        ...
        wsgi = self.loop.run_in_executor(
            self.executor, self.wsgi, environ, self.start_response
        )


# 0.6.3 2018-10-31 96c51c959ae5592194f0b785a424e225cd4f4d3c

class WSGIMiddleware:
    ...
    async def __call__(self, receive: Receive, send: Send) -> None:
        # custom executor is dropped
        wsgi = self.loop.run_in_executor(
            None, self.wsgi, environ, self.start_response
        )
```

I don't think anyone is still using the "worker" param after more than 2 years. ~~But out of caution, only made a `DeprecationWarning` first. Cause I'm not sure which is the correct time to obsolete this param in init, just gave a release number "1.0", which may need to be adjusted.~~ The parameter was removed.