### PR TITLE
mkdocs: Added dark theme for the documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,18 @@ site_url: https://www.starlette.io
 theme:
   name: 'material'
   custom_dir: docs/overrides
+  palette:
+    - scheme: 'default'
+      media: '(prefers-color-scheme: light)'
+      toggle:
+        icon: 'material/lightbulb'
+        name: "Switch to dark mode"
+    - scheme: 'slate'
+      media: '(prefers-color-scheme: dark)'
+      primary: 'blue'
+      toggle:
+        icon: 'material/lightbulb-outline'
+        name: 'Switch to light mode'
 
 repo_name: encode/starlette
 repo_url: https://github.com/encode/starlette


### PR DESCRIPTION
mkdocs: expanded theme configuration to add alternative dark theme. The default theme will be determined by the users system theme by the `prefers-color-scheme` media query.

The primary color for the dark theme was changed to `blue`, instead of the default `indigo` to improve readability of links. 