### PR TITLE
Add custom URL convertor register

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -55,6 +55,31 @@ Route('/floating-point/{number:float}', floating_point)
 Route('/uploaded/{rest_of_path:path}', uploaded)
 ```
 
+If you need a different converter that is not defined, you can create your own.
+See below an example on how to create a `datetime` convertor, and how to register it:
+
+```python
+from starlette.convertors import Convertor, register_url_convertor
+
+
+class DateTimeConvertor(Convertor):
+    regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?"
+
+    def convert(self, value: str) -> dt.datetime:
+        return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
+
+    def to_string(self, value: dt.datetime) -> str:
+        return value.strftime("%Y-%m-%dT%H:%M:%S")
+
+register_url_convertor("datetime", DateTimeConvertor())
+```
+
+After registering it, you'll be able to use it as:
+
+```python
+Route('/history/{date:datetime}', history)
+```
+
 Path parameters are made available in the request, as the `request.path_params`
 dictionary.
 
@@ -184,9 +209,9 @@ url = app.url_path_for("user_detail", username=...)
 If you want to use different routes for the same path based on the `Host` header.
 
 Note that port is removed from the `Host` header when matching.
-For example, `Host (host='example.org:3600', ...)` will be processed 
+For example, `Host (host='example.org:3600', ...)` will be processed
 even if the `Host` header contains or does not contain a port other than `3600`
-(`example.org:5600`, `example.org`). 
+(`example.org:5600`, `example.org`).
 Therefore, you can specify the port if you need it for use in `url_for`.
 
 There are several ways to connect host-based routes to your application

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -68,7 +68,7 @@ class DateTimeConvertor(Convertor):
     regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?"
 
     def convert(self, value: str) -> datetime:
-        return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
 
     def to_string(self, value: datetime) -> str:
         return value.strftime("%Y-%m-%dT%H:%M:%S")

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -59,16 +59,18 @@ If you need a different converter that is not defined, you can create your own.
 See below an example on how to create a `datetime` convertor, and how to register it:
 
 ```python
+from datetime import datetime
+
 from starlette.convertors import Convertor, register_url_convertor
 
 
 class DateTimeConvertor(Convertor):
     regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?"
 
-    def convert(self, value: str) -> dt.datetime:
+    def convert(self, value: str) -> datetime:
         return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
 
-    def to_string(self, value: dt.datetime) -> str:
+    def to_string(self, value: datetime) -> str:
         return value.strftime("%Y-%m-%dT%H:%M:%S")
 
 register_url_convertor("datetime", DateTimeConvertor())

--- a/starlette/convertors.py
+++ b/starlette/convertors.py
@@ -79,3 +79,7 @@ CONVERTOR_TYPES = {
     "float": FloatConvertor(),
     "uuid": UUIDConvertor(),
 }
+
+
+def register_url_convertor(key: str, convertor: Convertor) -> None:
+    CONVERTOR_TYPES[key] = convertor

--- a/tests/test_convertors.py
+++ b/tests/test_convertors.py
@@ -1,4 +1,4 @@
-import datetime as dt
+from datetime import datetime
 
 import pytest
 
@@ -18,8 +18,8 @@ def refresh_convertor_types():
 class DateTimeConvertor(Convertor):
     regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?"
 
-    def convert(self, value: str) -> dt.datetime:
-        return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
+    def convert(self, value: str) -> datetime:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
 
     def to_string(self, value: dt.datetime) -> str:
         return value.strftime("%Y-%m-%dT%H:%M:%S")
@@ -31,7 +31,7 @@ def app() -> Router:
 
     def datetime_convertor(request):
         param = request.path_params["param"]
