### PR TITLE
Add-support-for-converter-arguments

### DIFF
--- a/starlette/convertors.py
+++ b/starlette/convertors.py
@@ -8,7 +8,7 @@ T = typing.TypeVar("T")
 class Convertor(typing.Generic[T]):
     regex: typing.ClassVar[str] = ""
 
-    def __init__(self, *args) -> None:
+    def __init__(self, *args: typing.Any) -> None:
         pass
 
     def convert(self, value: str) -> T:
@@ -86,5 +86,5 @@ CONVERTOR_TYPES = {
 }
 
 
-def register_url_convertor(key: str, convertor: Convertor) -> None:
+def register_url_convertor(key: str, convertor: typing.Any) -> None:
     CONVERTOR_TYPES[key] = convertor

--- a/starlette/convertors.py
+++ b/starlette/convertors.py
@@ -8,6 +8,9 @@ T = typing.TypeVar("T")
 class Convertor(typing.Generic[T]):
     regex: typing.ClassVar[str] = ""
 
+    def __init__(self, *args) -> typing.NoReturn:
+        pass
+
     def convert(self, value: str) -> T:
         raise NotImplementedError()  # pragma: no cover
 
@@ -75,11 +78,11 @@ class UUIDConvertor(Convertor):
 
 
 CONVERTOR_TYPES = {
-    "str": StringConvertor(),
-    "path": PathConvertor(),
-    "int": IntegerConvertor(),
-    "float": FloatConvertor(),
-    "uuid": UUIDConvertor(),
+    "str": StringConvertor,
+    "path": PathConvertor,
+    "int": IntegerConvertor,
+    "float": FloatConvertor,
+    "uuid": UUIDConvertor,
 }
 
 

--- a/starlette/convertors.py
+++ b/starlette/convertors.py
@@ -8,7 +8,7 @@ T = typing.TypeVar("T")
 class Convertor(typing.Generic[T]):
     regex: typing.ClassVar[str] = ""
 
-    def __init__(self, *args) -> typing.NoReturn:
+    def __init__(self, *args) -> None:
         pass
 
     def convert(self, value: str) -> T:

--- a/starlette/convertors.py
+++ b/starlette/convertors.py
@@ -6,9 +6,9 @@ T = typing.TypeVar("T")
 
 
 class Convertor(typing.Generic[T]):
-    regex: typing.ClassVar[str] = ""
+    regex: str = ""
 
-    def __init__(self, *args: typing.Any) -> None:
+    def __init__(self, *args: str) -> None:
         pass
 
     def convert(self, value: str) -> T:

--- a/starlette/convertors.py
+++ b/starlette/convertors.py
@@ -9,7 +9,7 @@ class Convertor(typing.Generic[T]):
     regex: str = ""
 
     def __init__(self, *args: str) -> None:
