### PR TITLE
support non-coroutine asgi apps in TestClient

### DIFF
--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -233,6 +233,25 @@ def test_testclient_endpoint_class(test_client_factory):
     assert response.text == "Hello, world!"
 
 
+def test_testclient_coro_closure(test_client_factory):
+    async def inner_app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", b"text/plain"]],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"Hello, world!"})
+    
+    def outer_app(scope, receive, send):
+        return inner_app(scope, receive, send)
+
+    client = test_client_factory(outer_app)
+    response = client.get("/")
+    assert response.text == "Hello, world!"
+
+
 def test_websocket_blocking_receive(test_client_factory):
     def app(scope):
         async def respond(websocket):

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -243,7 +243,7 @@ def test_testclient_coro_closure(test_client_factory):
             }
         )
         await send({"type": "http.response.body", "body": b"Hello, world!"})
-    
+
     def outer_app(scope, receive, send):
         return inner_app(scope, receive, send)
 


### PR DESCRIPTION
This adds support for testing ASGI apps like `starlette.endpoints.HTTPEndpoint` via TestClient

This is a piece of #1453 