### PR TITLE
Try to propagate contexvars from lifespan to endpoints

### DIFF
--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -1,6 +1,6 @@
 import functools
 import typing
-from typing import Any, AsyncGenerator, Iterator, Set
+from typing import AbstractSet, Any, AsyncGenerator, Iterator, Optional
 
 import anyio
 
@@ -15,11 +15,12 @@ except ImportError:  # pragma: no cover
 T = typing.TypeVar("T")
 
 
-def restore_context(context: Context, exclude: Set[ContextVar]):
-    """Copy the state of `context` to the current `context` for all ContextVars in `context`.
-    """
+def restore_context(
+    context: Context, exclude: Optional[AbstractSet[ContextVar]] = None
+) -> None:
+    """Copy the state of `context` to the current context."""
     for cvar in context:
-        if cvar in exclude:
+        if exclude and cvar in exclude:
             continue
         try:
             if cvar.get() != context.get(cvar):

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -6,11 +6,24 @@ import anyio
 
 try:
     import contextvars  # Python 3.7+ only or via contextvars backport.
+    from contextvars import Context
 except ImportError:  # pragma: no cover
     contextvars = None  # type: ignore
+    Context = None
 
 
 T = typing.TypeVar("T")
+
+
+def restore_context(context: Context):
+    """Copy the state of `context` to the current `context` for all ContextVars in `context`.
+    """
+    for cvar in context:
+        try:
+            if cvar.get() != context.get(cvar):
+                cvar.set(context.get(cvar))
+        except LookupError:
+            cvar.set(context.get(cvar))
 
 
 async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -> None:

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -1,32 +1,16 @@
 import functools
 import typing
-from typing import AbstractSet, Any, AsyncGenerator, Iterator, Optional
+from typing import Any, AsyncGenerator, Iterator
 
 import anyio
 
 try:
     import contextvars  # Python 3.7+ only or via contextvars backport.
-    from contextvars import Context, ContextVar
 except ImportError:  # pragma: no cover
     contextvars = None  # type: ignore
-    Context = ContextVar = None  # type: ignore
 
 
 T = typing.TypeVar("T")
-
-
-def restore_context(
-    context: Context, exclude: Optional[AbstractSet[ContextVar]] = None
-) -> None:
-    """Copy the state of `context` to the current context."""
-    for cvar in context:
-        if exclude and cvar in exclude:
-            continue
-        try:
-            if cvar.get() != context.get(cvar):
-                cvar.set(context.get(cvar))
-        except LookupError:
-            cvar.set(context.get(cvar))
 
 
 async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -> None:

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -6,24 +6,11 @@ import anyio
 
 try:
     import contextvars  # Python 3.7+ only or via contextvars backport.
-    from contextvars import Context
 except ImportError:  # pragma: no cover
     contextvars = None  # type: ignore
-    Context = None
 
 
 T = typing.TypeVar("T")
-
-
-def restore_context(context: Context):
-    """Copy the state of `context` to the current `context` for all ContextVars in `context`.
-    """
-    for cvar in context:
-        try:
-            if cvar.get() != context.get(cvar):
-                cvar.set(context.get(cvar))
-        except LookupError:
-            cvar.set(context.get(cvar))
 
 
 async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -> None:

--- a/starlette/context.py
+++ b/starlette/context.py
@@ -1,0 +1,54 @@
+from typing import Any, Optional
+
+try:
+    from contextvars import Context, ContextVar, copy_context
+except ImportError:  # pragma: no cover
+    Context = object  # type: ignore
+    ContextVar = copy_context = None  # type: ignore
+
+
+def _set_cvar(cvar: ContextVar, val: Any) -> None:
+    cvar.set(val)
+
+
+class CaptureContext:
+    def __init__(self) -> None:
+        if Context is not None:
+            self.context = Context()
+        else:
+            self.context = None
+
+    def __enter__(self) -> "CaptureContext":
+        if copy_context is not None:
+            self._outer = copy_context()
+        else:   # pragma: no cover
+            self._outer = None
+        return self
+
+    def sync(self) -> None:
+        if self._outer is None:  # pragma: no cover
+            return
+        final = copy_context()
+        for cvar in final:
+            if cvar not in self._outer:
+                # new contextvar set
+                self.context.run(_set_cvar, cvar, final.get(cvar))
+            else:
+                final_val = final.get(cvar)
+                if self._outer.get(cvar) != final_val:
+                    # value changed
+                    self.context.run(_set_cvar, cvar, final_val)
+
+    def __exit__(self, *args: Any) -> None:
+        self.sync()
+
+
+def restore_context(context: Optional[Context]) -> None:
+    """Restore `context` to the current Context"""
+    if context is None:
+        return
+    for cvar in context.keys():
+        try:
+            cvar.set(context.get(cvar))
+        except LookupError:
+            cvar.set(context.get(cvar))

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -652,7 +652,15 @@ class Router:
         partial = None
 
         if self.user_ctx is not None:
-            restore_context(self.user_ctx)
+            current_ctx = contextvars.copy_context()
+            for cvar in self.user_ctx:
+                if cvar in current_ctx:
+                    continue
+                try:
+                    if cvar.get() != self.user_ctx.get(cvar):
+                        cvar.set(self.user_ctx.get(cvar))
+                except LookupError:
+                    cvar.set(self.user_ctx.get(cvar))
 
         for route in self.routes:
             # Determine if any route matches the incoming scope,

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -11,7 +11,7 @@ import typing
 import warnings
 from enum import Enum
 
-from starlette.concurrency import restore_context, run_in_threadpool
+from starlette.concurrency import run_in_threadpool
 from starlette.convertors import CONVERTOR_TYPES, Convertor
 from starlette.datastructures import URL, Headers, URLPath
 from starlette.exceptions import HTTPException
@@ -655,6 +655,8 @@ class Router:
             current_ctx = contextvars.copy_context()
             for cvar in self.user_ctx:
                 if cvar in current_ctx:
+                    # not set by the user, skip to avoid modifying
+                    # vars used by event loops, servers, etc.
                     continue
                 try:
                     if cvar.get() != self.user_ctx.get(cvar):

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -1,7 +1,7 @@
 import contextvars
-from itertools import permutations
 import os
 import sys
+from itertools import permutations
 
 import pytest
 


### PR DESCRIPTION
The goal is that, from a users perspective, it endpoints should be run as if they were a task being executed from within the `yield of a lifespan.