### PR TITLE
Pin sqlalchemy to versions before 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ databases[sqlite]
 flake8
 isort==5.*
 mypy
+sqlalchemy<1.4
 pytest
 pytest-cov
 pytest-asyncio


### PR DESCRIPTION
If I try to run tests on `master`:

```
_____________________________________________________________________________________ ERROR collecting tests/test_database.py _____________________________________________________________________________________
ImportError while importing test module '/home/jordan/src/starlette/tests/test_database.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../.pyenv/versions/3.7.5/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_database.py:31: in <module>
    database = databases.Database(DATABASE_URL, force_rollback=True)
venv/lib/python3.7/site-packages/databases/core.py:66: in __init__
    backend_cls = import_from_string(backend_str)
venv/lib/python3.7/site-packages/databases/importer.py:21: in import_from_string
    raise exc from None
venv/lib/python3.7/site-packages/databases/importer.py:18: in import_from_string
    module = importlib.import_module(module_str)
../../.pyenv/versions/3.7.5/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
venv/lib/python3.7/site-packages/databases/backends/sqlite.py:8: in <module>
    from sqlalchemy.engine.result import ResultMetaData, RowProxy
E   ImportError: cannot import name 'RowProxy' from 'sqlalchemy.engine.result' (/home/jordan/src/starlette/venv/lib/python3.7/site-packages/sqlalchemy/engine/result.py)
```

It seems that sqlalchemy 1.4 changed the name from `RowProxy` to `Row`, and `databases` probably needs to be updated.  This PR pins sqlalchemy to versions before 1.4 which is the quickest fix for the issue.