### PR TITLE
Raise exceptions that happened on mounted apps using `BaseHTTPMiddleware`

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -63,10 +63,9 @@ class BaseHTTPMiddleware:
             request = Request(scope, receive=receive)
             response = await self.dispatch_func(request, call_next)
             await response(scope, receive, send)
+            if app_exc is not None:
+                raise app_exc
             task_group.cancel_scope.cancel()
-
-        if app_exc is not None:
-            raise app_exc
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -22,8 +22,9 @@ class BaseHTTPMiddleware:
             await self.app(scope, receive, send)
             return
 
+        app_exc: typing.Optional[Exception] = None
+
         async def call_next(request: Request) -> Response:
-            app_exc: typing.Optional[Exception] = None
             send_stream, recv_stream = anyio.create_memory_object_stream()
 
             async def coro() -> None:
@@ -63,6 +64,9 @@ class BaseHTTPMiddleware:
             response = await self.dispatch_func(request, call_next)
             await response(scope, receive, send)
             task_group.cancel_scope.cancel()
+
+        if app_exc is not None:
+            raise app_exc
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -158,3 +158,13 @@ def test_fully_evaluated_response(test_client_factory):
     client = test_client_factory(app)
     response = client.get("/does_not_exist")
     assert response.text == "Custom"
+
+
+def test_exception_on_mounted_apps(test_client_factory):
+    sub_app = Starlette(routes=[Route("/", exc)])
+    app.mount("/sub", sub_app)
+
+    client = test_client_factory(app)
+    with pytest.raises(Exception) as ctx:
+        client.get("/sub/")
+    assert str(ctx.value) == "Exc"


### PR DESCRIPTION
Closes #1433

The problem here is that the mounted app is able to send `http.response.start` (and the following `http.response.body`), but we check if an exception happened only if there was an `anyio.EndOfStream` i.e. only if messages were not sent.

The solution here just raises the exception at the end of the middleware. 