### PR TITLE
Add dependbot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Following [this](https://github.com/encode/starlette/pull/1373#issuecomment-995796307) comment, this will add dependbot in version control same as httpx, httpcore.
As mentioned uvicorn uses Dependbot as an app, but I guess having it in repo would be more clear.