### PR TITLE
Change default chunk size from 4Kb to 64Kb

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -248,7 +248,7 @@ class StreamingResponse(Response):
 
 
 class FileResponse(Response):
-    chunk_size = 65536
+    chunk_size = 64 * 1024
 
     def __init__(
         self,

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -248,7 +248,7 @@ class StreamingResponse(Response):
 
 
 class FileResponse(Response):
-    chunk_size = 4096
+    chunk_size = 65536
 
     def __init__(
         self,


### PR DESCRIPTION
- Closes https://github.com/encode/starlette/issues/1100

@tomchristie On that issue, you said that "httpx uses 64k read size", but I couldn't find that. Do you mind pointing me out what did you mean?