-        assert isinstance(param, dt.datetime)
+        assert isinstance(param, datetime)
         return JSONResponse({"datetime": param.strftime("%Y-%m-%dT%H:%M:%S")})
 
     return Router(
@@ -51,6 +51,6 @@ def test_datetime_convertor(test_client_factory, app: Router):
     assert response.json() == {"datetime": "2020-01-01T00:00:00"}
 
     assert (
-        app.url_path_for("datetime-convertor", param=dt.datetime(1996, 1, 22, 23, 0, 0))
+        app.url_path_for("datetime-convertor", param=datetime(1996, 1, 22, 23, 0, 0))
         == "/datetime/1996-01-22T23:00:00"
     )

--- a/tests/test_convertors.py
+++ b/tests/test_convertors.py
@@ -1,8 +1,18 @@
 import datetime as dt
 
+import pytest
+
+from starlette import convertors
 from starlette.convertors import Convertor, register_url_convertor
 from starlette.responses import JSONResponse
-from starlette.routing import Router
+from starlette.routing import Route, Router
+
+
+@pytest.fixture(scope="module", autouse=True)
+def refresh_convertor_types():
+    convert_types = convertors.CONVERTOR_TYPES.copy()
+    yield
+    convertors.CONVERTOR_TYPES = convert_types
 
 
 class DateTimeConvertor(Convertor):
@@ -15,59 +25,27 @@ class DateTimeConvertor(Convertor):
         return value.strftime("%Y-%m-%dT%H:%M:%S")
 
 
-register_url_convertor("datetime", DateTimeConvertor())
+@pytest.fixture(scope="function")
+def app() -> Router:
+    register_url_convertor("datetime", DateTimeConvertor())
+
+    def datetime_convertor(request):
+        param = request.path_params["param"]
+        assert isinstance(param, dt.datetime)
+        return JSONResponse({"datetime": param.strftime("%Y-%m-%dT%H:%M:%S")})
+
+    return Router(
+        routes=[
+            Route(
+                "/datetime/{param:datetime}",
+                endpoint=datetime_convertor,
+                name="datetime-convertor",
+            )
+        ]
+    )
 
 
-class DateConvertor(Convertor):
-    regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}"
-
-    def convert(self, value: str) -> dt.date:
-        return dt.datetime.strptime(value, "%Y-%m-%d").date()
-
-    def to_string(self, value: dt.datetime) -> str:
-        return value.strftime("%Y-%m-%d")
-
-
-register_url_convertor("date", DateConvertor())
-
-
-class TimeConvertor(Convertor):
-    regex = "[0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?"
-
-    def convert(self, value: str) -> dt.time:
-        return dt.datetime.strptime(value, "%H:%M:%S").time()
-
-    def to_string(self, value: dt.datetime) -> str:
-        return value.strftime("%H:%M:%S")
-
-
-register_url_convertor("time", TimeConvertor())
-
-app = Router()
-
-
-@app.route("/datetime/{param:datetime}", name="datetime-convertor")
-def datetime_convertor(request):
-    param = request.path_params["param"]
-    assert isinstance(param, dt.datetime)
-    return JSONResponse({"datetime": param.strftime("%Y-%m-%dT%H:%M:%S")})
-
-
-@app.route("/date/{param:date}", name="date-convertor")
-def date_convertor(request):
-    param = request.path_params["param"]
-    assert isinstance(param, dt.date)
-    return JSONResponse({"date": param.strftime("%Y-%m-%d")})
-
-
-@app.route("/time/{param:time}", name="time-convertor")
-def time_convertor(request):
-    param = request.path_params["param"]
-    assert isinstance(param, dt.time)
-    return JSONResponse({"time": param.strftime("%H:%M:%S")})
-
-
-def test_datetime_convertor(test_client_factory):
+def test_datetime_convertor(test_client_factory, app: Router):
     client = test_client_factory(app)
     response = client.get("/datetime/2020-01-01T00:00:00")
     assert response.json() == {"datetime": "2020-01-01T00:00:00"}
@@ -75,25 +53,4 @@ def test_datetime_convertor(test_client_factory):
     assert (
         app.url_path_for("datetime-convertor", param=dt.datetime(1996, 1, 22, 23, 0, 0))
         == "/datetime/1996-01-22T23:00:00"
-    )
-
-
-def test_date_convertor(test_client_factory):
-    client = test_client_factory(app)
-    response = client.get("/date/2020-01-01")
-    assert response.json() == {"date": "2020-01-01"}
-
-    assert (
-        app.url_path_for("date-convertor", param=dt.date(1996, 1, 22))
-        == "/date/1996-01-22"
-    )
-
-
-def test_time_convertor(test_client_factory):
-    client = test_client_factory(app)
-    response = client.get("/time/00:00:00")
-    assert response.json() == {"time": "00:00:00"}
-
-    assert (
-        app.url_path_for("time-convertor", param=dt.time(23, 0, 0)) == "/time/23:00:00"
     )

