### PR TITLE
Allow `env_options` in ``Jinja2Templates`

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -64,6 +64,20 @@ def test_homepage():
     assert "request" in response.context
 ```
 
+## Customizing Jinja2 Environment
+
+`Jinja2Templates` accepts all options supported by Jinja2 `Environment`.
+This will allow more control over the `Enivornment` instance created by Starlette.
+
+For the list of options available to `Environment` you can check Jinja2 documentation [here](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment)
+
+```python
+from starlette.templating import Jinja2Templates
+
+
+templates = Jinja2Templates(directory='templates', autoescape=False, auto_reload=True)
+```
+
 ## Asynchronous template rendering
 
 Jinja2 supports async template rendering, however as a general rule

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -55,12 +55,14 @@ class Jinja2Templates:
     return templates.TemplateResponse("index.html", {"request": request})
     """
 
-    def __init__(self, directory: typing.Union[str, PathLike]) -> None:
+    def __init__(
+        self, directory: typing.Union[str, PathLike], **env_options: typing.Any
+    ) -> None:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
-        self.env = self._create_env(directory)
+        self.env = self._create_env(directory, **env_options)
 
     def _create_env(
-        self, directory: typing.Union[str, PathLike]
+        self, directory: typing.Union[str, PathLike], **env_options: typing.Any
     ) -> "jinja2.Environment":
         @pass_context
         def url_for(context: dict, name: str, **path_params: typing.Any) -> str:
@@ -68,7 +70,10 @@ class Jinja2Templates:
             return request.url_for(name, **path_params)
 
         loader = jinja2.FileSystemLoader(directory)
-        env = jinja2.Environment(loader=loader, autoescape=True)
+        env_options.setdefault("loader", loader)
+        env_options.setdefault("autoescape", True)
+
+        env = jinja2.Environment(**env_options)
         env.globals["url_for"] = url_for
         return env
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -29,3 +29,12 @@ def test_template_response_requires_request(tmpdir):
     templates = Jinja2Templates(str(tmpdir))
     with pytest.raises(ValueError):
         templates.TemplateResponse(None, {})
+
+
+def test_template_jinja2_env_options(tmpdir):
+    templates = Jinja2Templates(
+        directory=str(tmpdir), autoescape=False, auto_reload=True
+    )
+
+    assert templates.env.autoescape is False
+    assert templates.env.auto_reload is True


### PR DESCRIPTION
Closes #427 

Allows `Jinja2Templates` to set Jinja2 `Environment` options [here](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment).

For example:

```python
templates = Jinja2Templates(
        directory=directory, autoescape=False, auto_reload=True, enable_async=True
)
```

Or:

```python
loader = jinja2.FileSystemLoader(directory)

templates = Jinja2Templates(
        directory=directory, loader=loader
)
```

Since `directory` is still a required argument, it will be passed in this case, but the loader passed will take precedence over the `directory` and the loader created by Starlette. I can't think of any way to handle this right now, until maybe we can consider another API for Jinja2Templates later. This way we can deal with issues like #1214 .

- [x] Tests
- [x] Docs