### PR TITLE
Add staticfiles packages with directory

### DIFF
--- a/docs/staticfiles.md
+++ b/docs/staticfiles.md
@@ -6,7 +6,7 @@ Starlette also includes a `StaticFiles` class for serving files in a given direc
 Signature: `StaticFiles(directory=None, packages=None, check_dir=True)`
 
 * `directory` - A string or [os.Pathlike][pathlike] denoting a directory path.
-* `packages` - A list of strings of python packages.
+* `packages` - A list of strings or list of tuples of strings of python packages.
 * `html` - Run in HTML mode. Automatically loads `index.html` for directories if such file exist.
 * `check_dir` - Ensure that the directory exists upon instantiation. Defaults to `True`.
 
@@ -46,6 +46,16 @@ routes=[
 ]
 
 app = Starlette(routes=routes)
+```
+
+By default `StaticFiles` will look for `statics` directory in each package,
+you can change the default directory by specifying a tuple of strings.
+
+```python
+routes=[
+    ...
+    Mount('/static', app=StaticFiles(packages=[('bootstrap4', 'static')]), name="static"),
+]
 ```
 
 You may prefer to include static files directly inside the "static" directory

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -63,6 +63,10 @@ class StaticFiles:
         """
         Given `directory` and `packages` arguments, return a list of all the
         directories that should be used for serving static files from.
+
+        It can take a single directory,
+        or a list of `packages` and look for default `statics` in each package,
+        or a list of `packages` with a `directory` to look for in each package.
         """
         directories = []
         if directory is not None:

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -67,7 +67,7 @@ def test_staticfiles_with_package(test_client_factory):
     assert response.status_code == 200
     assert response.text == "123\n"
 
-    app = StaticFiles(packages=["tests"], directory="statics")
+    app = StaticFiles(packages=[("tests", "statics")])
     client = test_client_factory(app)
     response = client.get("/example.txt")
     assert response.status_code == 200

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -67,6 +67,12 @@ def test_staticfiles_with_package(test_client_factory):
     assert response.status_code == 200
     assert response.text == "123\n"
 
+    app = StaticFiles(packages=["tests"], directory="statics")
+    client = test_client_factory(app)
+    response = client.get("/example.txt")
+    assert response.status_code == 200
+    assert response.text == "123\n"
+
 
 def test_staticfiles_post(tmpdir, test_client_factory):
     path = os.path.join(tmpdir, "example.txt")


### PR DESCRIPTION
Closes #1265.

Adds ability to specify directory when using the `packages` argument in StaticFiles.

The final API is:


```python
routes=[
    ...
    Mount('/static', app=StaticFiles(packages=['bootstrap4', ('mypackage', 'dist')]), name="static"),
]
```

This will look for "statics" directory in "bootstrap4" package and "dist" directory in "mypackage".
