### PR TITLE
Publish workflow now requires ops approval.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,3 @@
----
 name: Publish
 
 on:
@@ -10,6 +9,9 @@ jobs:
   publish:
     name: "Publish release"
     runs-on: "ubuntu-latest"
+
+    environment:
+      name: deploy
 
     steps:
       - uses: "actions/checkout@v2"


### PR DESCRIPTION
See also https://github.com/encode/uvicorn/pull/1339, https://github.com/encode/httpcore/pull/487, https://github.com/encode/httpx/pull/2040