### PR TITLE
Fix BadSignature exception handling in SessionMiddleware

### DIFF
--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -3,7 +3,7 @@ import typing
 from base64 import b64decode, b64encode
 
 import itsdangerous
-from itsdangerous.exc import BadTimeSignature, SignatureExpired
+from itsdangerous.exc import BadSignature
 
 from starlette.datastructures import MutableHeaders, Secret
 from starlette.requests import HTTPConnection
@@ -42,7 +42,7 @@ class SessionMiddleware:
                 data = self.signer.unsign(data, max_age=self.max_age)
                 scope["session"] = json.loads(b64decode(data))
                 initial_session_was_empty = False
-            except (BadTimeSignature, SignatureExpired):
+            except BadSignature:
                 scope["session"] = {}
         else:
             scope["session"] = {}

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -112,3 +112,16 @@ def test_session_cookie_subpath(test_client_factory):
     cookie = response.headers["set-cookie"]
     cookie_path = re.search(r"; path=(\S+);", cookie).groups()[0]
     assert cookie_path == "/second_app"
+
+
+def test_invalid_session_cookie(test_client_factory):
+    app = create_app()
+    app.add_middleware(SessionMiddleware, secret_key="example")
+    client = test_client_factory(app)
+
+    response = client.post("/update_session", json={"some": "data"})
+    assert response.json() == {"session": {"some": "data"}}
+
+    # we expect it to not raise an exception if we provide a bogus session cookie
+    response = client.get("/view_session", cookies={"session": "invalid"})
+    assert response.json() == {"session": {}}


### PR DESCRIPTION
The `SessionMiddleware` does not catch all possible exceptions of `TimestampSigner.unsign`, specifically there is an edge case where a `BadSignature` exception can be raised by the method if a totally bogus session cookie is provided that does not match the expected format.

This PR broadens the caught exceptions (since all the other exceptions inherit `BadSignature`) and fixes the issue.
The issue can be reproduced by running the new test without the fix applied. 