### PR TITLE
minimize event loop round trips in routing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
     install_requires=[
-        "anyio @ git+https://github.com/adriangb/anyio.git@allow-awaitable-in-to-thread",
+        "anyio>=3.0.0,<4",
         "typing_extensions; python_version < '3.10'",
         "contextlib2 >= 21.6.0; python_version < '3.7'",
     ],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
     install_requires=[
-        "anyio>=3.0.0,<4",
+        "git+https://github.com/adriangb/anyio.git@allow-awaitable-in-to-thread",
         "typing_extensions; python_version < '3.10'",
         "contextlib2 >= 21.6.0; python_version < '3.7'",
     ],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     package_data={"starlette": ["py.typed"]},
     include_package_data=True,
     install_requires=[
-        "git+https://github.com/adriangb/anyio.git@allow-awaitable-in-to-thread",
+        "anyio @ git+https://github.com/adriangb/anyio.git@allow-awaitable-in-to-thread",
         "typing_extensions; python_version < '3.10'",
         "contextlib2 >= 21.6.0; python_version < '3.7'",
     ],

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -88,7 +88,9 @@ def _is_asgi3(app: typing.Union[ASGI2App, ASGI3App]) -> bool:
     elif inspect.isfunction(app):
         return asyncio.iscoroutinefunction(app)
     call = getattr(app, "__call__", None)
-    return asyncio.iscoroutinefunction(call) or typing.get_origin(typing.get_type_hints(call).get("return")) in (collections.Awaitable, typing.Awaitable)
+    return asyncio.iscoroutinefunction(call) or typing.get_origin(
+        typing.get_type_hints(call).get("return")
+    ) in (collections.Awaitable, typing.Awaitable)
 
 
 class _WrapASGI2:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -416,7 +416,7 @@ class TestClient(requests.Session):
         self.async_backend = _AsyncBackend(
             backend=backend, backend_options=backend_options or {}
         )
-        asgi_app = _WrapASGI2(app)  #  type: ignore
+        asgi_app = _WrapASGI2(app)
         adapter = _ASGIAdapter(
             asgi_app,
             portal_factory=self._portal_factory,

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -21,9 +21,9 @@ from starlette.types import Message, Receive, Scope, Send
 from starlette.websockets import WebSocketDisconnect
 
 if sys.version_info >= (3, 8):  # pragma: no cover
-    from typing import TypedDict
+    from typing import TypedDict, get_origin, get_type_hints
 else:  # pragma: no cover
-    from typing_extensions import TypedDict
+    from typing_extensions import TypedDict, get_origin, get_type_hints
 
 
 _PortalFactoryType = typing.Callable[
@@ -88,8 +88,8 @@ def _is_asgi3(app: typing.Union[ASGI2App, ASGI3App]) -> bool:
     elif inspect.isfunction(app):
         return asyncio.iscoroutinefunction(app)
     call = getattr(app, "__call__", None)
-    return asyncio.iscoroutinefunction(call) or typing.get_origin(
-        typing.get_type_hints(call).get("return")
+    return asyncio.iscoroutinefunction(call) or get_origin(
+        get_type_hints(call).get("return")
     ) in (collections.Awaitable, typing.Awaitable)
 
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -87,7 +87,7 @@ def _is_asgi3(app: typing.Union[ASGI2App, ASGI3App]) -> bool:
         return hasattr(app, "__await__")
     elif inspect.isfunction(app):
         return asyncio.iscoroutinefunction(app)
-    call = getattr(app, "__call__", None)
+    call: typing.Any = getattr(app, "__call__", None)
     return asyncio.iscoroutinefunction(call) or get_origin(
         get_type_hints(call).get("return")
     ) in (collections.Awaitable, typing.Awaitable)

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -87,15 +87,14 @@ class _WrapASGI2:
     def __init__(self, app: typing.Union[ASGI2App, ASGI3App]) -> None:
         self.app = app
 
-    def __call__(
-        self, scope: Scope, receive: Receive, send: Send
-    ) -> typing.Awaitable[None]:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         try:
             asgi3app = typing.cast(ASGI3App, self.app)
-            return asgi3app(scope, receive, send)
+            aw = asgi3app(scope, receive, send)
         except TypeError:
             asgi2app = typing.cast(ASGI2App, self.app)
-            return asgi2app(scope)(receive, send)
+            aw = asgi2app(scope)(receive, send)
+        await aw
 
 
 class _AsyncBackend(TypedDict):

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -1,4 +1,5 @@
 import asyncio
+import collections
 import contextlib
 import http
 import inspect
@@ -87,7 +88,7 @@ def _is_asgi3(app: typing.Union[ASGI2App, ASGI3App]) -> bool:
     elif inspect.isfunction(app):
         return asyncio.iscoroutinefunction(app)
     call = getattr(app, "__call__", None)
-    return asyncio.iscoroutinefunction(call)
+    return asyncio.iscoroutinefunction(call) or typing.get_origin(typing.get_type_hints(call).get("return")) in (collections.Awaitable, typing.Awaitable)
 
 
 class _WrapASGI2:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -416,7 +416,6 @@ class TestClient(requests.Session):
         self.async_backend = _AsyncBackend(
             backend=backend, backend_options=backend_options or {}
         )
-        app = typing.cast(ASGI2App, app)
         asgi_app = _WrapASGI2(app)  #  type: ignore
         adapter = _ASGIAdapter(
             asgi_app,


### PR DESCRIPTION
This change minimizes roundtrips to the event loop during routing and by modifying `BaseRoute` allows implementers of the interface more freedom in how the implement functions returning awaitables.

To work this would need https://github.com/agronholm/anyio/pull/416#pullrequestreview-867085900