### PR TITLE
Apply CORS response headers to unhandled exception responses

### DIFF
--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -3,10 +3,16 @@ import http
 import typing
 
 from starlette.concurrency import run_in_threadpool
+from starlette.datastructures import Headers
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+
+class CORSException(Exception):
+    """"""
+    def __init__(self, headers: Headers):
+        self.headers = headers
 
 class HTTPException(Exception):
     def __init__(self, status_code: int, detail: str = None) -> None:


### PR DESCRIPTION
*This is pretty awful code, but it demonstrates a possible solution for the CORS response header problem (#1116)*

I don't like how we have to make `starlette.errors.ServerErrorMiddleware` aware of `CORSException` but it does provide a convenient way to convey the CORS response headers to the outer layer of the middleware onion.