### PR TITLE
Set `request` in template context

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -24,7 +24,7 @@ routes = [
 app = Starlette(debug=True, routes=routes)
 ```
 
-The Jinja2 template context will automatically include a `url_for` function,
+The Jinja2 template context will automatically include `request` and a `url_for` function,
 so we can correctly hyperlink to other pages within the application.
 
 For example, we can link to static files from within our HTML templates:
@@ -58,6 +58,7 @@ def test_homepage():
     response = client.get("/")
     assert response.status_code == 200
     assert response.template.name == 'index.html'
+    assert "request" in response.context
 ```
 
 ## Asynchronous template rendering

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -14,7 +14,7 @@ from starlette.staticfiles import StaticFiles
 templates = Jinja2Templates(directory='templates')
 
 async def homepage(request):
-    return templates.TemplateResponse('index.html', {'request': request})
+    return templates.TemplateResponse('index.html')
 
 routes = [
     Route('/', endpoint=homepage),
@@ -23,9 +23,6 @@ routes = [
 
 app = Starlette(debug=True, routes=routes)
 ```
-
-Note that the incoming `request` instance must be included as part of the
-template context.
 
 The Jinja2 template context will automatically include a `url_for` function,
 so we can correctly hyperlink to other pages within the application.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -58,7 +58,6 @@ def test_homepage():
     response = client.get("/")
     assert response.status_code == 200
     assert response.template.name == 'index.html'
-    assert "request" in response.context
 ```
 
 ## Asynchronous template rendering

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -24,7 +24,7 @@ routes = [
 app = Starlette(debug=True, routes=routes)
 ```
 
-The Jinja2 template context will automatically include `request` and a `url_for` function,
+The Jinja2 template context will automatically include a `request` instance, and a `url_for` function,
 so we can correctly hyperlink to other pages within the application.
 
 For example, we can link to static files from within our HTML templates:

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -35,13 +35,12 @@ class _TemplateResponse(Response):
         super().__init__(b"", status_code, headers, media_type, background)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if "request" not in self.context:
-            self.context["request"] = Request(scope, receive, send)
+        self.context["_request"] = Request(scope, receive, send)
 
         content = self.template.render(self.context)
         self.body = self.render(content)
 
-        request = self.context.get("request", {})
+        request = self.context.get("_request", {})
         extensions = request.get("extensions", {})
 
         if "http.response.template" in extensions:
@@ -71,7 +70,7 @@ class Jinja2Templates:
     ) -> "jinja2.Environment":
         @pass_context
         def url_for(context: dict, name: str, **path_params: typing.Any) -> str:
-            request = context["request"]
+            request = context["_request"]
             return request.url_for(name, **path_params)
 
         loader = jinja2.FileSystemLoader(directory)

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -35,12 +35,13 @@ class _TemplateResponse(Response):
         super().__init__(b"", status_code, headers, media_type, background)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        self.context["_request"] = Request(scope, receive, send)
+        if "request" not in self.context:
+            self.context["request"] = Request(scope, receive, send)
 
         content = self.template.render(self.context)
         self.body = self.render(content)
 
-        request = self.context.get("_request", {})
+        request = self.context.get("request", {})
         extensions = request.get("extensions", {})
 
         if "http.response.template" in extensions:
@@ -70,7 +71,7 @@ class Jinja2Templates:
     ) -> "jinja2.Environment":
         @pass_context
         def url_for(context: dict, name: str, **path_params: typing.Any) -> str:
-            request = context["_request"]
+            request = context["request"]
             return request.url_for(name, **path_params)
 
         loader = jinja2.FileSystemLoader(directory)

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -35,7 +35,7 @@ class _TemplateResponse(Response):
         super().__init__(b"", status_code, headers, media_type, background)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if not "request" in self.context:
+        if "request" not in self.context:
             self.context["request"] = Request(scope, receive, send)
 
         content = self.template.render(self.context)

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -58,7 +58,7 @@ class Jinja2Templates:
     """
     templates = Jinja2Templates("templates")
 
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse("index.html")
     """
 
     def __init__(self, directory: typing.Union[str, PathLike]) -> None:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -20,4 +20,4 @@ def test_templates(tmpdir, test_client_factory):
     response = client.get("/")
     assert response.text == "<html>Hello, <a href='http://testserver/'>world</a></html>"
     assert response.template.name == "index.html"
-    assert set(response.context.keys()) == {"request"}
+    assert set(response.context.keys()) == {"_request"}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -20,4 +20,4 @@ def test_templates(tmpdir, test_client_factory):
     response = client.get("/")
     assert response.text == "<html>Hello, <a href='http://testserver/'>world</a></html>"
     assert response.template.name == "index.html"
-    assert set(response.context.keys()) == {"_request"}
+    assert set(response.context.keys()) == {"request"}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,7 +1,5 @@
 import os
 
-import pytest
-
 from starlette.applications import Starlette
 from starlette.templating import Jinja2Templates
 
@@ -16,16 +14,10 @@ def test_templates(tmpdir, test_client_factory):
 
     @app.route("/")
     async def homepage(request):
-        return templates.TemplateResponse("index.html", {"request": request})
+        return templates.TemplateResponse("index.html")
 
     client = test_client_factory(app)
     response = client.get("/")
     assert response.text == "<html>Hello, <a href='http://testserver/'>world</a></html>"
     assert response.template.name == "index.html"
     assert set(response.context.keys()) == {"request"}
-
-
-def test_template_response_requires_request(tmpdir):
-    templates = Jinja2Templates(str(tmpdir))
-    with pytest.raises(ValueError):
-        templates.TemplateResponse(None, {})


### PR DESCRIPTION
Closes #482 according to [this](https://github.com/encode/starlette/issues/482#issuecomment-484138702).

Sets up request for template context automatically. So instead of this:

```python
async def homepage(request):
    return templates.TemplateResponse('index.html', {'request': request})
```

We can do:

```python
async def homepage(request):
    return templates.TemplateResponse('index.html')
```

So the `context` argument to `templates.TemplateResponse` is not required anymore.