### PR TITLE
Type background argument in responses as Optional

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -40,7 +40,7 @@ class Response:
         status_code: int = 200,
         headers: dict = None,
         media_type: str = None,
-        background: BackgroundTask = None,
+        background: typing.Optional[BackgroundTask] = None,
     ) -> None:
         self.status_code = status_code
         if media_type is not None:
@@ -186,7 +186,7 @@ class RedirectResponse(Response):
         url: typing.Union[str, URL],
         status_code: int = 307,
         headers: dict = None,
-        background: BackgroundTask = None,
+        background: typing.Optional[BackgroundTask] = None,
     ) -> None:
         super().__init__(
             content=b"", status_code=status_code, headers=headers, background=background
@@ -201,7 +201,7 @@ class StreamingResponse(Response):
         status_code: int = 200,
         headers: dict = None,
         media_type: str = None,
-        background: BackgroundTask = None,
+        background: typing.Optional[BackgroundTask] = None,
     ) -> None:
         if isinstance(content, typing.AsyncIterable):
             self.body_iterator = content
@@ -256,7 +256,7 @@ class FileResponse(Response):
         status_code: int = 200,
         headers: dict = None,
         media_type: str = None,
-        background: BackgroundTask = None,
+        background: typing.Optional[BackgroundTask] = None,
         filename: str = None,
         stat_result: os.stat_result = None,
         method: str = None,

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -27,7 +27,7 @@ class _TemplateResponse(Response):
         status_code: int = 200,
         headers: dict = None,
         media_type: str = None,
-        background: BackgroundTask = None,
+        background: typing.Optional[BackgroundTask] = None,
     ):
         self.template = template
         self.context = context
@@ -82,7 +82,7 @@ class Jinja2Templates:
         status_code: int = 200,
         headers: dict = None,
         media_type: str = None,
-        background: BackgroundTask = None,
+        background: typing.Optional[BackgroundTask] = None,
     ) -> _TemplateResponse:
         if "request" not in context:
             raise ValueError('context must include a "request" key')


### PR DESCRIPTION
Having `background` argument as `Optional` allows for conditionally pass a background task (`background=background if ... else None`) together with `no_implicit_optional=true` configured for mypy.

With the setup above, one is currently hit with:

```
error: Argument "background" to "Response" has incompatible type "Optional[BackgroundTask]"; expected "BackgroundTask"  [arg-type]
```

Here's a snippet for checking in on the adjusted type:

```python
import random

from starlette.background import BackgroundTask
from starlette.responses import (
    FileResponse,
    RedirectResponse,
    Response,
    StreamingResponse,
)
from starlette.templating import Jinja2Templates


def bg() -> None:
    return None


background = BackgroundTask(bg)

Response(background=background if random.choice([True, False]) else None)
Response(background=background)
Response(background=None)

RedirectResponse("", background=background if random.choice([True, False]) else None)
RedirectResponse("", background=background)
RedirectResponse("", background=None)

StreamingResponse("", background=background if random.choice([True, False]) else None)
StreamingResponse("", background=background)
StreamingResponse("", background=None)

FileResponse("", background=background if random.choice([True, False]) else None)
FileResponse("", background=background)
FileResponse("", background=None)

jinja = Jinja2Templates("")
jinja.TemplateResponse("", {}, background=background if random.choice([True, False]) else None)
jinja.TemplateResponse("", {}, background=background)
jinja.TemplateResponse("", {}, background=None)
```