### PR TITLE
Removed redundant parantheses for return statement in staticfiles.py

### DIFF
--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -155,10 +155,10 @@ class StaticFiles:
                 continue
             try:
                 stat_result = await aio_stat(full_path)
-                return (full_path, stat_result)
+                return full_path, stat_result
             except FileNotFoundError:
                 pass
-        return ("", None)
+        return "", None
 
     def file_response(
         self,


### PR DESCRIPTION
Replaced `return (full_path, stat_result)` with `return full_path, stat_result` -> the later will return tuple as well, so there is no need for an extra parantheses.