### PR TITLE
Replaced built-in type name with type_ and removed redundant variable assignment

### DIFF
--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -24,18 +24,17 @@ def requires(
     scopes_list = [scopes] if isinstance(scopes, str) else list(scopes)
 
     def decorator(func: typing.Callable) -> typing.Callable:
-        type = None
         sig = inspect.signature(func)
         for idx, parameter in enumerate(sig.parameters.values()):
             if parameter.name == "request" or parameter.name == "websocket":
-                type = parameter.name
+                type_ = parameter.name
                 break
         else:
             raise Exception(
                 f'No "request" or "websocket" argument on function "{func}"'
             )
 
-        if type == "websocket":
+        if type_ == "websocket":
             # Handle websocket functions. (Always async)
             @functools.wraps(func)
             async def websocket_wrapper(


### PR DESCRIPTION
As `type` is the built-in name and using it for assignment may lead to shadowing issues, the suggestion to use type_ instead.
Another improvement is to remove the `type_ = None` variable assignment at the very beginning - as the for loop has an else clause with raised Exception, it will ensure that there will be no unassigned `type_` variable before hitting the if check.