### PR TITLE
Check if `status_code` is `None` on `Response`

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -74,7 +74,11 @@ class Response:
         if (
             body is not None
             and populate_content_length
-            and not (self.status_code < 200 or self.status_code in (204, 304))
+            and not (
+                self.status_code
+                and self.status_code < 200
+                or self.status_code in (204, 304)
+            )
         ):
             content_length = str(len(body))
             raw_headers.append((b"content-length", content_length.encode("latin-1")))


### PR DESCRIPTION
Either here or https://github.com/tiangolo/fastapi/pull/4411

It makes more sense to have this on FastAPI, but the `RedirectResponse` makes it difficult to be there...

EDIT: Deciding if this is going to be solved by Starlette or FastAPI should be done before the next release.