### PR TITLE
Add session argument for GraphQLApp() constructor

### DIFF
--- a/starlette/graphql.py
+++ b/starlette/graphql.py
@@ -33,6 +33,7 @@ class GraphQLApp:
         schema: "graphene.Schema",
         executor_class: type = None,
         graphiql: bool = True,
+        session: "sqlalchemy.orm.Session" = None,
     ) -> None:
         self.schema = schema
         self.graphiql = graphiql
@@ -40,6 +41,7 @@ class GraphQLApp:
         self.is_async = executor_class is not None and issubclass(
             executor_class, AsyncioExecutor
         )
+        self.session = session
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if self.executor_class is not None:
@@ -94,6 +96,8 @@ class GraphQLApp:
 
         background = BackgroundTasks()
         context = {"request": request, "background": background}
+        if self.session:
+            context['session'] = self.session
 
         result = await self.execute(
             query, variables=variables, context=context, operation_name=operation_name


### PR DESCRIPTION
* Add session argument for GraphQLApp() constructor to allow
specify sqlalchemy session.

---

see [graphene doc](https://docs.graphene-python.org/projects/sqlalchemy/en/latest/tips/#querying).

Now we use this method,

> Create a query for the models.
```python
Base = declarative_base()
Base.query = db_session.query_property()

class MyModel(Base):
    # ...

```

but below method cannot use.

> Set the db session when you do the execution:
```python
schema = graphene.Schema()
schema.execute(context_value={'session': session})
```

This patch allows to use latter method like this.
```python
schema = graphene.Schema(query=Query)
app = starlette.graphql.GraphQLApp(schema=schema, session={{your SA session}})
```