### PR TITLE
Fix FileResponse not listening for http.disconnect

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pyyaml
 requests
 
 # Testing
+anyio
 autoflake
 black==20.8b1
 coverage>=5.3
@@ -19,6 +20,7 @@ types-PyYAML
 types-dataclasses
 pytest
 trio
+uvicorn
 
 # Documentation
 mkdocs

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,8 @@ if [ -z $GITHUB_ACTIONS ]; then
     scripts/check
 fi
 
-${PREFIX}coverage run -m pytest $@
+${PREFIX}coverage run --concurrency=multiprocessing -m pytest $@
+${PREFIX}coverage combine
 
 if [ -z $GITHUB_ACTIONS ]; then
     scripts/coverage

--- a/tests/test_response_abort.py
+++ b/tests/test_response_abort.py
@@ -1,0 +1,240 @@
+"""Test scenarios where the response is aborted while streaming
+
+These scenarios are tested with regard to the effect on
+ - Background Tasks: should always execute
+ - On Complete Tasks: should only execute if disconnect is received after stream is
+   completed
+"""
+
+import os
+import tempfile
+import time
+from multiprocessing import Process
+from typing import AsyncGenerator
+
+import anyio
+import pytest
+import requests
+import uvicorn
+
+from starlette import status
+from starlette.applications import Starlette
+from starlette.background import BackgroundTask
+from starlette.requests import Request
+from starlette.responses import FileResponse, Response, StreamingResponse
+from starlette.routing import Route
+
+HOST = "127.0.0.1"
+PORT = 8889
+
+BG = ""
+OC = ""
+CONTENT = b"<file content>" * 1000
+PATH = os.path.join(tempfile.mkdtemp(), "xyz")
+
+
+async def numbers(minimum: int, maximum: int) -> AsyncGenerator[str, None]:
+    "Create numbers asynchronously with commas as seperators"
+    for i in range(minimum, maximum + 1):
+        yield str(i)
+        if i != maximum:
+            yield ", "
+        await anyio.sleep(0.1)
+
+
+async def count_out_loud(start: int = 1, stop: int = 5) -> str:
+    "Generate string with list of numbers as string"
+    result = ""
+    async for thing in numbers(start, stop):
+        result = result + thing
+    return result
+
+
+async def set_bg_artifact() -> None:
+    """Change state of global BG variable
+
+    This is used to track whether the Background Task is really run.
+    """
+    global BG
+    BG = await count_out_loud(10, 15)
+
+
+async def set_oc_artifact() -> None:
+    """Change state of global BG variable
+
+    This is used to track whether the on complete task is really run.
+    """
+    global OC
+    OC = await count_out_loud(16, 20)
+
+
+async def stream_response(request: Request) -> StreamingResponse:
+    cleanup_task = BackgroundTask(set_bg_artifact)
+    always = BackgroundTask(set_oc_artifact)
+    generator = numbers(1, 5)
+    return StreamingResponse(
+        generator,
+        media_type="text/plain",
+        on_complete=cleanup_task,
+        background=always,
+    )
+
+
+async def stream_file_response(request: Request) -> FileResponse:
+    cleanup_task = BackgroundTask(set_bg_artifact)
+    always = BackgroundTask(set_oc_artifact)
+    return FileResponse(
+        path=PATH, filename="example.png", on_complete=cleanup_task, background=always
+    )
+
+
+async def bg_route(request: Request) -> Response:
+    "Return the value of BG to verify if Background task was executed"
+    return Response(f"{BG}", media_type="text/plain")
+
+
+async def oc_route(request: Request) -> Response:
+    "Return the value of OC to verify if On Complete was executed"
+    return Response(f"{OC}", media_type="text/plain")
+
+
+def run_server():
+    app = Starlette(
+        debug=True,
+        routes=[
+            Route("/", stream_response),
+            Route("/bg", bg_route),
+            Route("/oc", oc_route),
+            Route("/file", stream_file_response),
+        ],
+    )
+    uvicorn.run(app, host=HOST, port=PORT)
+
+
+@pytest.fixture
+def server():
+    """Run server in parallel thread
+
+    This fixture also takes care of creating and removing the file used for the
+    FileResponse.
+    """
+    # Setup Test
+    with open(PATH, "wb") as file:
+        file.write(CONTENT)
+    proc = Process(target=run_server, args=(), daemon=True)
+    proc.start()
+    time.sleep(1)
+    # Execute Test
+    yield
+    # Cleanup after test
+    os.remove(PATH)
+    proc.terminate()
+
+
+def test_streaming_response_abort(server):
+    check = requests.get(f"http://{HOST}:{PORT}/bg")
+    assert check.status_code == status.HTTP_200_OK
+    assert check.content == b""
+
+    resp = requests.get(
+        f"http://{HOST}:{PORT}",
+        stream=True,
+    )
+    resp.close()
+
+    assert resp.status_code == 200
+    assert resp.content == b""
+
+    time.sleep(1)
+    check = requests.get(f"http://{HOST}:{PORT}/bg")
+    assert resp.status_code == 200
+    assert check.content == b""
+
+    check = requests.get(f"http://{HOST}:{PORT}/oc")
+    assert check.status_code == 200
+    assert check.content == b"16, 17, 18, 19, 20"
+
+
+def test_streaming_response_complete(server):
+    check = requests.get(f"http://{HOST}:{PORT}/bg")
+    assert check.status_code == status.HTTP_200_OK
+    assert check.content == b""
+
+    resp = requests.get(
+        f"http://{HOST}:{PORT}",
+        stream=True,
+    )
+    time.sleep(1)
+    resp.close()
+
+    assert resp.status_code == 200
+    assert resp.content == b""
+
+    time.sleep(1)
+    check = requests.get(f"http://{HOST}:{PORT}/bg")
+    assert resp.status_code == 200
+    assert check.content == b"10, 11, 12, 13, 14, 15"
+
+    check = requests.get(f"http://{HOST}:{PORT}/oc")
+    assert check.status_code == 200
+    assert check.content == b"16, 17, 18, 19, 20"
+
+
+def test_file_response_abort(server):
+    check = requests.get(f"http://{HOST}:{PORT}/bg")
+    assert check.status_code == status.HTTP_200_OK
+    assert check.content == b""
+
+    response = requests.get(
+        f"http://{HOST}:{PORT}/file",
+        stream=True,
+    )
+    response.close()
+
+    assert response.content == b""
+    assert response.status_code == status.HTTP_200_OK
+    assert response.headers["content-type"] == "image/png"
+    assert (
+        response.headers["content-disposition"] == 'attachment; filename="example.png"'
+    )
+    assert "content-length" in response.headers
+    assert "last-modified" in response.headers
+    assert "etag" in response.headers
+
+    time.sleep(1)
+    check = requests.get(f"http://{HOST}:{PORT}/bg")
+    assert check.status_code == status.HTTP_200_OK
+    assert check.content == b""
+
+    check = requests.get(f"http://{HOST}:{PORT}/oc")
+    assert check.status_code == 200
+    assert check.content == b"16, 17, 18, 19, 20"
+
+
+def test_file_response_complete(server):
+    check = requests.get(f"http://{HOST}:{PORT}/bg")
+    assert check.status_code == status.HTTP_200_OK
+    assert check.content == b""
+
+    response = requests.get(f"http://{HOST}:{PORT}/file", stream=True)
+    time.sleep(1)
+    response.close()
+
+    assert response.content == b""
+    assert response.status_code == status.HTTP_200_OK
+    assert response.headers["content-type"] == "image/png"
+    assert (
+        response.headers["content-disposition"] == 'attachment; filename="example.png"'
+    )
+    assert "content-length" in response.headers
+    assert "last-modified" in response.headers
+    assert "etag" in response.headers
+
+    time.sleep(1)
+    check = requests.get(f"http://{HOST}:{PORT}/bg")
+    assert check.status_code == status.HTTP_200_OK
+    assert check.content == b"10, 11, 12, 13, 14, 15"
+
+    check = requests.get(f"http://{HOST}:{PORT}/oc")
+    assert check.status_code == 200
+    assert check.content == b"16, 17, 18, 19, 20"

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -317,6 +317,7 @@ def test_staticfiles_with_invalid_dir_permissions_returns_401(
     response = client.get("/example.txt")
     assert response.status_code == 401
     assert response.text == "Unauthorized"
+    os.chmod(tmpdir, stat.S_IRWXU)
 
 
 def test_staticfiles_with_missing_dir_returns_404(tmpdir, test_client_factory):


### PR DESCRIPTION
Fixes #1301

# Summary

 - implement aborting FileResponse stream on http.disconnect similar to
   StreamResponse
 - implement on_complete Background Tasks for
   StreamResponse/FileResponse
    - background: always executed (even if stream aborted)
    - on_complete: only executed if stream not abored by client
   I initially assumed that background would work as on_complete is now
   implemented. However as this is not the case, adding on_complete
   seemed like the best choice to ensure backwards compatibility.
 - implement testsuite for abort scenarios

# On_complete 
I'm aware that `on_complete` rather counts as a new feature, however it was very useful in writing the test and I would consider it a reasonable feature (or even default behaviour :thinking: ).
Consider it as a basis for discussion. If you prefer I'm happy to separate it out in a different PR.

# Further improvements

It might also make sense to implement FileResponse as a child class of Streaming Response, as they share quite some code.
If you agree I'd be happy to implement this.