### PR TITLE
Don't use 'raise exc from None' because it suppresses exception causes

### DIFF
--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -71,7 +71,7 @@ class WebSocketEndpoint:
                     break
         except Exception as exc:
             close_code = status.WS_1011_INTERNAL_ERROR
-            raise exc from None
+            raise exc
         finally:
             await self.on_disconnect(websocket, close_code)
 

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -79,7 +79,7 @@ class ExceptionMiddleware:
                 handler = self._lookup_exception_handler(exc)
 
             if handler is None:
-                raise exc from None
+                raise exc
 
             if response_started:
                 msg = "Caught handled exception, but response already started."

--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -178,7 +178,7 @@ class ServerErrorMiddleware:
             # We always continue to raise the exception.
             # This allows servers to log the error, or allows test clients
             # to optionally raise the error within the test case.
-            raise exc from None
+            raise exc
 
     def format_line(
         self, index: int, line: str, frame_lineno: int, frame_index: int

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -240,7 +240,7 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
             loop.run_until_complete(self.app(scope, receive, send))
         except BaseException as exc:
             if self.raise_server_exceptions:
-                raise exc from None
+                raise exc
 
         if self.raise_server_exceptions:
             assert response_started, "TestClient did not receive any response."


### PR DESCRIPTION
Fixes https://github.com/encode/starlette/issues/1114

I think `raise exc from None` is better for targeted cases (like catching KeyError to re-raise a more suitable exception). For catch-all clauses like `except Exception` we are potentially throwing out useful info about the cause.