### PR TITLE
Update the Jinja2Templates() constructor to allow PathLike

### DIFF
--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -1,3 +1,4 @@
+from os import PathLike
 import typing
 
 from starlette.background import BackgroundTask
@@ -54,11 +55,11 @@ class Jinja2Templates:
     return templates.TemplateResponse("index.html", {"request": request})
     """
 
-    def __init__(self, directory: str) -> None:
+    def __init__(self, directory: PathLike[str]) -> None:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         self.env = self._create_env(directory)
 
-    def _create_env(self, directory: str) -> "jinja2.Environment":
+    def _create_env(self, directory: PathLike[str]) -> "jinja2.Environment":
         @pass_context
         def url_for(context: dict, name: str, **path_params: typing.Any) -> str:
             request = context["request"]

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -60,7 +60,7 @@ class Jinja2Templates:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         self.env = self._create_env(directory)
 
-    def _create_env(self, directory: Union[str, PathLike]) -> "jinja2.Environment":
+    def _create_env(self, directory: typing.Union[str, PathLike]) -> "jinja2.Environment":
         @pass_context
         def url_for(context: dict, name: str, **path_params: typing.Any) -> str:
             request = context["request"]

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -59,7 +59,9 @@ class Jinja2Templates:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         self.env = self._create_env(directory)
 
-    def _create_env(self, directory: typing.Union[str, PathLike]) -> "jinja2.Environment":
+    def _create_env(
+        self, directory: typing.Union[str, PathLike]
+    ) -> "jinja2.Environment":
         @pass_context
         def url_for(context: dict, name: str, **path_params: typing.Any) -> str:
             request = context["request"]

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -1,5 +1,6 @@
 from os import PathLike
 import typing
+from typing import Union
 
 from starlette.background import BackgroundTask
 from starlette.responses import Response
@@ -55,11 +56,11 @@ class Jinja2Templates:
     return templates.TemplateResponse("index.html", {"request": request})
     """
 
-    def __init__(self, directory: PathLike[str]) -> None:
+    def __init__(self, directory: Union[str, PathLike]) -> None:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         self.env = self._create_env(directory)
 
-    def _create_env(self, directory: PathLike[str]) -> "jinja2.Environment":
+    def _create_env(self, directory: Union[str, PathLike]) -> "jinja2.Environment":
         @pass_context
         def url_for(context: dict, name: str, **path_params: typing.Any) -> str:
             request = context["request"]

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -1,6 +1,5 @@
-from os import PathLike
 import typing
-from typing import Union
+from os import PathLike
 
 from starlette.background import BackgroundTask
 from starlette.responses import Response

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -56,7 +56,7 @@ class Jinja2Templates:
     return templates.TemplateResponse("index.html", {"request": request})
     """
 
-    def __init__(self, directory: Union[str, PathLike]) -> None:
+    def __init__(self, directory: typing.Union[str, PathLike]) -> None:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         self.env = self._create_env(directory)
 


### PR DESCRIPTION
The directory argument for `Jinja2Templates` is annotated as a `str`, which means a type checker fails if you pass a `pathlib.Path`, but Jinja2 accepts `PathLike[str]` (either a path string or a Path) for environment creation.

This PR updates the type annotation to allow both cases.