### PR TITLE
Send lifespan.shutdown.failed event on lifespan shutdown error

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -580,6 +580,7 @@ class Router:
             await send({"type": "lifespan.shutdown.failed", "message": exc_text})
             raise
         else:
+            await gen.aclose()
             raise RuntimeError("Lifespan context yielded multiple times.")
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -528,4 +528,11 @@ class TestClient(requests.Session):
             message = await self.stream_send.receive()
             if message is None:
                 self.task.result()
-            assert message["type"] == "lifespan.shutdown.complete"
+            assert message["type"] in (
+                "lifespan.shutdown.complete",
+                "lifespan.shutdown.failed",
+            )
+            if message["type"] == "lifespan.shutdown.failed":
+                message = await self.stream_send.receive()
+                if message is None:
+                    self.task.result()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -528,6 +528,31 @@ def test_lifespan_async():
     assert shutdown_complete
 
 
+def test_lifespan_context_async():
+    startup_complete = False
+    shutdown_complete = False
+
+    async def hello_world(request):
+        return PlainTextResponse("hello, world")
+
+    async def lifespan(app):
+        nonlocal startup_complete, shutdown_complete
+        startup_complete = True
+        yield
+        shutdown_complete = True
+
+    app = Router(lifespan=lifespan, routes=[Route("/", hello_world)])
+
+    assert not startup_complete
+    assert not shutdown_complete
+    with TestClient(app) as client:
+        assert startup_complete
+        assert not shutdown_complete
+        client.get("/")
+    assert startup_complete
+    assert shutdown_complete
+
+
 def test_lifespan_sync():
     startup_complete = False
     shutdown_complete = False
@@ -548,6 +573,31 @@ def test_lifespan_sync():
         on_shutdown=[run_shutdown],
         routes=[Route("/", hello_world)],
     )
+
+    assert not startup_complete
+    assert not shutdown_complete
+    with TestClient(app) as client:
+        assert startup_complete
+        assert not shutdown_complete
+        client.get("/")
+    assert startup_complete
+    assert shutdown_complete
+
+
+def test_lifespan_context_sync():
+    startup_complete = False
+    shutdown_complete = False
+
+    def hello_world(request):
+        return PlainTextResponse("hello, world")
+
+    def lifespan(app):
+        nonlocal startup_complete, shutdown_complete
+        startup_complete = True
+        yield
+        shutdown_complete = True
+
+    app = Router(lifespan=lifespan, routes=[Route("/", hello_world)])
 
     assert not startup_complete
     assert not shutdown_complete


### PR DESCRIPTION
Fixes #1138 

We supported `lifespan.startup.failed` but not `lifespan.shutdown.failed` for some reason. These were added in the Lifespan 2.0 ASGI spec.

Previously, we used single-iteration for-loops to communicate with the lifespan generator. This changes to an explicit `try`/`except StopAsyncIteration`, closer to what pytest/AnyIO do when calling test fixtures.

Added additional tests for the incorrect number of yields. Previously we just had an `assert` on a boolean flag, but now we explicitly raise a `RuntimeError` (again, similar to pytest which raises this error type in a similar situation).