### PR TITLE
mkdocs: Set site_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Starlette
 site_description: The little ASGI library that shines.
+site_url: https://www.starlette.io
 
 theme:
   name: 'material'


### PR DESCRIPTION
I'm hoping this fixes #1212, but tbh it is a bit difficult to test. I can confirm that this warning when running `scripts/docs` is gone:
```
❯ scripts/docs
+ venv/bin/mkdocs serve
INFO     -  Building documentation...
WARNING  -  Config value: 'site_url'. Warning: This option is now required. Set to a
            valid URL or an empty string to avoid an error in a future release.
WARNING  -  Config value: 'site_url'. Warning: The 'use_directory_urls' option has been
            disabled because 'site_url' contains an empty value. Either define a valid
            URL for 'site_url' or set 'use_directory_urls' to False.
INFO     -  Cleaning site directory
INFO     -  Documentation built in 1.62 seconds
INFO     -  [21:55:26] Serving on http://127.0.0.1:8000/
```

...and that `sitemap.xml` makes sense when running locally. Currently, https://www.starlette.io/sitemap.xml has bad `loc` attributes (they're all `None`).

w.r.t. the HTTPS redirect issue (there being no redirect), I don't have sufficient permissions on GitHub to fix that as per these instructions: https://docs.github.com/en/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https

I'm hoping that I can just run `mkdocs gh-deploy --force` after this is merged to deploy new docs but will see.