### PR TITLE
Stream with utf8 filename

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -34,7 +34,6 @@ def guess_type(
     return mimetypes_guess_type(url, strict)
 
 
-# Build Content Disposition Header from filename
 def build_content_disposition_header(filename: str) -> str:
     content_disposition_filename = quote(filename)
     if content_disposition_filename != filename:

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from io import BytesIO
 
 import pytest
 
@@ -143,6 +144,19 @@ def test_sync_streaming_response():
     client = TestClient(app)
     response = client.get("/")
     assert response.text == "1, 2, 3, 4, 5"
+
+
+def test_streaming_response_with_japanese_filename():
+    filename = "こんにちは.txt"  # "Hello.txt" in Japanese
+    content = b"1, 2, 3, 4, 5"
+    client = TestClient(StreamingResponse(BytesIO(content), filename=filename))
+    response = client.get("/")
+    expected_disposition = (
+        "attachment; filename*=utf-8''%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF.txt"
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.content == content
+    assert response.headers["content-disposition"] == expected_disposition
 
 
 def test_response_headers():


### PR DESCRIPTION
Fixes: https://github.com/encode/starlette/issues/790#issuecomment-667881654

This adds support filename for StreamingResponse  same as FileResponse.