### PR TITLE
Default WebSocket accept message headers to an empty list

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -74,8 +74,7 @@ class WebSocket(HTTPConnection):
         subprotocol: str = None,
         headers: typing.Iterable[typing.Tuple[bytes, bytes]] = None,
     ) -> None:
-        if headers is None:
-            headers = []
+        headers = headers or []
 
         if self.client_state == WebSocketState.CONNECTING:
             # If we haven't yet seen the 'connect' message, then wait for it first.

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -74,6 +74,9 @@ class WebSocket(HTTPConnection):
         subprotocol: str = None,
         headers: typing.Iterable[typing.Tuple[bytes, bytes]] = None,
     ) -> None:
+        if headers is None:
+            headers = []
+
         if self.client_state == WebSocketState.CONNECTING:
             # If we haven't yet seen the 'connect' message, then wait for it first.
             await self.receive()

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -316,27 +316,17 @@ def test_additional_headers(test_client_factory):
 
 
 def test_no_additional_headers(test_client_factory):
-    expected_headers = []
-
-    def wrap(send):
-        async def _send(message):
-            if "headers" in message:
-                actual_headers = message.get("headers")
-                assert actual_headers == expected_headers
-            return await send(message)
-        return _send
-
     def app(scope):
         async def asgi(receive, send):
-            websocket = WebSocket(scope, receive=receive, send=wrap(send))
+            websocket = WebSocket(scope, receive=receive, send=send)
             await websocket.accept(headers=None)
             await websocket.close()
 
         return asgi
 
     client = test_client_factory(app)
-    with client.websocket_connect("/"):
-        pass  # pragma: nocover
+    with client.websocket_connect("/") as websocket:
+        assert websocket.extra_headers == []
 
 
 def test_websocket_exception(test_client_factory):

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -319,7 +319,7 @@ def test_no_additional_headers(test_client_factory):
     def app(scope):
         async def asgi(receive, send):
             websocket = WebSocket(scope, receive=receive, send=send)
-            await websocket.accept(headers=None)
+            await websocket.accept()
             await websocket.close()
 
         return asgi

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -315,6 +315,30 @@ def test_additional_headers(test_client_factory):
         assert websocket.extra_headers == [(b"additional", b"header")]
 
 
+def test_no_additional_headers(test_client_factory):
+    expected_headers = []
+
+    def wrap(send):
+        async def _send(message):
+            if "headers" in message:
+                actual_headers = message.get("headers")
+                assert actual_headers == expected_headers
+            return await send(message)
+        return _send
+
+    def app(scope):
+        async def asgi(receive, send):
+            websocket = WebSocket(scope, receive=receive, send=wrap(send))
+            await websocket.accept(headers=None)
+            await websocket.close()
+
+        return asgi
+
+    client = test_client_factory(app)
+    with client.websocket_connect("/"):
+        pass  # pragma: nocover
+
+
 def test_websocket_exception(test_client_factory):
     def app(scope):
         async def asgi(receive, send):


### PR DESCRIPTION
Recently, #1361 introduced a possibility to pass a set of extra headers into the `accept` method. If no headers are passed, the default value is `None`. This value then gets sent to the protocol server.

This causes Uvicorn to raise an exception: `TypeError: NoneType object is not iterable` when using websockets and `TypeError: can only concatenate list (not "NoneType") to list` when using wsproto.

This PR fixes this, setting the `headers` argument to an empty list if it is not passed into the method. This is recommended by the ASGI spec (https://asgi.readthedocs.io/en/latest/specs/www.html#accept-send-event).