### PR TITLE
starlette's setup.py creates a broken top_level.txt record in the wheel file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import os
 import re
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 def get_version(package):
@@ -23,17 +23,6 @@ def get_long_description():
         return f.read()
 
 
-def get_packages(package):
-    """
-    Return root package and all sub-packages.
-    """
-    return [
-        dirpath
-        for dirpath, dirnames, filenames in os.walk(package)
-        if os.path.exists(os.path.join(dirpath, "__init__.py"))
-    ]
-
-
 setup(
     name="starlette",
     python_requires=">=3.6",
@@ -45,7 +34,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Tom Christie",
     author_email="tom@tomchristie.com",
-    packages=get_packages("starlette"),
+    packages=find_packages(exclude=["tests*"]),
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
     extras_require={


### PR DESCRIPTION
The current setup file has a hand-rolled `get_packages` function which returns the following packages:

```
>>> get_packages("starlette")
['starlette', 'starlette/middleware']
```

This results in an [incorrect `top_level.txt` file to be generated in the wheel's dist-info directory](https://setuptools.readthedocs.io/en/latest/deprecated/python_eggs.html#top-level-txt-conflict-management-metadata):

```
$ cat starlette-0.14.2.dist-info/top_level.txt
starlette
starlette/middleware
```

"starlette/middleware" is not a Python identifier, breaking some automated tooling at $EMPLOYER.

After the change in this PR, the correct packages list passed to setup is:

```
['starlette', 'starlette.middleware']
```

Which is resulting in the correct `top_level.txt` file being generated in the wheel:

```
starlette
```
