### PR TITLE
Add proper type hints to add_exception_handler

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -129,7 +129,7 @@ class Starlette:
     def add_exception_handler(
         self,
         exc_class_or_status_code: typing.Union[int, typing.Type[Exception]],
-        handler: typing.Callable,
+        handler: typing.Callable[[Request, Any], typing.Coroutine[Any, Any, Response]],
     ) -> None:
         self.exception_handlers[exc_class_or_status_code] = handler
         self.middleware_stack = self.build_middleware_stack()

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -5,6 +5,8 @@ from starlette.exceptions import ExceptionMiddleware
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.errors import ServerErrorMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
 from starlette.routing import BaseRoute, Router
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -129,7 +131,7 @@ class Starlette:
     def add_exception_handler(
         self,
         exc_class_or_status_code: typing.Union[int, typing.Type[Exception]],
-        handler: typing.Callable[[Request, Any], typing.Coroutine[Any, Any, Response]],
+        handler: typing.Callable[[Request, Exception], typing.Union[Response, typing.Coroutine[typing.Any, typing.Any, Response]]],
     ) -> None:
         self.exception_handlers[exc_class_or_status_code] = handler
         self.middleware_stack = self.build_middleware_stack()


### PR DESCRIPTION
I lost a bit of time due to a missing return statement and type hint in an exception handler. 

In my case I had registered an `HTTPException` exception handler without a return. Here's the exception I ended up with:

```
Traceback (most recent call last):
  File "/Users/phillip/Library/Caches/pypoetry/virtualenvs/myproj-0dUE00O2-py3.8/lib/python3.8/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/Users/phillip/Library/Caches/pypoetry/virtualenvs/myproj-0dUE00O2-py3.8/lib/python3.8/site-packages/starlette/routing.py", line 609, in __call__
    await self.default(scope, receive, send)
  File "/Users/phillip/Library/Caches/pypoetry/virtualenvs/myproj-0dUE00O2-py3.8/lib/python3.8/site-packages/starlette/routing.py", line 497, in not_found
    raise HTTPException(status_code=404)
starlette.exceptions.HTTPException

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/phillip/Library/Caches/pypoetry/virtualenvs/myproj-0dUE00O2-py3.8/lib/python3.8/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/Users/phillip/Library/Caches/pypoetry/virtualenvs/myproj-0dUE00O2-py3.8/lib/python3.8/site-packages/starlette/middleware/cors.py", line 78, in __call__
    await self.app(scope, receive, send)
  File "/Users/phillip/Library/Caches/pypoetry/virtualenvs/myproj-0dUE00O2-py3.8/lib/python3.8/site-packages/starlette/exceptions.py", line 93, in __call__
    await response(scope, receive, sender)
TypeError: 'NoneType' object is not callable
```

Here's what my exception handler and registration looked like:

```python
...

async def http_exception_handler(request, exc):
   JSONResponse(
        status_code=exc.status_code,
        content=jsonable_encoder(
            {
                "errors": [
                    {
                        "id": uuid4(),
                        "title": "Internal Exception",
                        "detail": exc.detail,
                    }
                ]
            }
        ),
    )

application.add_exception_handler(HTTPException, http_exception_handler)
```

This is clearly an error but it would've been nice to get a type hint error on it before I went through and traced down the implementation.

Thanks for such a great library!