### PR TITLE
reverse url lookup for custom middleware in subapp fixed

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -15,6 +15,8 @@ class BaseHTTPMiddleware:
     def __init__(self, app: ASGIApp, dispatch: DispatchFunction = None) -> None:
         self.app = app
         self.dispatch_func = self.dispatch if dispatch is None else dispatch
+        if hasattr(app, "routes"):
+            self.routes = self.app.routes
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -16,7 +16,7 @@ class BaseHTTPMiddleware:
         self.app = app
         self.dispatch_func = self.dispatch if dispatch is None else dispatch
         if hasattr(app, "routes"):
-            self.routes = self.app.routes
+            self.routes = self.app.routes  # type: ignore
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":


### PR DESCRIPTION
Applying custom middleware into sub application will cause no routes to be found when `request.url_for("subapp:route_remain")` is called. It was because the `self.routes` for Mount will be `None` as the Middleware layer wraps it.