### PR TITLE
Deduplicate failure text in CORS preflight response

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -129,6 +129,7 @@ class CORSMiddleware:
             for header in [h.lower() for h in requested_headers.split(",")]:
                 if header.strip() not in self.allow_headers:
                     failures.append("headers")
+                    break
 
         # We don't strictly need to use 400 responses here, since its up to
         # the browser to enforce the CORS policy, but its more informative

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -179,6 +179,16 @@ def test_cors_disallowed_preflight():
     assert response.text == "Disallowed CORS origin, method, headers"
     assert "access-control-allow-origin" not in response.headers
 
+    # Bug specific test, https://github.com/encode/starlette/pull/1199
+    # Test preflight response text with multiple disallowed headers
+    headers = {
+        "Origin": "https://example.org",
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "X-Nope-1, X-Nope-2",
+    }
+    response = client.options("/", headers=headers)
+    assert response.text == "Disallowed CORS headers"
+
 
 def test_preflight_allows_request_origin_if_origins_wildcard_and_credentials_allowed():
     app = Starlette()


### PR DESCRIPTION
Break the loop to t avoid appending string `headers` into `failures` multiple times. Otherwise it causes duplication in CORS response text (not response header).

```diff
        elif requested_headers is not None:
            for header in [h.lower() for h in requested_headers.split(",")]:
                if header.strip() not in self.allow_headers:
                    failures.append("headers")
+                    break
        ...
        if failures:
            failure_text = "Disallowed CORS " + ", ".join(failures)
            return PlainTextResponse(failure_text, status_code=400, headers=headers)
```