### PR TITLE
Add "Allow" headers to 405 Method Not Allowed responses

### DIFF
--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -43,9 +43,17 @@ class HTTPEndpoint:
         # If we're running inside a starlette application then raise an
         # exception, so that the configurable exception handler can deal with
         # returning the response. For plain ASGI apps, just return the response.
+        allowed_methods = filter(
+            lambda method: getattr(self, method.lower(), None) is not None,
+            ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        )
         if "app" in self.scope:
             raise HTTPException(status_code=405)
-        return PlainTextResponse("Method Not Allowed", status_code=405)
+        return PlainTextResponse(
+            "Method Not Allowed",
+            status_code=405,
+            headers={"allow": ", ".join(allowed_methods)},
+        )
 
 
 class WebSocketEndpoint:

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -253,7 +253,11 @@ class Route(BaseRoute):
             if "app" in scope:
                 raise HTTPException(status_code=405)
             else:
-                response = PlainTextResponse("Method Not Allowed", status_code=405)
+                response = PlainTextResponse(
+                    "Method Not Allowed",
+                    status_code=405,
+                    headers={"allow": ", ".join(self.methods)},
+                )
             await response(scope, receive, send)
         else:
             await self.app(scope, receive, send)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -40,6 +40,7 @@ def test_http_endpoint_route_method(client):
     response = client.post("/")
     assert response.status_code == 405
     assert response.text == "Method Not Allowed"
+    assert response.headers["allow"] == "GET"
 
 
 def test_websocket_endpoint_on_connect(test_client_factory):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -17,6 +17,10 @@ def not_modified(request):
     raise HTTPException(status_code=304)
 
 
+def not_allowed(request):
+    raise HTTPException(status_code=405)
+
+
 class HandledExcAfterResponse:
     async def __call__(self, scope, receive, send):
         response = PlainTextResponse("OK", status_code=200)
@@ -29,6 +33,7 @@ router = Router(
         Route("/runtime_error", endpoint=raise_runtime_error),
         Route("/not_acceptable", endpoint=not_acceptable),
         Route("/not_modified", endpoint=not_modified),
+        Route("/not_allowed", endpoint=not_allowed),
         Route("/handled_exc_after_response", endpoint=HandledExcAfterResponse()),
         WebSocketRoute("/runtime_error", endpoint=raise_runtime_error),
     ]
@@ -54,6 +59,12 @@ def test_not_modified(client):
     response = client.get("/not_modified")
     assert response.status_code == 304
     assert response.text == ""
+
+
+def test_not_allowed(client):
+    response = client.get("/not_allowed")
+    assert response.status_code == 405
+    assert set(response.headers["allow"].split(", ")) == {"HEAD", "GET"}
 
 
 def test_websockets_should_raise(client):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -161,6 +161,7 @@ def test_router(client):
     response = client.post("/")
     assert response.status_code == 405
     assert response.text == "Method Not Allowed"
+    assert set(response.headers["allow"].split(", ")) == {"HEAD", "GET"}
 
     response = client.get("/foo")
     assert response.status_code == 404


### PR DESCRIPTION
This PR was inspired based on a [FastAPI issue](https://github.com/tiangolo/fastapi/issues/4478) reported by @hellocoldworld.

As we can see on the [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.5), responses with 405 status code **MUST** provide the `allow` headers. Starlette doesn't honor that.

What this PR introduces is a potential solution, which I'd like to discuss - to understand if it's the best solution. Changes here:
- `ExceptionMiddleware` adds `allow` headers when `HTTPException.status_code == 405`. (I'm not sure if this makes sense yet).
- Add `allow` headers when `PlainResponse.status_code == 405`.

There's still a case that is not being handled on this PR:
- When we have AnyResponse(status_code=405), it doesn't add the `allow` headers. It should, right? 

Important resources:
- [Click here to see](https://github.com/django/django/blob/a93a1ba347be9744e8492dd8288f18b3831caa02/django/http/response.py#L560-L573) Django way of handling 405 allow headers.
- [Click here to see](https://github.com/pallets/werkzeug/blob/b611af2f5bf5f447d1d535b45f7c19309b0dc48d/src/werkzeug/exceptions.py#L351-L384) Flask way of handling 405 allow headers.
