### PR TITLE
Ignore loop deprecation warnings originating inside asyncio

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ filterwarnings=
     ignore: Using or importing the ABCs from 'collections' instead of from 'collections\.abc' is deprecated.*:DeprecationWarning
     ignore: The 'context' alias has been deprecated. Please use 'context_value' instead\.:DeprecationWarning
     ignore: The 'variables' alias has been deprecated. Please use 'variable_values' instead\.:DeprecationWarning
+    # Workaround for Python 3.9.7 (see https://bugs.python.org/issue45097)
+    ignore:The loop argument is deprecated since Python 3\.8, and scheduled for removal in Python 3\.10\.:DeprecationWarning:asyncio
 
 [coverage:run]
 source_pkgs = starlette, tests


### PR DESCRIPTION
References:
- https://bugs.python.org/issue45097
- https://github.com/encode/uvicorn/pull/1185
- https://github.com/encode/uvicorn/pull/1183