### PR TITLE
feat: add headers to UploadFile

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -122,7 +122,7 @@ multidict, containing both file uploads and text input. File upload items are re
 * `filename`: A `str` with the original file name that was uploaded (e.g. `myimage.jpg`).
 * `content_type`: A `str` with the content type (MIME type / media type) (e.g. `image/jpeg`).
 * `file`: A <a href="https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile" target="_blank">`SpooledTemporaryFile`</a> (a <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> object). This is the actual Python file that you can pass directly to other functions or libraries that expect a "file-like" object.
-
+* `headers`: A `Headers` object. Often this will only be the `Content-Type` header, but if additional headers were included in the multipart field they will be included here. Note that these headers have no relationship with the headers in `Request.headers`.
 
 `UploadFile` has the following `async` methods. They all call the corresponding file methods underneath (using the internal `SpooledTemporaryFile`).
 
@@ -141,6 +141,7 @@ form = await request.form()
 filename = form["upload_file"].filename
 contents = await form["upload_file"].read()
 ```
+
 
 #### Application
 

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -423,14 +423,14 @@ class UploadFile:
         file: typing.IO = None,
         content_type: str = "",
         *,
-        raw_headers: typing.Optional[typing.List[typing.Tuple[bytes, bytes]]] = None,
+        headers: "typing.Optional[Headers]" = None,
     ) -> None:
         self.filename = filename
         self.content_type = content_type
         if file is None:
             file = tempfile.SpooledTemporaryFile(max_size=self.spool_max_size)
         self.file = file
-        self.headers = Headers(raw=raw_headers or [])
+        self.headers = headers or Headers()
 
     @property
     def _in_memory(self) -> bool:

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -430,9 +430,7 @@ class UploadFile:
         if file is None:
             file = tempfile.SpooledTemporaryFile(max_size=self.spool_max_size)
         self.file = file
-        self.headers = Headers(
-            raw=raw_headers or [(b"Content-Type", content_type.encode("latin-1"))]
-        )
+        self.headers = Headers(raw=raw_headers or [])
 
     @property
     def _in_memory(self) -> bool:

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -415,15 +415,24 @@ class UploadFile:
     """
 
     spool_max_size = 1024 * 1024
+    headers: "Headers"
 
     def __init__(
-        self, filename: str, file: typing.IO = None, content_type: str = ""
+        self,
+        filename: str,
+        file: typing.IO = None,
+        content_type: str = "",
+        *,
+        raw_headers: typing.Optional[typing.List[typing.Tuple[bytes, bytes]]] = None,
     ) -> None:
         self.filename = filename
         self.content_type = content_type
         if file is None:
             file = tempfile.SpooledTemporaryFile(max_size=self.spool_max_size)
         self.file = file
+        self.headers = Headers(
+            raw=raw_headers or [(b"Content-Type", content_type.encode("latin-1"))]
+        )
 
     @property
     def _in_memory(self) -> bool:

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -184,6 +184,7 @@ class MultiPartParser:
         file: typing.Optional[UploadFile] = None
 
         items: typing.List[typing.Tuple[str, typing.Union[str, UploadFile]]] = []
+        item_headers: typing.List[typing.Tuple[bytes, bytes]] = []
 
         # Feed the parser with data from the request.
         async for chunk in self.stream:
@@ -195,6 +196,7 @@ class MultiPartParser:
                     content_disposition = None
                     content_type = b""
                     data = b""
+                    item_headers = []
                 elif message_type == MultiPartMessage.HEADER_FIELD:
                     header_field += message_bytes
                 elif message_type == MultiPartMessage.HEADER_VALUE:
@@ -205,6 +207,7 @@ class MultiPartParser:
                         content_disposition = header_value
                     elif field == b"content-type":
                         content_type = header_value
+                    item_headers.append((field, header_value))
                     header_field = b""
                     header_value = b""
                 elif message_type == MultiPartMessage.HEADERS_FINISHED:
@@ -215,6 +218,7 @@ class MultiPartParser:
                         file = UploadFile(
                             filename=filename,
                             content_type=content_type.decode("latin-1"),
+                            raw_headers=item_headers,
                         )
                     else:
                         file = None

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -218,7 +218,7 @@ class MultiPartParser:
                         file = UploadFile(
                             filename=filename,
                             content_type=content_type.decode("latin-1"),
-                            raw_headers=item_headers,
+                            headers=Headers(raw=item_headers),
                         )
                     else:
                         file = None


### PR DESCRIPTION
Alternative / subset of #1311.

This preserves the multipart field headers for file uploads. Currently only `content_type` is preserved.

As per https://github.com/encode/starlette/pull/1311#issuecomment-999752023, this is pretty much the same API Flask uses.