### PR TITLE
Add better exception msg for duplicated param names

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -107,6 +107,7 @@ def compile_path(
     """
     path_regex = "^"
     path_format = ""
+    duplicated_params = set()
 
     idx = 0
     param_convertors = {}
@@ -124,9 +125,17 @@ def compile_path(
         path_format += path[idx : match.start()]
         path_format += "{%s}" % param_name
 
+        if param_name in param_convertors:
+            duplicated_params.add(param_name)
+
         param_convertors[param_name] = convertor
 
         idx = match.end()
+
+    if duplicated_params:
+        names = ", ".join(sorted(duplicated_params))
+        ending = "s" if len(duplicated_params) > 1 else ""
+        raise ValueError(f"Duplicated param name{ending} {names} at path {path}")
 
     path_regex += re.escape(path[idx:]) + "$"
     path_format += path[idx:]

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -622,3 +622,17 @@ def test_partial_async_endpoint():
     cls_method_response = test_client.get("/cls")
     assert cls_method_response.status_code == 200
     assert cls_method_response.json() == {"arg": "foo"}
+
+
+def test_duplicated_param_names():
+    with pytest.raises(
+        ValueError,
+        match="Duplicated param name id at path /{id}/{id}",
+    ):
+        Route("/{id}/{id}", user)
+
+    with pytest.raises(
+        ValueError,
+        match="Duplicated param names id, name at path /{id}/{name}/{id}/{name}",
+    ):
+        Route("/{id}/{name}/{id}/{name}", user)


### PR DESCRIPTION
Raise `ValueError` with information about duplicated names instead of `sre_constants.error`.

For instance:
```py
app = Starlette(
    routes=[
        Route("/api/users/{id}/groups/{id}", route),
    ]
)
```

Will raise:
```py
ValueError: Duplicated param name id at path /api/users/{id}/groups/{id}
```
Instead of:
```
sre_constants.error: redefinition of group name 'id' as group 2; was group 1 at position 42
```