### PR TITLE
Test on Python 3.10

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.0-beta.3"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,0 @@
-import sys
-
-collect_ignore = ["tests/test_graphql.py"] if sys.version_info >= (3, 10) else []

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,3 @@
+import sys
+
+collect_ignore = ["tests/test_graphql.py"] if sys.version_info >= (3, 10) else []

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -2,9 +2,10 @@
 !!! Warning
 
     GraphQL support in Starlette is **deprecated** as of version 0.15 and will
-    be removed in a future release. Please consider using a third-party library
-    to provide GraphQL support. This is usually done by mounting a GraphQL ASGI
-    application. See [#619](https://github.com/encode/starlette/issues/619).
+    be removed in a future release. It is also incompatible with Python 3.10+.
+    Please consider using a third-party library to provide GraphQL support. This
+    is usually done by mounting a GraphQL ASGI application.
+    See [#619](https://github.com/encode/starlette/issues/619).
     Some example libraries are:
 
     * [Ariadne](https://ariadnegraphql.org/docs/asgi)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Optionals
 aiofiles
-graphene
+graphene; python_version<'3.10'
 itsdangerous
 jinja2
 python-multipart

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,8 @@ filterwarnings=
 
 [coverage:run]
 source_pkgs = starlette, tests
+# GraphQLApp incompatible with and untested on Python 3.10. It's deprecated, let's just ignore
+# coverage for it until it's gone.
+omit =
+  starlette/graphql.py
+  tests/test_graphql.py

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     extras_require={
         "full": [
             "aiofiles",
-            "graphene",
+            "graphene; python_version<'3.10'",
             "itsdangerous",
             "jinja2",
             "python-multipart",

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     zip_safe=False,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
+import sys
+
 import pytest
 
 from starlette.testclient import TestClient
+
+collect_ignore = ["test_graphql.py"] if sys.version_info >= (3, 10) else []
 
 
 @pytest.fixture(


### PR DESCRIPTION
~Work in progress. Waiting on #1157 which should remove usages of `asyncio.get_event_loop` which is deprecated in Python 3.10.~ ✅ 