### PR TITLE
Bunch of improvements on authentication documentation

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -135,6 +135,10 @@ For class-based endpoints, you should wrap the decorator
 around a method on the class.
 
 ```python
+from starlette.authentication import requires
+from starlette.endpoints import HTTPEndpoint
+
+
 class Dashboard(HTTPEndpoint):
     @requires("authenticated")
     async def get(self, request):
@@ -147,6 +151,11 @@ You can customise the error response sent when a `AuthenticationError` is
 raised by an auth backend:
 
 ```python
+from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+
 def on_auth_error(request: Request, exc: Exception):
     return JSONResponse({"error": str(exc)}, status_code=401)
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -7,8 +7,7 @@ interfaces will be available in your endpoints.
 ```python
 from starlette.applications import Starlette
 from starlette.authentication import (
-    AuthenticationBackend, AuthenticationError, SimpleUser, UnauthenticatedUser,
-    AuthCredentials
+    AuthCredentials, AuthenticationBackend, AuthenticationError, SimpleUser
 )
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -19,11 +19,11 @@ import binascii
 
 
 class BasicAuthBackend(AuthenticationBackend):
-    async def authenticate(self, request):
-        if "Authorization" not in request.headers:
+    async def authenticate(self, conn):
+        if "Authorization" not in conn.headers:
             return
 
-        auth = request.headers["Authorization"]
+        auth = conn.headers["Authorization"]
         try:
             scheme, credentials = auth.split()
             if scheme.lower() != 'basic':


### PR DESCRIPTION
`AuthenticationBackend.authenticate` signature was updated [here](https://github.com/encode/starlette/pull/335/files#diff-44db7dbf84f50ab50eaa07be93238de53ac2d2363189fd6eef7f1de5b62752dfR71) to handle both HTTP and websocket protocols, but the documentation still uses `request`.

Also removing `UnauthenticatedUser` import in `AuthenticationBackend` example, as it is not used, and adding some missing imports in a few examples.

Side-note: The documention mixes single and double quotes usage for strings. Should a consistent style be used? Maybe https://github.com/asottile/blacken-docs could be helpful?