### PR TITLE
[typing] Allow non-class callables to be used as middleware

### DIFF
--- a/starlette/middleware/__init__.py
+++ b/starlette/middleware/__init__.py
@@ -1,8 +1,9 @@
 import typing
+from starlette.types import ASGIApp
 
 
 class Middleware:
-    def __init__(self, cls: type, **options: typing.Any) -> None:
+    def __init__(self, cls: typing.Callable[..., ASGIApp], **options: typing.Any) -> None:
         self.cls = cls
         self.options = options
 


### PR DESCRIPTION
1. Right now, it's possible to pass a sequence of tuples `(callable, options)` where `callable` is a callable accepting `**options` and returning an ASGI app. But the type annotation on `Starlette` says that one has to pass a sequence of `Middleware` objects.
This PR allows passing in a sequence of tuples as well as a list of `Middleware` objects

2. Type annotations only allow classes to be used as middleware, but it's possible to provide any callable that returns an ASGI app. This PR fixes that as well.