### PR TITLE
Adjust type of `exception_handlers` to allow async callable

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -44,7 +44,10 @@ class Starlette:
         routes: typing.Sequence[BaseRoute] = None,
         middleware: typing.Sequence[Middleware] = None,
         exception_handlers: typing.Mapping[
-            typing.Any, typing.Callable[[Request, Exception], Response]
+            typing.Any,
+            typing.Callable[
+                [Request, Exception], typing.Union[Response, typing.Awaitable[Response]]
+            ],
         ] = None,
         on_startup: typing.Sequence[typing.Callable] = None,
         on_shutdown: typing.Sequence[typing.Callable] = None,


### PR DESCRIPTION
In #1360 the type for `exception_handlers` was updated but it now only accounts for callables that return a `Response`. We can have sync and async handlers here so this change should fix that.