### PR TITLE
use quote instead of quote_plus for RedirectResponse location header

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -7,7 +7,7 @@ import sys
 import typing
 from email.utils import formatdate
 from mimetypes import guess_type as mimetypes_guess_type
-from urllib.parse import quote, quote_plus
+from urllib.parse import quote
 
 from starlette.background import BackgroundTask
 from starlette.concurrency import iterate_in_threadpool, run_until_first_complete

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -178,7 +178,7 @@ class RedirectResponse(Response):
         super().__init__(
             content=b"", status_code=status_code, headers=headers, background=background
         )
-        self.headers["location"] = quote_plus(str(url), safe=":/%#?&=@[]!$&'()*+,;")
+        self.headers["location"] = quote(str(url), safe=":/%#?=@[]!$&'()*+,;")
 
 
 class StreamingResponse(Response):

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -60,6 +60,20 @@ def test_redirect_response():
     assert response.url == "http://testserver/"
 
 
+def test_quoting_redirect_response():
+    async def app(scope, receive, send):
+        if scope["path"] == "/I ♥ Starlette/":
+            response = Response("hello, world", media_type="text/plain")
+        else:
+            response = RedirectResponse("/I ♥ Starlette/")
+        await response(scope, receive, send)
+
+    client = TestClient(app)
+    response = client.get("/redirect")
+    assert response.text == "hello, world"
+    assert response.url == "http://testserver/I%20%E2%99%A5%20Starlette/"
+
+
 def test_streaming_response():
     filled_by_bg_task = ""
 


### PR DESCRIPTION
Closes #1162

use `quote` instead of `quote_plus` for `RedirectResponse` location header

adjust safe characters: rem. duplicate `&` symbol

add test for redirect quoting

Used django's redirect quote call as a reference: https://github.com/django/django/blob/23fa29f6a6659e0f600d216de6bcb79e7f6818c9/django/utils/encoding.py#L129