### PR TITLE
test: use --show-error-codes for mypy

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -11,4 +11,4 @@ set -x
 ${PREFIX}isort --check --diff --project=starlette $SOURCE_FILES
 ${PREFIX}black --check --diff $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
-${PREFIX}mypy $SOURCE_FILES
+${PREFIX}mypy --show-error-codes $SOURCE_FILES

--- a/scripts/check
+++ b/scripts/check
@@ -11,4 +11,4 @@ set -x
 ${PREFIX}isort --check --diff --project=starlette $SOURCE_FILES
 ${PREFIX}black --check --diff $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
-${PREFIX}mypy --show-error-codes $SOURCE_FILES
+${PREFIX}mypy $SOURCE_FILES

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ max-line-length = 88
 [mypy]
 disallow_untyped_defs = True
 ignore_missing_imports = True
+show_error_codes = True
 
 [mypy-tests.*]
 disallow_untyped_defs = False


### PR DESCRIPTION
This is helpful in adding tactical `# type: ignore[error-code]`s