### PR TITLE
use Mapping type for Response.headers

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -38,7 +38,7 @@ class Response:
         self,
         content: typing.Any = None,
         status_code: int = 200,
-        headers: dict = None,
+        headers: typing.Mapping[str, str] = None,
         media_type: str = None,
         background: BackgroundTask = None,
     ) -> None:
@@ -199,7 +199,7 @@ class RedirectResponse(Response):
         self,
         url: typing.Union[str, URL],
         status_code: int = 307,
-        headers: dict = None,
+        headers: typing.Mapping[str, str] = None,
         background: BackgroundTask = None,
     ) -> None:
         super().__init__(
@@ -213,7 +213,7 @@ class StreamingResponse(Response):
         self,
         content: typing.Any,
         status_code: int = 200,
-        headers: dict = None,
+        headers: typing.Mapping[str, str] = None,
         media_type: str = None,
         background: BackgroundTask = None,
     ) -> None:
@@ -268,7 +268,7 @@ class FileResponse(Response):
         self,
         path: typing.Union[str, "os.PathLike[str]"],
         status_code: int = 200,
-        headers: dict = None,
+        headers: typing.Mapping[str, str] = None,
         media_type: str = None,
         background: BackgroundTask = None,
         filename: str = None,

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -25,7 +25,7 @@ class _TemplateResponse(Response):
         template: typing.Any,
         context: dict,
         status_code: int = 200,
-        headers: dict = None,
+        headers: typing.Mapping[str, str] = None,
         media_type: str = None,
         background: BackgroundTask = None,
     ):
@@ -85,7 +85,7 @@ class Jinja2Templates:
         name: str,
         context: dict,
         status_code: int = 200,
-        headers: dict = None,
+        headers: typing.Mapping[str, str] = None,
         media_type: str = None,
         background: BackgroundTask = None,
     ) -> _TemplateResponse:


### PR DESCRIPTION
Hi,

I have read your guideline and I think this fit the "clearly identified bug"

the `headers` arg of  `Response` (or it sub classes) is annotated as  `dict`.

It is *only* used as the argument of `init_headers(self, headers: typing.Mapping[str, str] = None) -> None:`

which accepts `typing.Mapping[str, str]`, so the PR replaces the `dict` type declaration by `typing.Mapping[str, str]`.

ref:
https://github.com/encode/starlette/blob/master/starlette/responses.py#L59