--- a/tests/test_convertors.py
+++ b/tests/test_convertors.py
@@ -21,7 +21,7 @@ class DateTimeConvertor(Convertor):
     def convert(self, value: str) -> datetime:
         return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
 
-    def to_string(self, value: dt.datetime) -> str:
+    def to_string(self, value: datetime) -> str:
         return value.strftime("%Y-%m-%dT%H:%M:%S")
 
 

--- a/tests/test_convertors.py
+++ b/tests/test_convertors.py
@@ -1,4 +1,4 @@
-import typing
+import datetime as dt
 
 from starlette.convertors import Convertor, register_url_convertor
 from starlette.responses import JSONResponse
@@ -8,10 +8,10 @@ from starlette.routing import Router
 class DateTimeConvertor(Convertor):
     regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?"
 
-    def convert(self, value: str) -> typing.Any:
-        return str(value)
+    def convert(self, value: str) -> dt.datetime:
+        return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
 
-    def to_string(self, value: typing.Any) -> str:
+    def to_string(self, value: dt.datetime) -> str:
         return value.strftime("%Y-%m-%dT%H:%M:%S")
 
 
@@ -21,10 +21,10 @@ register_url_convertor("datetime", DateTimeConvertor())
 class DateConvertor(Convertor):
     regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}"
 
-    def convert(self, value: str) -> typing.Any:
-        return str(value)
+    def convert(self, value: str) -> dt.date:
+        return dt.datetime.strptime(value, "%Y-%m-%d").date()
 
-    def to_string(self, value: typing.Any) -> str:
+    def to_string(self, value: dt.datetime) -> str:
         return value.strftime("%Y-%m-%d")
 
 
@@ -34,10 +34,10 @@ register_url_convertor("date", DateConvertor())
 class TimeConvertor(Convertor):
     regex = "[0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?"
 
-    def convert(self, value: str) -> typing.Any:
-        return str(value)
+    def convert(self, value: str) -> dt.time:
+        return dt.datetime.strptime(value, "%H:%M:%S").time()
 
-    def to_string(self, value: typing.Any) -> str:
+    def to_string(self, value: dt.datetime) -> str:
         return value.strftime("%H:%M:%S")
 
 
@@ -48,20 +48,23 @@ app = Router()
 
 @app.route("/datetime/{param:datetime}", name="datetime-convertor")
 def datetime_convertor(request):
-    dt = request.path_params["param"]
-    return JSONResponse({"datetime": dt})
+    param = request.path_params["param"]
+    assert isinstance(param, dt.datetime)
+    return JSONResponse({"datetime": param.strftime("%Y-%m-%dT%H:%M:%S")})
 
 
 @app.route("/date/{param:date}", name="date-convertor")
 def date_convertor(request):
-    date = request.path_params["param"]
-    return JSONResponse({"date": date})
+    param = request.path_params["param"]
+    assert isinstance(param, dt.date)
+    return JSONResponse({"date": param.strftime("%Y-%m-%d")})
 
 
 @app.route("/time/{param:time}", name="time-convertor")
 def time_convertor(request):
-    time = request.path_params["param"]
-    return JSONResponse({"time": time})
+    param = request.path_params["param"]
+    assert isinstance(param, dt.time)
+    return JSONResponse({"time": param.strftime("%H:%M:%S")})
 
 
 def test_datetime_convertor(test_client_factory):
@@ -69,14 +72,28 @@ def test_datetime_convertor(test_client_factory):
     response = client.get("/datetime/2020-01-01T00:00:00")
     assert response.json() == {"datetime": "2020-01-01T00:00:00"}
 
+    assert (
+        app.url_path_for("datetime-convertor", param=dt.datetime(1996, 1, 22, 23, 0, 0))
+        == "/datetime/1996-01-22T23:00:00"
+    )
+
 
 def test_date_convertor(test_client_factory):
     client = test_client_factory(app)
     response = client.get("/date/2020-01-01")
     assert response.json() == {"date": "2020-01-01"}
 
