### PR TITLE
Add authentication args length check

### DIFF
--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -40,7 +40,9 @@ def requires(
             async def websocket_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> None:
-                websocket = kwargs.get("websocket", args[idx] if idx < len(args) else None)
+                websocket = kwargs.get(
+                    "websocket", args[idx] if idx < len(args) else None
+                )
                 assert isinstance(websocket, WebSocket)
 
                 if not has_required_scope(websocket, scopes_list):

--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -40,7 +40,7 @@ def requires(
             async def websocket_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> None:
-                websocket = kwargs.get("websocket", args[idx] if args else None)
+                websocket = kwargs.get("websocket", args[idx] if args and idx < len(args) else None)
                 assert isinstance(websocket, WebSocket)
 
                 if not has_required_scope(websocket, scopes_list):
@@ -56,7 +56,7 @@ def requires(
             async def async_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> Response:
-                request = kwargs.get("request", args[idx] if args else None)
+                request = kwargs.get("request", args[idx] if args and idx < len(args) else None)
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):
@@ -73,7 +73,7 @@ def requires(
             # Handle sync request/response functions.
             @functools.wraps(func)
             def sync_wrapper(*args: typing.Any, **kwargs: typing.Any) -> Response:
-                request = kwargs.get("request", args[idx] if args else None)
+                request = kwargs.get("request", args[idx] if args and idx < len(args) else None)
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):

--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -41,7 +41,7 @@ def requires(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> None:
                 websocket = kwargs.get(
-                    "websocket", args[idx] if args and idx < len(args) else None
+                    "websocket", args[idx] if idx < len(args) else None
                 )
                 assert isinstance(websocket, WebSocket)
 
@@ -59,7 +59,7 @@ def requires(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> Response:
                 request = kwargs.get(
-                    "request", args[idx] if args and idx < len(args) else None
+                    "request", args[idx] if idx < len(args) else None
                 )
                 assert isinstance(request, Request)
 
@@ -78,7 +78,7 @@ def requires(
             @functools.wraps(func)
             def sync_wrapper(*args: typing.Any, **kwargs: typing.Any) -> Response:
                 request = kwargs.get(
-                    "request", args[idx] if args and idx < len(args) else None
+                    "request", args[idx] if idx < len(args) else None
                 )
                 assert isinstance(request, Request)
 

--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -40,9 +40,7 @@ def requires(
             async def websocket_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> None:
-                websocket = kwargs.get(
-                    "websocket", args[idx] if idx < len(args) else None
-                )
+                websocket = kwargs.get("websocket", args[idx] if idx < len(args) else None)
                 assert isinstance(websocket, WebSocket)
 
                 if not has_required_scope(websocket, scopes_list):
@@ -58,9 +56,7 @@ def requires(
             async def async_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> Response:
-                request = kwargs.get(
-                    "request", args[idx] if idx < len(args) else None
-                )
+                request = kwargs.get("request", args[idx] if idx < len(args) else None)
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):
@@ -77,9 +73,7 @@ def requires(
             # Handle sync request/response functions.
             @functools.wraps(func)
             def sync_wrapper(*args: typing.Any, **kwargs: typing.Any) -> Response:
-                request = kwargs.get(
-                    "request", args[idx] if idx < len(args) else None
-                )
+                request = kwargs.get("request", args[idx] if idx < len(args) else None)
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):

--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -40,7 +40,9 @@ def requires(
             async def websocket_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> None:
-                websocket = kwargs.get("websocket", args[idx] if args and idx < len(args) else None)
+                websocket = kwargs.get(
+                    "websocket", args[idx] if args and idx < len(args) else None
+                )
                 assert isinstance(websocket, WebSocket)
 
                 if not has_required_scope(websocket, scopes_list):
@@ -56,7 +58,9 @@ def requires(
             async def async_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> Response:
-                request = kwargs.get("request", args[idx] if args and idx < len(args) else None)
+                request = kwargs.get(
+                    "request", args[idx] if args and idx < len(args) else None
+                )
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):
@@ -73,7 +77,9 @@ def requires(
             # Handle sync request/response functions.
             @functools.wraps(func)
             def sync_wrapper(*args: typing.Any, **kwargs: typing.Any) -> Response:
-                request = kwargs.get("request", args[idx] if args and idx < len(args) else None)
+                request = kwargs.get(
+                    "request", args[idx] if args and idx < len(args) else None
+                )
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):


### PR DESCRIPTION
Fix for `IndexError` when both `args` and `kwargs` are specified, resulting in the possibility of trying to access a tuple index that is higher than the tuple size.

* Closes [Authentication middleware IndexError on instance method  #1334](https://github.com/encode/starlette/issues/1334)