### PR TITLE
remove file parameter from UploadFile

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -421,17 +421,13 @@ class UploadFile:
     def __init__(
         self,
         filename: str,
-        file: typing.Optional[typing.BinaryIO] = None,
         content_type: str = "",
         *,
         headers: "typing.Optional[Headers]" = None,
     ) -> None:
         self.filename = filename
         self.content_type = content_type
-        if file is None:
-            self.file = tempfile.SpooledTemporaryFile(max_size=self.spool_max_size)  # type: ignore  # noqa: E501
-        else:
-            self.file = file
+        self.file = tempfile.SpooledTemporaryFile(max_size=self.spool_max_size)  # type: ignore  # noqa: E501
         self.headers = headers or Headers()
 
     @property

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -227,18 +227,6 @@ async def test_upload_file():
     await big_file.close()
 
 
-@pytest.mark.anyio
-async def test_upload_file_file_input():
-    """Test passing file/stream into the UploadFile constructor"""
-    stream = io.BytesIO(b"data")
-    file = UploadFile(filename="file", file=stream)
-    assert await file.read() == b"data"
-    await file.write(b" and more data!")
-    assert await file.read() == b""
-    await file.seek(0)
-    assert await file.read() == b"data and more data!"
-
-
 def test_formdata():
     stream = io.BytesIO(b"data")
     upload = UploadFile(filename="file", file=stream)

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1,5 +1,3 @@
-import io
-
 import pytest
 
 from starlette.datastructures import (
@@ -228,8 +226,8 @@ async def test_upload_file():
 
 
 def test_formdata():
-    stream = io.BytesIO(b"data")
-    upload = UploadFile(filename="file", file=stream)
+    upload = UploadFile(filename="file")
+    upload.file.write(b"data")
     form = FormData([("a", "123"), ("a", "456"), ("b", upload)])
     assert "a" in form
     assert "A" not in form


### PR DESCRIPTION
As per discussion in #1405 and #1312, this parameter is not used in Starlette and is not documented as part of the public API. Having this parameters makes it harder to implement features like the one suggested in #1405.

This PR would remove this parameter.
This may break users _tests_, but should not break their production code since Starlette doesn't currently use that feature.
For a user to experience a breakage at runtime in their production code, they would have to have been using an undocumented constructor parameter to UploadFile outside of the context of the rest of Starlette, which I'm guessing is no one.