+    assert (
+        app.url_path_for("date-convertor", param=dt.date(1996, 1, 22))
+        == "/date/1996-01-22"
+    )
+
 
 def test_time_convertor(test_client_factory):
     client = test_client_factory(app)
     response = client.get("/time/00:00:00")
     assert response.json() == {"time": "00:00:00"}
+
+    assert (
+        app.url_path_for("time-convertor", param=dt.time(23, 0, 0)) == "/time/23:00:00"
+    )

--- a/tests/test_convertors.py
+++ b/tests/test_convertors.py
@@ -1,0 +1,82 @@
+import typing
+
+from starlette.convertors import Convertor, register_url_convertor
+from starlette.responses import JSONResponse
+from starlette.routing import Router
+
+
+class DateTimeConvertor(Convertor):
+    regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?"
+
+    def convert(self, value: str) -> typing.Any:
+        return str(value)
+
+    def to_string(self, value: typing.Any) -> str:
+        return value.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+register_url_convertor("datetime", DateTimeConvertor())
+
+
+class DateConvertor(Convertor):
+    regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}"
+
+    def convert(self, value: str) -> typing.Any:
+        return str(value)
+
+    def to_string(self, value: typing.Any) -> str:
+        return value.strftime("%Y-%m-%d")
+
+
+register_url_convertor("date", DateConvertor())
+
+
+class TimeConvertor(Convertor):
+    regex = "[0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?"
+
+    def convert(self, value: str) -> typing.Any:
+        return str(value)
+
+    def to_string(self, value: typing.Any) -> str:
+        return value.strftime("%H:%M:%S")
+
+
+register_url_convertor("time", TimeConvertor())
+
+app = Router()
+
+
+@app.route("/datetime/{param:datetime}", name="datetime-convertor")
+def datetime_convertor(request):
+    dt = request.path_params["param"]
+    return JSONResponse({"datetime": dt})
+
+
+@app.route("/date/{param:date}", name="date-convertor")
+def date_convertor(request):
+    date = request.path_params["param"]
+    return JSONResponse({"date": date})
+
+
+@app.route("/time/{param:time}", name="time-convertor")
+def time_convertor(request):
+    time = request.path_params["param"]
+    return JSONResponse({"time": time})
+
+
+def test_datetime_convertor(test_client_factory):
+    client = test_client_factory(app)
+    response = client.get("/datetime/2020-01-01T00:00:00")
+    assert response.json() == {"datetime": "2020-01-01T00:00:00"}
+
+
+def test_date_convertor(test_client_factory):
+    client = test_client_factory(app)
+    response = client.get("/date/2020-01-01")
+    assert response.json() == {"date": "2020-01-01"}
+
+
+def test_time_convertor(test_client_factory):
+    client = test_client_factory(app)
+    response = client.get("/time/00:00:00")
+    assert response.json() == {"time": "00:00:00"}


### PR DESCRIPTION
## Custom URL Convertor

Currently, we don't have a way to create URL convertors, meaning that our users can only match the default types. Those are:
https://github.com/encode/starlette/blob/2b54f427613ebd1a6ccb2031aa97364e2d5070a5/starlette/convertors.py#L75-L81

To be fair, there's a way: adding a `key, value` pair on the `CONVERTOR_TYPES` dictionary. That's not available on Starlette's public API, or documented.

The idea of this PR is to document and introduce a public API that can be used to create custom URL convertors.

- Closes https://github.com/encode/starlette/issues/231
- Reattempts https://github.com/encode/starlette/pull/458

## How does Django and Flask handle this?

Both of them have a way to register custom URL convertors. You can find the way Django makes it possible [here](https://docs.djangoproject.com/en/4.0/topics/http/urls/#registering-custom-path-converters), and for Flask [here](https://uniwebsidad.com/libros/explore-flask/chapter-6/url-converters).

## Other

Recently, there was a PR to introduce time related convertors on https://github.com/encode/starlette/pull/1398, and I think we should follow the path this PR proposes here, and not creating more convertors on Starlette itself.

## Missing

- [x] docs (Do we want a single page with this, or it should be a section on the Routing page?)