### PR TITLE
Catch more general`BaseException` instead of `Exception`

### DIFF
--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -157,7 +157,7 @@ class ServerErrorMiddleware:
 
         try:
             await self.app(scope, receive, _send)
-        except Exception as exc:
+        except BaseException as exc:
             if not response_started:
                 request = Request(scope)
                 if self.debug:


### PR DESCRIPTION
`anyio.ExceptionGroup`, for example, is not an `Exception` but is a `BaseException`