-        pass
+        self.args = args
 
     def convert(self, value: str) -> T:
         raise NotImplementedError()  # pragma: no cover

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -102,7 +102,7 @@ def replace_params(
 # Match parameters in URL paths, eg. '{param}', and '{param:int}'
 PARAM_REGEX = re.compile(
     "{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?"
-    "((?:(?:\\(.*\\))|(?:\\[.*\\]))*)}"
+    "(?:\\((.*?)\\))?}"  # Match any number of characters in parentheses
 )
 
 
@@ -130,7 +130,7 @@ def compile_path(
             convertor_type in CONVERTOR_TYPES
         ), f"Unknown path convertor '{convertor_type}'"
         if args:
-            normalized_args = args.strip("()").split(",")
+            normalized_args = args.split(",")
             convertor = CONVERTOR_TYPES[convertor_type](*normalized_args)
         else:
             convertor = CONVERTOR_TYPES[convertor_type]()

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -129,11 +129,11 @@ def compile_path(
         assert (
             convertor_type in CONVERTOR_TYPES
         ), f"Unknown path convertor '{convertor_type}'"
-        if args:
+        if args:  # pragma: no cover
             # split args by comma except in {}
             normalized_args = re.split(r"\,(?![^\{]*\})", args)
             convertor = CONVERTOR_TYPES[convertor_type](*normalized_args)
-        else:
+        else:  # pragma: no cover
             convertor = CONVERTOR_TYPES[convertor_type]()
         path_regex += re.escape(path[idx : match.start()])
         path_regex += f"(?P<{param_name}>{convertor.regex})"

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -101,7 +101,8 @@ def replace_params(
 
 # Match parameters in URL paths, eg. '{param}', and '{param:int}'
 PARAM_REGEX = re.compile(
-    "{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?((?:(?:\\(.*\\))|(?:\\[.*\\]))*)}"
+    "{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?"
+    "((?:(?:\\(.*\\))|(?:\\[.*\\]))*)}"
 )
 
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -124,16 +124,17 @@ def compile_path(
     idx = 0
     param_convertors = {}
     for match in PARAM_REGEX.finditer(path):
-        param_name, convertor_type, args = match.groups("str")
+        param_name, convertor_type, args = match.groups()
+        convertor_type = convertor_type or "str"
         convertor_type = convertor_type.lstrip(":")
         assert (
             convertor_type in CONVERTOR_TYPES
         ), f"Unknown path convertor '{convertor_type}'"
-        if args:  # pragma: no cover
+        if args:
             # split args by comma except in {}
             normalized_args = re.split(r"\,(?![^\{]*\})", args)
             convertor = CONVERTOR_TYPES[convertor_type](*normalized_args)
-        else:  # pragma: no cover
+        else:
             convertor = CONVERTOR_TYPES[convertor_type]()
         path_regex += re.escape(path[idx : match.start()])
         path_regex += f"(?P<{param_name}>{convertor.regex})"

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -100,7 +100,9 @@ def replace_params(
 
 
 # Match parameters in URL paths, eg. '{param}', and '{param:int}'
-PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?}")
+PARAM_REGEX = re.compile(
+    "{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?((?:(?:\\(.*\\))|(?:\\[.*\\]))*)}"
+)
 
 
 def compile_path(
@@ -121,12 +123,12 @@ def compile_path(
     idx = 0
     param_convertors = {}
     for match in PARAM_REGEX.finditer(path):
-        param_name, convertor_type = match.groups("str")
+        param_name, convertor_type, args = match.groups("str")
         convertor_type = convertor_type.lstrip(":")
         assert (
             convertor_type in CONVERTOR_TYPES
         ), f"Unknown path convertor '{convertor_type}'"
-        convertor = CONVERTOR_TYPES[convertor_type]
+        convertor = CONVERTOR_TYPES[convertor_type](args)
 
         path_regex += re.escape(path[idx : match.start()])
         path_regex += f"(?P<{param_name}>{convertor.regex})"

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -130,7 +130,8 @@ def compile_path(
             convertor_type in CONVERTOR_TYPES
         ), f"Unknown path convertor '{convertor_type}'"
         if args:
-            normalized_args = args.split(",")
+            # split args by comma except in {}
+            normalized_args = re.split(r"\,(?![^\{]*\})", args)
             convertor = CONVERTOR_TYPES[convertor_type](*normalized_args)
         else:
             convertor = CONVERTOR_TYPES[convertor_type]()

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -129,8 +129,11 @@ def compile_path(
         assert (
             convertor_type in CONVERTOR_TYPES
         ), f"Unknown path convertor '{convertor_type}'"
-        convertor = CONVERTOR_TYPES[convertor_type](args)
-
+        if args:
+            normalized_args = args.strip("()").split(",")
+            convertor = CONVERTOR_TYPES[convertor_type](*normalized_args)
+        else:
+            convertor = CONVERTOR_TYPES[convertor_type]()
         path_regex += re.escape(path[idx : match.start()])
         path_regex += f"(?P<{param_name}>{convertor.regex})"
 

--- a/tests/test_convertors.py
+++ b/tests/test_convertors.py
@@ -27,8 +27,8 @@ class DateTimeConvertor(Convertor):
 
 
 class RegexConvertor(Convertor):
-    def __init__(self, *args: typing.Any) -> None:
-        self.__class__.regex = args[0]
+    def __init__(self, *args: str) -> None:
+        self.regex = args[0]
 
     def convert(self, value: str) -> typing.Any:
         return value

--- a/tests/test_convertors.py
+++ b/tests/test_convertors.py
@@ -27,8 +27,8 @@ class DateTimeConvertor(Convertor):
 
 
 class RegexConvertor(Convertor):
-    def __init__(self, *args):
-        self.regex = args[0]
+    def __init__(self, *args: typing.Any) -> None:
+        self.__class__.regex = args[0]
 
     def convert(self, value: str) -> typing.Any:
         return value

--- a/tests/test_convertors.py
+++ b/tests/test_convertors.py
@@ -87,3 +87,9 @@ def test_regex_convertor(test_client_factory, app: Router):
         app.url_path_for("regex-convertor", param="123-456-7890")
         == "/regex/123-456-7890"
     )
+
+
+def test_regex_convertor_fail(test_client_factory, app: Router):
+    client = test_client_factory(app)
+    response = client.get("/regex/123-456-7890-")
+    assert response.status_code == 404

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -5,7 +5,15 @@ import pytest
 
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse, PlainTextResponse, Response
-from starlette.routing import Host, Mount, NoMatchFound, Route, Router, WebSocketRoute
+from starlette.routing import (
+    Host,
+    Mount,
+    NoMatchFound,
+    Route,
+    Router,
+    WebSocketRoute,
+    compile_path,
+)
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
 
@@ -700,3 +708,13 @@ def test_duplicated_param_names():
         match="Duplicated param names id, name at path /{id}/{name}/{id}/{name}",
     ):
         Route("/{id}/{name}/{id}/{name}", user)
+
+
+def test_compile_path_with_arguments():
+    _, _, param_convertors = compile_path("/{foo:str([0-1]{2},[2-3]{3})}")
+    assert param_convertors["foo"].args == ("[0-1]{2}", "[2-3]{3}")
+
+
+def test_compile_path_without_arguments():
+    _, _, param_convertors = compile_path("/{foo:str}")
+    assert param_convertors["foo"].args == ()


### PR DESCRIPTION
Add support for converter arguments which will be used to allow regex patterns for route path as requested here #1101 
### How does Django and Flask handle this?
Flask do the same thing here as described here https://werkzeug.palletsprojects.com/en/2.0.x/routing/#rule-format 

### How adding support for converter arguments related to allow regex patterns for route path ?
By simply create a regex converter which will takes the first argument as our new regex as declared in test_converters and also here https://stackoverflow.com/a/5872904/10799351