### PR TITLE
Concatenate parameters on Request/WebSocket discovery in `requires()`

### DIFF
--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -40,7 +40,8 @@ def requires(
             async def websocket_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> None:
-                websocket = kwargs.get("websocket", args[idx] if args else None)
+                params = args + tuple(kwargs.values())
+                websocket = kwargs.get("websocket", params[idx])
                 assert isinstance(websocket, WebSocket)
 
                 if not has_required_scope(websocket, scopes_list):
@@ -56,7 +57,8 @@ def requires(
             async def async_wrapper(
                 *args: typing.Any, **kwargs: typing.Any
             ) -> Response:
-                request = kwargs.get("request", args[idx] if args else None)
+                params = args + tuple(kwargs.values())
+                request = kwargs.get("request", params[idx])
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):
@@ -73,7 +75,8 @@ def requires(
             # Handle sync request/response functions.
             @functools.wraps(func)
             def sync_wrapper(*args: typing.Any, **kwargs: typing.Any) -> Response:
-                request = kwargs.get("request", args[idx] if args else None)
+                params = args + tuple(kwargs.values())
+                request = kwargs.get("request", params[idx])
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):


### PR DESCRIPTION
This is an study about the differences between `Starlette` and `FastAPI` using the `AuthenticationMiddleware`. The problem is on how `FastAPI` manipulates the function signature, as we can see below:

<details>
<summary> Starlette Application </summary>

```python
import typing

from starlette.applications import Starlette
from starlette.authentication import (AuthCredentials, AuthenticationBackend,
                                      BaseUser, SimpleUser, requires)
from starlette.middleware import Middleware
from starlette.middleware.authentication import AuthenticationMiddleware
from starlette.requests import HTTPConnection, Request
from starlette.responses import JSONResponse
from starlette.routing import Route


class AuthBackend(AuthenticationBackend):
    async def authenticate(
        self, conn: HTTPConnection
    ) -> typing.Optional[typing.Tuple["AuthCredentials", "BaseUser"]]:
        return AuthCredentials(["TheScope"]), SimpleUser("TheUser)")


class Main:
    @requires("TheScope")
    def some_route(self, request: Request):
        return JSONResponse({"hello": "world"})


main = Main()
routes = [Route("/", endpoint=main.some_route, methods=["GET"])]
middleware = [Middleware(AuthenticationMiddleware, backend=AuthBackend())]
app = Starlette(routes=routes, middleware=middleware)
```

Args: `(<main_starlette.Main object at 0x7f0f9e6da400>, <starlette.requests.Request object at 0x7f0f9e6d4370>)`
Kwargs: `{}`
</details>

<details>
<summary> FastAPI Application Working </summary>

```python
import typing

from fastapi import FastAPI
from starlette.authentication import (
    AuthCredentials,
    AuthenticationBackend,
    BaseUser,
    SimpleUser,
    requires,
)
from starlette.middleware.authentication import AuthenticationMiddleware
from starlette.requests import HTTPConnection, Request


class AuthBackend(AuthenticationBackend):
    async def authenticate(
        self, conn: HTTPConnection
    ) -> typing.Optional[typing.Tuple["AuthCredentials", "BaseUser"]]:
        return AuthCredentials(["TheScope"]), SimpleUser("TheUser)")


app = FastAPI()
app.add_middleware(AuthenticationMiddleware, backend=AuthBackend())


@app.get("/")
@requires("TheScope")
def some_route(request: Request):
    return {"hello": "world"}
```

Args: `()`
Kwargs: `{'request': <starlette.requests.Request object at 0x7fbc12d376d0>}`
</details>

<details>
<summary> FastAPI Application not working </summary>

```python
# main_fastapi.py

import typing

from fastapi import APIRouter, FastAPI
from starlette.authentication import (
    AuthCredentials,
    AuthenticationBackend,
    BaseUser,
    SimpleUser,
    requires,
)
from starlette.middleware.authentication import AuthenticationMiddleware
from starlette.requests import HTTPConnection, Request


class AuthBackend(AuthenticationBackend):
    async def authenticate(
        self, conn: HTTPConnection
    ) -> typing.Optional[typing.Tuple["AuthCredentials", "BaseUser"]]:
        return AuthCredentials(["TheScope"]), SimpleUser("TheUser)")


app = FastAPI()
app.add_middleware(AuthenticationMiddleware, backend=AuthBackend())


class Main:
    @requires("TheScope")
    def some_route(self, request: Request):
        return {"hello": "world"}


main = Main()
router = APIRouter()
router.add_api_route("/", main.some_route, methods=["GET"])

app.include_router(router)
```

Args: `(<main_fastapi.Main object at 0x7f03b57ef580>,)`
Kwargs: `{'request': <starlette.requests.Request object at 0x7f03b57fdac0>}`
</details>

To be fair, this will solve the issue on FastAPI, but it doesn't seem right for Starlette to consider this case.

For the above reason, I'm not very keen on having this merged. I'll let this PR live to see if anyone else has a different opinion. 

- Closes https://github.com/encode/starlette/issues/1334
- Alternative solution was developed on #1335.