### PR TITLE
Removed the empty elif clause as it has no effect in formparsers.py

### DIFF
--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -108,8 +108,6 @@ class FormParser:
                     name = unquote_plus(field_name.decode("latin-1"))
                     value = unquote_plus(field_value.decode("latin-1"))
                     items.append((name, value))
-                elif message_type == FormMessage.END:
-                    pass
 
         return FormData(items)
 
@@ -235,8 +233,6 @@ class MultiPartParser:
                     else:
                         await file.seek(0)
                         items.append((field_name, file))
-                elif message_type == MultiPartMessage.END:
-                    pass
 
         parser.finalize()
         return FormData(items)


### PR DESCRIPTION
Eliminated similar empty `elif`s in 2 places:
```
elif message_type == FormMessage.END:
                    pass
```

The reason, as it is an empty clause and has no effect.