### PR TITLE
anyio integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 # Starlette
 
 Starlette is a lightweight [ASGI](https://asgi.readthedocs.io/en/latest/) framework/toolkit,
-which is ideal for building high performance asyncio services.
+which is ideal for building high performance async services.
 
 It is production-ready, and gives you the following:
 
@@ -38,7 +38,8 @@ It is production-ready, and gives you the following:
 * Session and Cookie support.
 * 100% test coverage.
 * 100% type annotated codebase.
-* Zero hard dependencies.
+* Few hard dependencies.
+* Compatible with `asyncio and `trio` backends.
 
 ## Requirements
 
@@ -86,7 +87,7 @@ For a more complete example, see [encode/starlette-example](https://github.com/e
 
 ## Dependencies
 
-Starlette does not have any hard dependencies, but the following are optional:
+Starlette only requires `anyio`, and the following are optional:
 
 * [`requests`][requests] - Required if you want to use the `TestClient`.
 * [`aiofiles`][aiofiles] - Required if you want to use `FileResponse` or `StaticFiles`.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It is production-ready, and gives you the following:
 * 100% test coverage.
 * 100% type annotated codebase.
 * Few hard dependencies.
-* Compatible with `asyncio and `trio` backends.
+* Compatible with `asyncio` and `trio` backends.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ For a more complete example, see [encode/starlette-example](https://github.com/e
 Starlette only requires `anyio`, and the following are optional:
 
 * [`requests`][requests] - Required if you want to use the `TestClient`.
-* [`aiofiles`][aiofiles] - Required if you want to use `FileResponse` or `StaticFiles`.
 * [`jinja2`][jinja2] - Required if you want to use `Jinja2Templates`.
 * [`python-multipart`][python-multipart] - Required if you want to support form parsing, with `request.form()`.
 * [`itsdangerous`][itsdangerous] - Required for `SessionMiddleware` support.
@@ -170,7 +169,6 @@ gunicorn -k uvicorn.workers.UvicornH11Worker ...
 <p align="center"><i>Starlette is <a href="https://github.com/encode/starlette/blob/master/LICENSE.md">BSD licensed</a> code. Designed & built in Brighton, England.</i></p>
 
 [requests]: http://docs.python-requests.org/en/master/
-[aiofiles]: https://github.com/Tinche/aiofiles
 [jinja2]: http://jinja.pocoo.org/
 [python-multipart]: https://andrew-d.github.io/python-multipart/
 [graphene]: https://graphene-python.org/

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,6 @@ For a more complete example, [see here](https://github.com/encode/starlette-exam
 Starlette does not have any hard dependencies, but the following are optional:
 
 * [`requests`][requests] - Required if you want to use the `TestClient`.
-* [`aiofiles`][aiofiles] - Required if you want to use `FileResponse` or `StaticFiles`.
 * [`jinja2`][jinja2] - Required if you want to use `Jinja2Templates`.
 * [`python-multipart`][python-multipart] - Required if you want to support form parsing, with `request.form()`.
 * [`itsdangerous`][itsdangerous] - Required for `SessionMiddleware` support.
@@ -161,7 +160,6 @@ gunicorn -k uvicorn.workers.UvicornH11Worker ...
 <p align="center"><i>Starlette is <a href="https://github.com/encode/starlette/blob/master/LICENSE.md">BSD licensed</a> code. Designed & built in Brighton, England.</i></p>
 
 [requests]: http://docs.python-requests.org/en/master/
-[aiofiles]: https://github.com/Tinche/aiofiles
 [jinja2]: http://jinja.pocoo.org/
 [python-multipart]: https://andrew-d.github.io/python-multipart/
 [graphene]: https://graphene-python.org/

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ It is production-ready, and gives you the following:
 * Session and Cookie support.
 * 100% test coverage.
 * 100% type annotated codebase.
-* Zero hard dependencies.
+* Few hard dependencies.
 
 ## Requirements
 
@@ -79,7 +79,7 @@ For a more complete example, [see here](https://github.com/encode/starlette-exam
 
 ## Dependencies
 
-Starlette does not have any hard dependencies, but the following are optional:
+Starlette only requires `anyio`, and the following dependencies are optional:
 
 * [`requests`][requests] - Required if you want to use the `TestClient`.
 * [`jinja2`][jinja2] - Required if you want to use `Jinja2Templates`.

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -35,7 +35,8 @@ case you should use `client = TestClient(app, raise_server_exceptions=False)`.
 
 `TestClient.async_backend` is a dictionary which allows you to set the options
 for the backend used to run tests.  These options are passed to
-`anyio.start_blocking_portal()`.  By default, `asyncio` is used.
+`anyio.start_blocking_portal()`. See the [anyio documentation](https://anyio.readthedocs.io/en/stable/basics.html#backend-options)
+for more information about backend options.  By default, `asyncio` is used.
 
 To run `Trio`, set `async_backend["backend"] = "trio"`, for example:
 

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -31,6 +31,21 @@ application. Occasionally you might want to test the content of 500 error
 responses, rather than allowing client to raise the server exception. In this
 case you should use `client = TestClient(app, raise_server_exceptions=False)`.
 
+### Selecting the Async backend
+
+`TestClient.async_backend` is a dictionary which allows you to set the options
+for the backend used to run tests.  These options are passed to
+`anyio.start_blocking_portal()`.  By default, `asyncio` is used.
+
+To run `Trio`, set `async_backend["backend"] = "trio"`, for example:
+
+```python
+def test_app()
+    client = TestClient(app)
+    client.async_backend["backend"] = "trio"
+    ...
+```
+
 ### Testing WebSocket sessions
 
 You can also test websocket sessions with the test client.
@@ -71,6 +86,8 @@ always raised by the test client.
 * `.websocket_connect(url, subprotocols=None, **options)` - Takes the same set of arguments as `requests.get()`.
 
 May raise `starlette.websockets.WebSocketDisconnect` if the application does not accept the websocket connection.
+
+`websocket_connect()` must be used as a context manager (in a `with` block).
 
 #### Sending data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 aiofiles
 graphene
 itsdangerous
-jinja2
+jinja2<3
 python-multipart
 pyyaml
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ types-requests
 types-contextvars
 types-aiofiles
 types-PyYAML
+types-dataclasses
 pytest
 pytest-cov
 trio

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ isort==5.*
 mypy
 pytest
 pytest-cov
-pytest-asyncio
+trio
 
 # Documentation
 mkdocs

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 aiofiles
 graphene
 itsdangerous
-jinja2<3
+jinja2
 python-multipart
 pyyaml
 requests

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     packages=get_packages("starlette"),
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
-    install_requires=["anyio<3,>=2"],
+    install_requires=["anyio>=3.0.0rc1"],
     extras_require={
         "full": [
             "aiofiles",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     packages=get_packages("starlette"),
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
-    install_requires=["anyio>=3.0.0rc1"],
+    install_requires=["anyio>=3.0.0rc2"],
     extras_require={
         "full": [
             "aiofiles",

--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,9 @@ setup(
     packages=get_packages("starlette"),
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
-    install_requires=["anyio>=3.0.0rc2"],
+    install_requires=["anyio>=3.0.0rc3"],
     extras_require={
         "full": [
-            "aiofiles",
             "graphene",
             "itsdangerous",
             "jinja2",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     packages=get_packages("starlette"),
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
-    install_requires=["anyio>=3.0.0rc3"],
+    install_requires=["anyio>=3.0.0rc4"],
     extras_require={
         "full": [
             "graphene",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     packages=get_packages("starlette"),
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
+    instal_requires=["anyio<3,>=2"],
     extras_require={
         "full": [
             "aiofiles",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     packages=get_packages("starlette"),
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
-    instal_requires=["anyio<3,>=2"],
+    install_requires=["anyio<3,>=2"],
     extras_require={
         "full": [
             "aiofiles",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
-    install_requires=["anyio>=3.0.0rc4"],
+    install_requires=["anyio>=3.0.0,<4"],
     extras_require={
         "full": [
             "graphene",

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -1,5 +1,7 @@
 import typing
 
+import anyio
+
 from starlette.datastructures import State, URLPath
 from starlette.exceptions import ExceptionMiddleware
 from starlette.middleware import Middleware
@@ -109,7 +111,9 @@ class Starlette:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope["app"] = self
-        await self.middleware_stack(scope, receive, send)
+        task_group = scope["task_group"] = anyio.create_task_group()
+        async with task_group:
+            await self.middleware_stack(scope, receive, send)
 
     # The following usages are now discouraged in favour of configuration
     #  during Starlette.__init__(...)

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -1,6 +1,7 @@
 import typing
 
 import anyio
+from anyio.abc import TaskGroup
 
 from starlette.datastructures import State, URLPath
 from starlette.exceptions import ExceptionMiddleware
@@ -37,6 +38,8 @@ class Starlette:
     Shutdown handler callables do not take any arguments, and may be be either
     standard functions, or async functions.
     """
+
+    task_group: TaskGroup
 
     def __init__(
         self,
@@ -111,8 +114,8 @@ class Starlette:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope["app"] = self
-        task_group = scope["task_group"] = anyio.create_task_group()
-        async with task_group:
+        self.task_group = anyio.create_task_group()
+        async with self.task_group:
             await self.middleware_stack(scope, receive, send)
 
     # The following usages are now discouraged in favour of configuration

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -1,8 +1,5 @@
 import typing
 
-import anyio
-from anyio.abc import TaskGroup
-
 from starlette.datastructures import State, URLPath
 from starlette.exceptions import ExceptionMiddleware
 from starlette.middleware import Middleware
@@ -38,8 +35,6 @@ class Starlette:
     Shutdown handler callables do not take any arguments, and may be be either
     standard functions, or async functions.
     """
-
-    task_group: TaskGroup
 
     def __init__(
         self,
@@ -114,9 +109,7 @@ class Starlette:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope["app"] = self
-        self.task_group = anyio.create_task_group()
-        async with self.task_group:
-            await self.middleware_stack(scope, receive, send)
+        await self.middleware_stack(scope, receive, send)
 
     # The following usages are now discouraged in favour of configuration
     #  during Starlette.__init__(...)

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -20,10 +20,10 @@ async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -
         async def task(_handler: typing.Callable, _kwargs: dict) -> Any:
             nonlocal result
             result = await _handler(**_kwargs)
-            await task_group.cancel_scope.cancel()
+            task_group.cancel_scope.cancel()
 
         for handler, kwargs in args:
-            await task_group.spawn(task, handler, kwargs)
+            task_group.spawn(task, handler, kwargs)
 
     return result
 

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -14,7 +14,7 @@ T = typing.TypeVar("T")
 
 
 async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -> None:
-    async def run(handler: typing.Callable[..., typing.Coroutine]) -> None:
+    async def run(handler: typing.Callable[[], typing.Coroutine]) -> None:
         await handler()
         tg.cancel_scope.cancel()
 

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -28,6 +28,7 @@ async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -
 
     return result
 
+
 async def run_in_threadpool(
     func: typing.Callable[..., T], *args: typing.Any, **kwargs: typing.Any
 ) -> T:

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -1,5 +1,4 @@
 import functools
-import sys
 import typing
 from typing import Any, AsyncGenerator, Iterator
 

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -13,6 +13,16 @@ except ImportError:  # pragma: no cover
 T = typing.TypeVar("T")
 
 
+async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -> None:
+    async def run(handler: typing.Callable[..., typing.Coroutine]) -> None:
+        await handler()
+        tg.cancel_scope.cancel()
+
+    async with anyio.create_task_group() as tg:
+        for handler, kwargs in args:
+            tg.start_soon(run, functools.partial(handler, **kwargs))
+
+
 async def run_in_threadpool(
     func: typing.Callable[..., T], *args: typing.Any, **kwargs: typing.Any
 ) -> T:

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -14,13 +14,14 @@ T = typing.TypeVar("T")
 
 
 async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -> None:
-    async def run(handler: typing.Callable[[], typing.Coroutine]) -> None:
-        await handler()
-        tg.cancel_scope.cancel()
+    async with anyio.create_task_group() as task_group:
 
-    async with anyio.create_task_group() as tg:
-        for handler, kwargs in args:
-            tg.start_soon(run, functools.partial(handler, **kwargs))
+        async def run(func: typing.Callable[[], typing.Coroutine]) -> None:
+            await func()
+            task_group.cancel_scope.cancel()
+
+        for func, kwargs in args:
+            task_group.start_soon(run, functools.partial(func, **kwargs))
 
 
 async def run_in_threadpool(

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -21,7 +21,7 @@ async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -
             task_group.cancel_scope.cancel()
 
         for handler, kwargs in args:
-            task_group.spawn(task, handler, kwargs)
+            task_group.start_soon(task, handler, kwargs)
 
 
 async def run_in_threadpool(

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -13,17 +13,6 @@ except ImportError:  # pragma: no cover
 T = typing.TypeVar("T")
 
 
-async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -> None:
-    async with anyio.create_task_group() as task_group:
-
-        async def task(_handler: typing.Callable, _kwargs: dict) -> Any:
-            await _handler(**_kwargs)
-            task_group.cancel_scope.cancel()
-
-        for handler, kwargs in args:
-            task_group.start_soon(task, handler, kwargs)
-
-
 async def run_in_threadpool(
     func: typing.Callable[..., T], *args: typing.Any, **kwargs: typing.Any
 ) -> T:

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -14,18 +14,14 @@ T = typing.TypeVar("T")
 
 
 async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -> None:
-    result: Any = None
     async with anyio.create_task_group() as task_group:
 
         async def task(_handler: typing.Callable, _kwargs: dict) -> Any:
-            nonlocal result
-            result = await _handler(**_kwargs)
+            await _handler(**_kwargs)
             task_group.cancel_scope.cancel()
 
         for handler, kwargs in args:
             task_group.spawn(task, handler, kwargs)
-
-    return result
 
 
 async def run_in_threadpool(

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -18,7 +18,7 @@ async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -
     result: Any = None
     async with anyio.create_task_group() as task_group:
 
-        async def task(_handler, _kwargs) -> Any:
+        async def task(_handler: typing.Callable, _kwargs: dict) -> Any:
             nonlocal result
             result = await _handler(**_kwargs)
             await task_group.cancel_scope.cancel()

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -36,7 +36,7 @@ async def run_in_threadpool(
     elif kwargs:  # pragma: no cover
         # run_sync doesn't accept 'kwargs', so bind them in here
         func = functools.partial(func, **kwargs)
-    return await anyio.run_sync_in_worker_thread(func, *args)
+    return await anyio.to_thread.run_sync(func, *args)
 
 
 class _StopIteration(Exception):
@@ -56,6 +56,6 @@ def _next(iterator: Iterator) -> Any:
 async def iterate_in_threadpool(iterator: Iterator) -> AsyncGenerator:
     while True:
         try:
-            yield await anyio.run_sync_in_worker_thread(_next, iterator)
+            yield await anyio.to_thread.run_sync(_next, iterator)
         except _StopIteration:
             break

--- a/starlette/graphql.py
+++ b/starlette/graphql.py
@@ -31,29 +31,18 @@ class GraphQLApp:
     def __init__(
         self,
         schema: "graphene.Schema",
-        executor: typing.Any = None,
         executor_class: type = None,
         graphiql: bool = True,
     ) -> None:
         self.schema = schema
         self.graphiql = graphiql
-        if executor is None:
-            # New style in 0.10.0. Use 'executor_class'.
-            # See issue https://github.com/encode/starlette/issues/242
-            self.executor = executor
-            self.executor_class = executor_class
-            self.is_async = executor_class is not None and issubclass(
-                executor_class, AsyncioExecutor
-            )
-        else:
-            # Old style. Use 'executor'.
-            # We should remove this in the next median/major version bump.
-            self.executor = executor
-            self.executor_class = None
-            self.is_async = isinstance(executor, AsyncioExecutor)
+        self.executor_class = executor_class
+        self.is_async = executor_class is not None and issubclass(
+            executor_class, AsyncioExecutor
+        )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if self.executor is None and self.executor_class is not None:
+        if self.executor_class is not None:
             self.executor = self.executor_class()
 
         request = Request(scope, receive=receive)

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -29,13 +29,12 @@ class BaseHTTPMiddleware:
     async def call_next(self, request: Request) -> Response:
         send_stream, recv_stream = anyio.create_memory_object_stream()
         scope = request.scope
-        task_group = scope["task_group"]
 
         async def coro() -> None:
             async with send_stream:
                 await self.app(scope, request.receive, send_stream.send)
 
-        task_group.start_soon(coro)
+        scope["app"].task_group.start_soon(coro)
 
         try:
             message = await recv_stream.receive()

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -36,7 +36,7 @@ class BaseHTTPMiddleware:
         async def coro() -> None:
             async with send_stream:
                 try:
-                    await self.app(scope, recv_stream.receive, send_stream.send)
+                    await self.app(scope, request.receive, send_stream.send)
                 except BaseException as exc:
                     nonlocal coro_exc
                     coro_exc = exc

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -27,7 +27,9 @@ class BaseHTTPMiddleware:
         await response(scope, receive, send)
 
     async def call_next(self, request: Request) -> Response:
-        send_stream, recv_stream = anyio.create_memory_object_stream(0, item_type=Message)  # XXX size
+        send_stream, recv_stream = anyio.create_memory_object_stream(
+            0, item_type=Message
+        )  # XXX size
 
         scope = request.scope
         task_group = scope["task_group"]

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -29,7 +29,7 @@ class BaseHTTPMiddleware:
     async def call_next(self, request: Request) -> Response:
         send_stream, recv_stream = anyio.create_memory_object_stream(
             0, item_type=Message
-        )  # XXX size
+        )
 
         scope = request.scope
         task_group = scope["task_group"]
@@ -43,7 +43,6 @@ class BaseHTTPMiddleware:
         try:
             message = await recv_stream.receive()
         except anyio.EndOfStream:
-            print("WHAT " * 10)
             raise RuntimeError("No response returned.")
 
         assert message["type"] == "http.response.start"

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -4,7 +4,7 @@ import anyio
 
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 RequestResponseEndpoint = typing.Callable[[Request], typing.Awaitable[Response]]
 DispatchFunction = typing.Callable[

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -35,7 +35,7 @@ class BaseHTTPMiddleware:
             async with send_stream:
                 await self.app(scope, request.receive, send_stream.send)
 
-        task_group.spawn(coro)
+        task_group.start_soon(coro)
 
         try:
             message = await recv_stream.receive()

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -27,10 +27,7 @@ class BaseHTTPMiddleware:
         await response(scope, receive, send)
 
     async def call_next(self, request: Request) -> Response:
-        send_stream, recv_stream = anyio.create_memory_object_stream(
-            0, item_type=Message
-        )
-
+        send_stream, recv_stream = anyio.create_memory_object_stream()
         scope = request.scope
         task_group = scope["task_group"]
 

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -54,6 +54,7 @@ class BaseHTTPMiddleware:
             request = Request(scope, receive=receive)
             response = await self.dispatch_func(request, call_next)
             await response(scope, receive, send)
+            task_group.cancel_scope.cancel()
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -4,7 +4,6 @@ import typing
 
 import anyio
 
-from starlette.concurrency import run_in_threadpool
 from starlette.types import Message, Receive, Scope, Send
 
 

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -86,7 +86,7 @@ class WSGIResponder:
         environ = build_environ(self.scope, body)
 
         async with anyio.create_task_group() as task_group:
-            task_group.spawn(self.sender, send)
+            task_group.start_soon(self.sender, send)
             async with self.stream_send:
                 await anyio.to_thread.run_sync(self.wsgi, environ, self.start_response)
         if self.exc_info is not None:

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -85,21 +85,27 @@ class WSGIResponder:
             more_body = message.get("more_body", False)
         environ = build_environ(self.scope, body)
 
+        self.send_done = anyio.Event()
+
         async with anyio.create_task_group() as task_group:
             task_group.spawn(self.sender, send)
             async with self.stream_send:
                 await anyio.run_sync_in_worker_thread(
                     self.wsgi, environ, self.start_response
                 )
+            await self.send_done.wait()
             if self.exc_info is not None:
                 raise self.exc_info[0].with_traceback(
                     self.exc_info[1], self.exc_info[2]
                 )
 
     async def sender(self, send: Send) -> None:
-        async with self.stream_receive:
-            async for message in self.stream_receive:
-                await send(message)
+        try:
+            async with self.stream_receive:
+                async for message in self.stream_receive:
+                    await send(message)
+        finally:
+            self.send_done.set()
 
     def start_response(
         self,

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -88,7 +88,9 @@ class WSGIResponder:
             sender_finished = anyio.create_event()
             try:
                 await task_group.spawn(self.sender, send, sender_finished)
-                await anyio.run_sync_in_worker_thread(self.wsgi, environ, self.start_response)
+                await anyio.run_sync_in_worker_thread(
+                    self.wsgi, environ, self.start_response
+                )
                 self.send_queue.append(None)
                 await self.send_event.set()
                 await sender_finished.wait()

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -101,7 +101,7 @@ class WSGIResponder:
             finally:
                 await task_group.cancel_scope.cancel()
 
-    async def sender(self, send: Send, finished) -> None:
+    async def sender(self, send: Send, finished: anyio.abc.Event) -> None:
         try:
             while True:
                 if self.send_queue:

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -253,7 +253,9 @@ class Request(HTTPConnection):
     async def is_disconnected(self) -> bool:
         if not self._is_disconnected:
             message: Message = {}
-            async with anyio.move_on_after(0.001):  # XXX: to small of a deadline and this blocks
+            async with anyio.move_on_after(
+                0.001
+            ):  # XXX: to small of a deadline and this blocks
                 message = await self._receive()
 
             if message.get("type") == "http.disconnect":

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -253,7 +253,7 @@ class Request(HTTPConnection):
     async def is_disconnected(self) -> bool:
         if not self._is_disconnected:
             message: Message = {}
-            async with anyio.move_on_after(0.0000001):
+            async with anyio.move_on_after(0.001):  # XXX: to small of a deadline and this blocks
                 message = await self._receive()
 
             if message.get("type") == "http.disconnect":

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -253,8 +253,8 @@ class Request(HTTPConnection):
     async def is_disconnected(self) -> bool:
         if not self._is_disconnected:
             message: Message = {}
-            with anyio.move_on_after(0.001):
-                # XXX: to small of a deadline and this blocks
+
+            with anyio.move_on_after(0):
                 message = await self._receive()
 
             if message.get("type") == "http.disconnect":

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -253,9 +253,8 @@ class Request(HTTPConnection):
     async def is_disconnected(self) -> bool:
         if not self._is_disconnected:
             message: Message = {}
-            async with anyio.move_on_after(
-                0.001
-            ):  # XXX: to small of a deadline and this blocks
+            with anyio.move_on_after(0.001):
+                # XXX: to small of a deadline and this blocks
                 message = await self._receive()
 
             if message.get("type") == "http.disconnect":

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -252,7 +252,7 @@ class Request(HTTPConnection):
 
     async def is_disconnected(self) -> bool:
         if not self._is_disconnected:
-            message = {}
+            message: Message = {}
             async with anyio.move_on_after(0.0000001):
                 message = await self._receive()
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -1,8 +1,9 @@
-import asyncio
 import json
 import typing
 from collections.abc import Mapping
 from http import cookies as http_cookies
+
+import anyio
 
 from starlette.datastructures import URL, Address, FormData, Headers, QueryParams, State
 from starlette.formparsers import FormParser, MultiPartParser
@@ -251,10 +252,9 @@ class Request(HTTPConnection):
 
     async def is_disconnected(self) -> bool:
         if not self._is_disconnected:
-            try:
-                message = await asyncio.wait_for(self._receive(), timeout=0.0000001)
-            except asyncio.TimeoutError:
-                message = {}
+            message = {}
+            async with anyio.move_on_after(0.0000001):
+                message = await self._receive()
 
             if message.get("type") == "http.disconnect":
                 self._is_disconnected = True

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -254,7 +254,9 @@ class Request(HTTPConnection):
         if not self._is_disconnected:
             message: Message = {}
 
-            with anyio.move_on_after(0):
+            # If message isn't immediately available, move on
+            with anyio.CancelScope() as cs:
+                cs.cancel()
                 message = await self._receive()
 
             if message.get("type") == "http.disconnect":

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -9,6 +9,8 @@ from email.utils import formatdate
 from mimetypes import guess_type as mimetypes_guess_type
 from urllib.parse import quote, quote_plus
 
+import anyio
+
 from starlette.background import BackgroundTask
 from starlette.concurrency import iterate_in_threadpool, run_until_first_complete
 from starlette.datastructures import URL, MutableHeaders
@@ -16,13 +18,6 @@ from starlette.types import Receive, Scope, Send
 
 # Workaround for adding samesite support to pre 3.8 python
 http.cookies.Morsel._reserved["samesite"] = "SameSite"  # type: ignore
-
-try:
-    import aiofiles
-    from aiofiles.os import stat as aio_stat
-except ImportError:  # pragma: nocover
-    aiofiles = None  # type: ignore
-    aio_stat = None  # type: ignore
 
 
 # Compatibility wrapper for `mimetypes.guess_type` to support `os.PathLike` on <py3.8
@@ -244,7 +239,6 @@ class FileResponse(Response):
         stat_result: os.stat_result = None,
         method: str = None,
     ) -> None:
-        assert aiofiles is not None, "'aiofiles' must be installed to use FileResponse"
         self.path = path
         self.status_code = status_code
         self.filename = filename
@@ -280,7 +274,7 @@ class FileResponse(Response):
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if self.stat_result is None:
             try:
-                stat_result = await aio_stat(self.path)
+                stat_result = await anyio.to_thread.run_sync(os.stat, self.path)
                 self.set_stat_headers(stat_result)
             except FileNotFoundError:
                 raise RuntimeError(f"File at path {self.path} does not exist.")
@@ -298,10 +292,7 @@ class FileResponse(Response):
         if self.send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
         else:
-            # Tentatively ignoring type checking failure to work around the wrong type
-            # definitions for aiofile that come with typeshed. See
-            # https://github.com/python/typeshed/pull/4650
-            async with aiofiles.open(self.path, mode="rb") as file:  # type: ignore
+            async with await anyio.open_file(self.path, mode="rb") as file:
                 more_body = True
                 while more_body:
                     chunk = await file.read(self.chunk_size)

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -219,12 +219,12 @@ class StreamingResponse(Response):
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         async with anyio.create_task_group() as task_group:
 
-            async def wrap(coro: typing.Callable[..., typing.Awaitable]) -> None:
+            async def wrap(coro: typing.Callable[[], typing.Coroutine]) -> None:
                 await coro()
                 task_group.cancel_scope.cancel()
 
             task_group.start_soon(wrap, partial(self.stream_response, send))
-            task_group.start_soon(wrap, partial(self.listen_for_disconnect, receive))
+            await wrap(partial(self.listen_for_disconnect, receive))
 
         if self.background is not None:
             await self.background()

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -219,8 +219,8 @@ class StreamingResponse(Response):
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         async with anyio.create_task_group() as task_group:
 
-            async def wrap(coro: typing.Callable[[], typing.Coroutine]) -> None:
-                await coro()
+            async def wrap(func: typing.Callable[[], typing.Coroutine]) -> None:
+                await func()
                 task_group.cancel_scope.cancel()
 
             task_group.start_soon(wrap, partial(self.stream_response, send))

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -4,7 +4,7 @@ import stat
 import typing
 from email.utils import parsedate
 
-from aiofiles.os import stat as aio_stat
+import anyio
 
 from starlette.datastructures import URL, Headers
 from starlette.responses import (
@@ -154,7 +154,7 @@ class StaticFiles:
                 # directory.
                 continue
             try:
-                stat_result = await aio_stat(full_path)
+                stat_result = await anyio.to_thread.run_sync(os.stat, full_path)
                 return (full_path, stat_result)
             except FileNotFoundError:
                 pass
@@ -187,7 +187,7 @@ class StaticFiles:
             return
 
         try:
-            stat_result = await aio_stat(self.directory)
+            stat_result = await anyio.to_thread.run_sync(os.stat, self.directory)
         except FileNotFoundError:
             raise RuntimeError(
                 f"StaticFiles directory '{self.directory}' does not exist."

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -382,10 +382,10 @@ class TestClient(requests.Session):
     __test__ = False  # For pytest to not discover this up.
 
     #: These options are passed to `anyio.start_blocking_portal()`
-    async_backend = {
+    async_backend: typing.Dict[str, typing.Any] = {
         "backend": "asyncio",
         "backend_options": {},
-    }  # type: typing.Dict[str, typing.Any]
+    }
 
     task: "Future[None]"
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -92,7 +92,11 @@ class _WrapASGI2:
 
 class _ASGIAdapter(requests.adapters.HTTPAdapter):
     def __init__(
-        self, app: ASGI3App, raise_server_exceptions: bool = True, root_path: str = "", async_backend: str = ""
+        self,
+        app: ASGI3App,
+        raise_server_exceptions: bool = True,
+        root_path: str = "",
+        async_backend: str = "",
     ) -> None:
         self.app = app
         self.raise_server_exceptions = raise_server_exceptions
@@ -268,7 +272,9 @@ class WebSocketTestSession:
         self.scope = scope
         self.accepted_subprotocol = None
         self.exit_stack = contextlib.ExitStack()
-        self.portal = self.exit_stack.enter_context(anyio.start_blocking_portal(async_backend))
+        self.portal = self.exit_stack.enter_context(
+            anyio.start_blocking_portal(async_backend)
+        )
         self._receive_queue = queue.Queue()  # type: queue.Queue
         self._send_queue = queue.Queue()  # type: queue.Queue
         self.portal.spawn_task(self._run)
@@ -374,7 +380,9 @@ class TestClient(requests.Session):
     ) -> None:
         super(TestClient, self).__init__()
         if async_backend is None:
-            self.async_backend = os.environ.get("STARLETTE_TESTCLIENT_ASYNC_BACKEND", "asyncio")
+            self.async_backend = os.environ.get(
+                "STARLETTE_TESTCLIENT_ASYNC_BACKEND", "asyncio"
+            )
         else:
             self.async_backend = async_backend
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -8,6 +8,7 @@ import math
 import queue
 import types
 import typing
+from concurrent.futures import Future
 from urllib.parse import unquote, urljoin, urlsplit
 
 import anyio
@@ -284,7 +285,7 @@ class WebSocketTestSession:
         )
 
         try:
-            self.portal.start_task_soon(self._run)
+            _: "Future[None]" = self.portal.start_task_soon(self._run)
             self.send({"type": "websocket.connect"})
             message = self.receive()
             self._raise_on_close(message)
@@ -384,6 +385,8 @@ class TestClient(requests.Session):
         "backend": "asyncio",
         "backend_options": {},
     }  # type: typing.Dict[str, typing.Any]
+
+    task: "Future[None]"
 
     def __init__(
         self,

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -233,7 +233,7 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
                 context = message["context"]
 
         try:
-            with anyio.start_blocking_portal(backend_options={"debug": True}) as portal:
+            with anyio.start_blocking_portal() as portal:
                 portal.call(self.app, scope, receive, send)
         except BaseException as exc:
             if self.raise_server_exceptions:
@@ -266,9 +266,7 @@ class WebSocketTestSession:
         self.scope = scope
         self.accepted_subprotocol = None
         self.exit_stack = contextlib.ExitStack()
-        self.portal = self.exit_stack.enter_context(
-            anyio.start_blocking_portal(backend_options={"debug": True})
-        )
+        self.portal = self.exit_stack.enter_context(anyio.start_blocking_portal())
         self._receive_queue = queue.Queue()  # type: queue.Queue
         self._send_queue = queue.Queue()  # type: queue.Queue
         self.portal.spawn_task(self._run)
@@ -453,7 +451,7 @@ class TestClient(requests.Session):
     def __enter__(self) -> "TestClient":
         self.exit_stack = contextlib.ExitStack()
         self.portal = self.exit_stack.enter_context(
-            anyio.start_blocking_portal(backend_options={"debug": True})
+            anyio.start_blocking_portal()
         )  # XXX backend
         self.stream_send, self.stream_receive = anyio.create_memory_object_stream(
             math.inf

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -380,7 +380,10 @@ class TestClient(requests.Session):
     __test__ = False  # For pytest to not discover this up.
 
     #: These options are passed to `anyio.start_blocking_portal()`
-    async_backend = {"backend": "asyncio", "backend_options": {}}  # type: typing.Dict[str, typing.Any]
+    async_backend = {
+        "backend": "asyncio",
+        "backend_options": {},
+    }  # type: typing.Dict[str, typing.Any]
 
     def __init__(
         self,

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -179,7 +179,8 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
             nonlocal request_complete
 
             if request_complete:
-                await response_complete.wait()
+                if not response_complete.is_set():
+                    await response_complete.wait()
                 return {"type": "http.disconnect"}
 
             body = request.body

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -284,7 +284,7 @@ class WebSocketTestSession:
         )
 
         try:
-            self.portal.spawn_task(self._run)
+            self.portal.start_task_soon(self._run)
             self.send({"type": "websocket.connect"})
             message = self.receive()
             self._raise_on_close(message)
@@ -484,7 +484,7 @@ class TestClient(requests.Session):
             *anyio.create_memory_object_stream(math.inf)
         )
         try:
-            self.task = self.portal.spawn_task(self.lifespan)
+            self.task = self.portal.start_task_soon(self.lifespan)
             self.portal.call(self.wait_startup)
         except Exception:
             self.exit_stack.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,15 @@
 import pytest
 
-@pytest.fixture(params=[
-    pytest.param(('asyncio', {'use_uvloop': True}), id='asyncio+uvloop'),
-    pytest.param(('asyncio', {'use_uvloop': False}), id='asyncio'),
-    pytest.param(('trio', {'restrict_keyboard_interrupt_to_checkpoints': True}), id='trio')
-], autouse=True)
+
+@pytest.fixture(
+    params=[
+        pytest.param(("asyncio", {"use_uvloop": True}), id="asyncio+uvloop"),
+        pytest.param(("asyncio", {"use_uvloop": False}), id="asyncio"),
+        pytest.param(
+            ("trio", {"restrict_keyboard_interrupt_to_checkpoints": True}), id="trio"
+        ),
+    ],
+    autouse=True,
+)
 def anyio_backend(request):
     return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,6 @@ import os
 
 import pytest
 
-from starlette import config
-
 
 @pytest.fixture(
     params=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,21 @@
-import os
-
 import pytest
+
+from starlette.testclient import TestClient
 
 
 @pytest.fixture(
     params=[
-        pytest.param(("asyncio", {"use_uvloop": True}), id="asyncio+uvloop"),
-        pytest.param(("asyncio", {"use_uvloop": False}), id="asyncio"),
         pytest.param(
-            ("trio", {"restrict_keyboard_interrupt_to_checkpoints": True}), id="trio"
+            {"backend": "asyncio", "backend_options": {"use_uvloop": False}},
+            id="asyncio",
         ),
+        pytest.param({"backend": "trio", "backend_options": {}}, id="trio"),
     ],
     autouse=True,
 )
-def anyio_backend(request):
-    os.environ["STARLETTE_TESTCLIENT_ASYNC_BACKEND"] = request.param[0]
-    return request.param
+def anyio_backend(request, monkeypatch):
+    monkeypatch.setattr(TestClient, "async_backend", request.param)
+    return request.param["backend"]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+@pytest.fixture(params=[
+    pytest.param(('asyncio', {'use_uvloop': True}), id='asyncio+uvloop'),
+    pytest.param(('asyncio', {'use_uvloop': False}), id='asyncio'),
+    pytest.param(('trio', {'restrict_keyboard_interrupt_to_checkpoints': True}), id='trio')
+], autouse=True)
+def anyio_backend(request):
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,8 @@
+import os
+
 import pytest
+
+from starlette import config
 
 
 @pytest.fixture(
@@ -12,4 +16,11 @@ import pytest
     autouse=True,
 )
 def anyio_backend(request):
+    os.environ["STARLETTE_TESTCLIENT_ASYNC_BACKEND"] = request.param[0]
     return request.param
+
+
+@pytest.fixture
+def no_trio_support(request):
+    if request.keywords.get("trio"):
+        pytest.skip("Trio not supported (yet!)")

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -143,3 +143,18 @@ def test_app_middleware_argument():
 def test_middleware_repr():
     middleware = Middleware(CustomMiddleware)
     assert repr(middleware) == "Middleware(CustomMiddleware)"
+
+
+def test_fully_evaluated_response():
+    # Test for https://github.com/encode/starlette/issues/1022
+    class CustomMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            await call_next(request)
+            return PlainTextResponse("Custom")
+
+    app = Starlette()
+    app.add_middleware(CustomMiddleware)
+
+    client = TestClient(app)
+    response = client.get("/does_not_exist")
+    assert response.text == "Custom"

--- a/tests/middleware/test_errors.py
+++ b/tests/middleware/test_errors.py
@@ -67,4 +67,5 @@ def test_debug_not_http():
 
     with pytest.raises(RuntimeError):
         client = TestClient(app)
-        client.websocket_connect("/")
+        with client.websocket_connect("/"):
+            pass

--- a/tests/middleware/test_errors.py
+++ b/tests/middleware/test_errors.py
@@ -68,4 +68,4 @@ def test_debug_not_http():
     with pytest.raises(RuntimeError):
         client = TestClient(app)
         with client.websocket_connect("/"):
-            pass
+            pass  # pragma: nocover

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -194,7 +194,7 @@ def test_routes():
     ]
 
 
-def test_app_mount(tmpdir):
+def test_app_mount(tmpdir, no_trio_support):
     path = os.path.join(tmpdir, "example.txt")
     with open(path, "w") as file:
         file.write("<file content>")

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -194,7 +194,7 @@ def test_routes():
     ]
 
 
-def test_app_mount(tmpdir, no_trio_support):
+def test_app_mount(tmpdir):
     path = os.path.join(tmpdir, "example.txt")
     with open(path, "w") as file:
         file.write("<file content>")

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -261,10 +261,14 @@ def test_authentication_required():
 def test_websocket_authentication_required():
     with TestClient(app) as client:
         with pytest.raises(WebSocketDisconnect):
-            client.websocket_connect("/ws")
+            with client.websocket_connect("/ws"):
+                pass
 
         with pytest.raises(WebSocketDisconnect):
-            client.websocket_connect("/ws", headers={"Authorization": "basic foobar"})
+            with client.websocket_connect(
+                "/ws", headers={"Authorization": "basic foobar"}
+            ):
+                pass
 
         with client.websocket_connect(
             "/ws", auth=("tomchristie", "example")
@@ -273,12 +277,14 @@ def test_websocket_authentication_required():
             assert data == {"authenticated": True, "user": "tomchristie"}
 
         with pytest.raises(WebSocketDisconnect):
-            client.websocket_connect("/ws/decorated")
+            with client.websocket_connect("/ws/decorated"):
+                pass
 
         with pytest.raises(WebSocketDisconnect):
-            client.websocket_connect(
+            with client.websocket_connect(
                 "/ws/decorated", headers={"Authorization": "basic foobar"}
-            )
+            ):
+                pass
 
         with client.websocket_connect(
             "/ws/decorated", auth=("tomchristie", "example")

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -262,13 +262,13 @@ def test_websocket_authentication_required():
     with TestClient(app) as client:
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect("/ws"):
-                pass
+                pass  # pragma: nocover
 
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect(
                 "/ws", headers={"Authorization": "basic foobar"}
             ):
-                pass
+                pass  # pragma: nocover
 
         with client.websocket_connect(
             "/ws", auth=("tomchristie", "example")
@@ -278,13 +278,13 @@ def test_websocket_authentication_required():
 
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect("/ws/decorated"):
-                pass
+                pass  # pragma: nocover
 
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect(
                 "/ws/decorated", headers={"Authorization": "basic foobar"}
             ):
-                pass
+                pass  # pragma: nocover
 
         with client.websocket_connect(
             "/ws/decorated", auth=("tomchristie", "example")

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,22 @@
+import anyio
+import pytest
+
+from starlette.concurrency import run_until_first_complete
+
+
+@pytest.mark.anyio
+async def test_run_until_first_complete():
+    task1_finished = anyio.Event()
+    task2_finished = anyio.Event()
+
+    async def task1():
+        task1_finished.set()
+
+    async def task2():
+        await task1_finished.wait()
+        await anyio.sleep(0)  # pragma: nocover
+        task2_finished.set()  # pragma: nocover
+
+    await run_until_first_complete((task1, {}), (task2, {}))
+    assert task1_finished.is_set()
+    assert not task2_finished.is_set()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -19,6 +19,9 @@ notes = sqlalchemy.Table(
 )
 
 
+pytestmark = pytest.mark.usefixtures("no_trio_support")
+
+
 @pytest.fixture(autouse=True, scope="module")
 def create_test_database():
     engine = sqlalchemy.create_engine(DATABASE_URL)

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -217,7 +217,7 @@ class BigUploadFile(UploadFile):
     spool_max_size = 1024
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_upload_file():
     big_file = BigUploadFile("big-file")
     await big_file.write(b"big-data" * 512)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -55,7 +55,7 @@ def test_not_modified():
 def test_websockets_should_raise():
     with pytest.raises(RuntimeError):
         with client.websocket_connect("/runtime_error"):
-            pass
+            pass  # pragma: nocover
 
 
 def test_handled_exc_after_response():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -54,7 +54,8 @@ def test_not_modified():
 
 def test_websockets_should_raise():
     with pytest.raises(RuntimeError):
-        client.websocket_connect("/runtime_error")
+        with client.websocket_connect("/runtime_error"):
+            pass
 
 
 def test_handled_exc_after_response():

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,5 +1,4 @@
 import graphene
-import pytest
 from graphql.execution.executors.asyncio import AsyncioExecutor
 
 from starlette.applications import Starlette

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -147,23 +147,3 @@ def test_graphql_async():
     response = client.get("/?query={ hello }")
     assert response.status_code == 200
     assert response.json() == {"data": {"hello": "Hello stranger"}}
-
-
-async_schema = graphene.Schema(query=ASyncQuery)
-
-
-@pytest.fixture
-def old_style_async_app(event_loop) -> GraphQLApp:
-    old_style_async_app = GraphQLApp(
-        schema=async_schema, executor=AsyncioExecutor(loop=event_loop)
-    )
-    return old_style_async_app
-
-
-@pytest.mark.skip("XXX")
-def test_graphql_async_old_style_executor(old_style_async_app: GraphQLApp):
-    # See https://github.com/encode/starlette/issues/242
-    client = TestClient(old_style_async_app)
-    response = client.get("/?query={ hello }")
-    assert response.status_code == 200
-    assert response.json() == {"data": {"hello": "Hello stranger"}}

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -141,7 +141,7 @@ async_schema = graphene.Schema(query=ASyncQuery)
 async_app = GraphQLApp(schema=async_schema, executor_class=AsyncioExecutor)
 
 
-def test_graphql_async():
+def test_graphql_async(no_trio_support):
     client = TestClient(async_app)
     response = client.get("/?query={ hello }")
     assert response.status_code == 200

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -160,6 +160,7 @@ def old_style_async_app(event_loop) -> GraphQLApp:
     return old_style_async_app
 
 
+@pytest.mark.skip("XXX")
 def test_graphql_async_old_style_executor(old_style_async_app: GraphQLApp):
     # See https://github.com/encode/starlette/issues/242
     client = TestClient(old_style_async_app)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,5 +1,4 @@
-import asyncio
-
+import anyio
 import pytest
 
 from starlette.requests import ClientDisconnect, Request, State
@@ -212,9 +211,8 @@ def test_request_disconnect():
         return {"type": "http.disconnect"}
 
     scope = {"type": "http", "method": "POST", "path": "/"}
-    loop = asyncio.get_event_loop()
     with pytest.raises(ClientDisconnect):
-        loop.run_until_complete(app(scope, receiver, None))
+        anyio.run(app, scope, receiver, None)
 
 
 def test_request_is_disconnected():

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -170,7 +170,7 @@ def test_response_phrase():
     assert response.reason == ""
 
 
-def test_file_response(tmpdir):
+def test_file_response(tmpdir, no_trio_support):
     path = os.path.join(tmpdir, "xyz")
     content = b"<file content>" * 1000
     with open(path, "wb") as file:
@@ -212,7 +212,7 @@ def test_file_response(tmpdir):
     assert filled_by_bg_task == "6, 7, 8, 9"
 
 
-def test_file_response_with_directory_raises_error(tmpdir):
+def test_file_response_with_directory_raises_error(tmpdir, no_trio_support):
     app = FileResponse(path=tmpdir, filename="example.png")
     client = TestClient(app)
     with pytest.raises(RuntimeError) as exc_info:
@@ -220,7 +220,7 @@ def test_file_response_with_directory_raises_error(tmpdir):
     assert "is not a file" in str(exc_info.value)
 
 
-def test_file_response_with_missing_file_raises_error(tmpdir):
+def test_file_response_with_missing_file_raises_error(tmpdir, no_trio_support):
     path = os.path.join(tmpdir, "404.txt")
     app = FileResponse(path=path, filename="404.txt")
     client = TestClient(app)
@@ -229,7 +229,7 @@ def test_file_response_with_missing_file_raises_error(tmpdir):
     assert "does not exist" in str(exc_info.value)
 
 
-def test_file_response_with_chinese_filename(tmpdir):
+def test_file_response_with_chinese_filename(tmpdir, no_trio_support):
     content = b"file content"
     filename = "你好.txt"  # probably "Hello.txt" in Chinese
     path = os.path.join(tmpdir, filename)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,6 +1,6 @@
-import asyncio
 import os
 
+import anyio
 import pytest
 
 from starlette import status
@@ -69,7 +69,7 @@ def test_streaming_response():
                 yield str(i)
                 if i != maximum:
                     yield ", "
-                await asyncio.sleep(0)
+                await anyio.sleep(0)
 
         async def numbers_for_cleanup(start=1, stop=5):
             nonlocal filled_by_bg_task
@@ -183,7 +183,7 @@ def test_file_response(tmpdir):
             yield str(i)
             if i != maximum:
                 yield ", "
-            await asyncio.sleep(0)
+            await anyio.sleep(0)
 
     async def numbers_for_cleanup(start=1, stop=5):
         nonlocal filled_by_bg_task

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -170,7 +170,7 @@ def test_response_phrase():
     assert response.reason == ""
 
 
-def test_file_response(tmpdir, no_trio_support):
+def test_file_response(tmpdir):
     path = os.path.join(tmpdir, "xyz")
     content = b"<file content>" * 1000
     with open(path, "wb") as file:
@@ -212,7 +212,7 @@ def test_file_response(tmpdir, no_trio_support):
     assert filled_by_bg_task == "6, 7, 8, 9"
 
 
-def test_file_response_with_directory_raises_error(tmpdir, no_trio_support):
+def test_file_response_with_directory_raises_error(tmpdir):
     app = FileResponse(path=tmpdir, filename="example.png")
     client = TestClient(app)
     with pytest.raises(RuntimeError) as exc_info:
@@ -220,7 +220,7 @@ def test_file_response_with_directory_raises_error(tmpdir, no_trio_support):
     assert "is not a file" in str(exc_info.value)
 
 
-def test_file_response_with_missing_file_raises_error(tmpdir, no_trio_support):
+def test_file_response_with_missing_file_raises_error(tmpdir):
     path = os.path.join(tmpdir, "404.txt")
     app = FileResponse(path=path, filename="404.txt")
     client = TestClient(app)
@@ -229,7 +229,7 @@ def test_file_response_with_missing_file_raises_error(tmpdir, no_trio_support):
     assert "does not exist" in str(exc_info.value)
 
 
-def test_file_response_with_chinese_filename(tmpdir, no_trio_support):
+def test_file_response_with_chinese_filename(tmpdir):
     content = b"file content"
     filename = "你好.txt"  # probably "Hello.txt" in Chinese
     path = os.path.join(tmpdir, filename)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -286,7 +286,8 @@ def test_protocol_switch():
         assert session.receive_json() == {"URL": "ws://testserver/"}
 
     with pytest.raises(WebSocketDisconnect):
-        client.websocket_connect("/404")
+        with client.websocket_connect("/404"):
+            pass
 
 
 ok = PlainTextResponse("OK")
@@ -492,7 +493,8 @@ def test_standalone_ws_route_does_not_match():
     app = WebSocketRoute("/", ws_helloworld)
     client = TestClient(app)
     with pytest.raises(WebSocketDisconnect):
-        client.websocket_connect("/invalid")
+        with client.websocket_connect("/invalid"):
+            pass
 
 
 def test_lifespan_async():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -287,7 +287,7 @@ def test_protocol_switch():
 
     with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/404"):
-            pass
+            pass  # pragma: nocover
 
 
 ok = PlainTextResponse("OK")
@@ -494,7 +494,7 @@ def test_standalone_ws_route_does_not_match():
     client = TestClient(app)
     with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/invalid"):
-            pass
+            pass  # pragma: nocover
 
 
 def test_lifespan_async():

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -1,8 +1,8 @@
-import asyncio
 import os
 import pathlib
 import time
 
+import anyio
 import pytest
 
 from starlette.applications import Starlette
@@ -153,8 +153,7 @@ def test_staticfiles_prevents_breaking_out_of_directory(tmpdir):
     # We can't test this with 'requests', so we test the app directly here.
     path = app.get_path({"path": "/../example.txt"})
     scope = {"method": "GET"}
-    loop = asyncio.get_event_loop()
-    response = loop.run_until_complete(app.get_response(path, scope))
+    response = anyio.run(app.get_response, path, scope)
     assert response.status_code == 404
     assert response.body == b"Not Found"
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -11,7 +11,6 @@ from starlette.routing import Mount
 from starlette.staticfiles import StaticFiles
 from starlette.testclient import TestClient
 
-
 pytestmark = pytest.mark.usefixtures("no_trio_support")
 
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -11,8 +11,6 @@ from starlette.routing import Mount
 from starlette.staticfiles import StaticFiles
 from starlette.testclient import TestClient
 
-pytestmark = pytest.mark.usefixtures("no_trio_support")
-
 
 def test_staticfiles(tmpdir):
     path = os.path.join(tmpdir, "example.txt")

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -12,6 +12,9 @@ from starlette.staticfiles import StaticFiles
 from starlette.testclient import TestClient
 
 
+pytestmark = pytest.mark.usefixtures("no_trio_support")
+
+
 def test_staticfiles(tmpdir):
     path = os.path.join(tmpdir, "example.txt")
     with open(path, "w") as file:

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -118,7 +118,7 @@ def test_websocket_blocking_receive():
             websocket = WebSocket(scope, receive=receive, send=send)
             await websocket.accept()
             async with anyio.create_task_group() as task_group:
-                task_group.spawn(respond, websocket)
+                task_group.start_soon(respond, websocket)
                 try:
                     # this will block as the client does not send us data
                     # it should not prevent `respond` from executing though

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -1,5 +1,4 @@
 import anyio
-
 import pytest
 
 from starlette.applications import Starlette

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -1,4 +1,4 @@
-import asyncio
+import anyio
 
 import pytest
 
@@ -118,13 +118,14 @@ def test_websocket_blocking_receive():
         async def asgi(receive, send):
             websocket = WebSocket(scope, receive=receive, send=send)
             await websocket.accept()
-            asyncio.ensure_future(respond(websocket))
-            try:
-                # this will block as the client does not send us data
-                # it should not prevent `respond` from executing though
-                await websocket.receive_json()
-            except WebSocketDisconnect:
-                pass
+            async with anyio.create_task_group() as task_group:
+                task_group.spawn(respond, websocket)
+                try:
+                    # this will block as the client does not send us data
+                    # it should not prevent `respond` from executing though
+                    await websocket.receive_json()
+                except WebSocketDisconnect:
+                    pass
 
         return asgi
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -223,7 +223,7 @@ def test_websocket_concurrency_pattern():
             await websocket.accept()
             async with anyio.create_task_group() as task_group:
                 task_group.start_soon(reader, websocket)
-                task_group.start_soon(writer, websocket)
+                await writer(websocket)
             await websocket.close()
 
         return asgi

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -284,7 +284,8 @@ def test_rejected_connection():
 
     client = TestClient(app)
     with pytest.raises(WebSocketDisconnect) as exc:
-        client.websocket_connect("/")
+        with client.websocket_connect("/"):
+            pass
     assert exc.value.code == status.WS_1001_GOING_AWAY
 
 
@@ -312,7 +313,8 @@ def test_websocket_exception():
 
     client = TestClient(app)
     with pytest.raises(AssertionError):
-        client.websocket_connect("/123?a=abc")
+        with client.websocket_connect("/123?a=abc"):
+            pass
 
 
 def test_duplicate_close():

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -285,7 +285,7 @@ def test_rejected_connection():
     client = TestClient(app)
     with pytest.raises(WebSocketDisconnect) as exc:
         with client.websocket_connect("/"):
-            pass
+            pass  # pragma: nocover
     assert exc.value.code == status.WS_1001_GOING_AWAY
 
 
@@ -314,7 +314,7 @@ def test_websocket_exception():
     client = TestClient(app)
     with pytest.raises(AssertionError):
         with client.websocket_connect("/123?a=abc"):
-            pass
+            pass  # pragma: nocover
 
 
 def test_duplicate_close():
@@ -330,7 +330,7 @@ def test_duplicate_close():
     client = TestClient(app)
     with pytest.raises(RuntimeError):
         with client.websocket_connect("/"):
-            pass
+            pass  # pragma: nocover
 
 
 def test_duplicate_disconnect():


### PR DESCRIPTION
Fixes: #811

This adds support for `asyncio` and `trio` by leveraging [anyio](https://anyio.readthedocs.io/) and a little more structured concurrency in spots.

Things to do yet:
- [x] 100% tests passing (there's one failing test at the moment)
- [x] `TestClient` rewritten for anyio, probably with portals.
- [x] `anyio` 3.0 release

This adds a hard dependency for starlette, which didn't exist before, and was a selling point.  In my opinion, the benefit is worth it.  It would be great to use starlette with either `uvicorn` or `hypercorn` using Trio.

This also removes the need for `aiofiles` which is gained for free with `anyio`.

Some drawbacks are that the other integrations such as graphql are only currently compatible with `asyncio`.  But, this does not make those integrations incompatible.  It does give users the ability to use trio without them, and maybe they can be ported in the future as well.

I created a branch for framework benchmarks here: https://github.com/uSpike/FrameworkBenchmarks/tree/starlette-anyio

See results: https://www.techempower.com/benchmarks/#section=test&shareid=c92a1338-0058-486c-9e47-c92ec4710b6a&hw=ph&test=query&a=2

There is a performance penalty to using anyio. The weighted composite score is 173 vs 165, so a 4.5% drop in performance.