### PR TITLE
Support customizing portal in TestClient

### DIFF
--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -90,6 +90,11 @@ def test_use_multiple_testclients_with_asyncio(test_client_factory, anyio_backen
         assert client_2.get("/").json() == {}
         assert parent_client.get("/").json() == {}
 
+        client_3 = test_client_factory(service, portal=parent_client.portal)
+        with client_3:
+            assert client_3.get("/").json() == {}
+            assert parent_client.get("/").json() == {}
+
 
 def test_use_testclient_as_contextmanager(test_client_factory, anyio_backend_name):
     """

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -72,7 +72,7 @@ def test_use_testclient_in_endpoint(test_client_factory):
 
 
 def test_use_multiple_testclients_with_asyncio(test_client_factory, anyio_backend_name):
-    if anyio_backend_name != 'asyncio':
+    if anyio_backend_name != "asyncio":
         return
     service = Starlette()
 


### PR DESCRIPTION
Consider a situation where we would like to create a second instance of `TestClient` within a started app:

```python
@pytest.fixture(scope='session')
def running_app() -> TestClient:
    with TestClient(app) as running_app:
        yield app

@pytest.fixture()
def user_client() -> TestClient:
    user_client = TestClient(app)
    user_client.headers['Authorization'] = 'Bearer abc123'
    return user_client

def test_auth(running_app: TestClient, user_client: TestClient):
    public_client = running_app
    assert public_client.get('/protected').status_code == 403
    assert user_client.get('/protected').status_code == 200
```

Previously, in `starlette<0.15.0`, this worked fine. However, since `starlette>=0.15.0` this causes mayhem when something attaches to the event loop on startup and then is used within a request. The specific reason this doesn't work is because two different event loops are created as described [here](https://github.com/encode/starlette/issues/1315#issuecomment-980784457) in #1315. This PR adds a new `portal` argument to `TestClient` which allows sharing the same `BlockingPortal` instance from anyio and transitively sharing the same event loop.

With this change, the example above just has to be slightly adapted as follows:
```python
@pytest.fixture()
def user_client(running_app) -> TestClient:
    user_client = TestClient(app, portal=running_app.portal)
    user_client.headers['Authorization'] = 'Bearer abc123'
    return user_client
```

Feel free to suggest alternate solutions. I figured I'd create the PR for discussion (since the code change is simple enough).

Also, note that from what I understand of Trio, this problem wouldn't happen there because it doesn't have the concept of unscoped task creation like asyncio does.