### PR TITLE
Prevent BaseHTTPMiddleware from hiding errors of StreamingResponse

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -47,8 +47,6 @@ class BaseHTTPMiddleware:
             assert message["type"] == "http.response.start"
 
             async def body_stream() -> typing.AsyncGenerator[bytes, None]:
-                nonlocal app_exc
-
                 async with recv_stream:
                     async for message in recv_stream:
                         assert message["type"] == "http.response.body"

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -47,10 +47,15 @@ class BaseHTTPMiddleware:
             assert message["type"] == "http.response.start"
 
             async def body_stream() -> typing.AsyncGenerator[bytes, None]:
+                nonlocal app_exc
+
                 async with recv_stream:
                     async for message in recv_stream:
                         assert message["type"] == "http.response.body"
                         yield message.get("body", b"")
+
+                if app_exc is not None:
+                    raise app_exc
 
             response = StreamingResponse(
                 status_code=message["status"], content=body_stream()

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -173,6 +173,7 @@ def test_fully_evaluated_response(test_client_factory):
     response = client.get("/does_not_exist")
     assert response.text == "Custom"
 
+
 def test_exception_on_mounted_apps(test_client_factory):
     sub_app = Starlette(routes=[Route("/", exc)])
     app.mount("/sub", sub_app)

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -3,7 +3,7 @@ import pytest
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import PlainTextResponse
+from starlette.responses import PlainTextResponse, StreamingResponse
 from starlette.routing import Route
 
 
@@ -26,6 +26,16 @@ def homepage(request):
 @app.route("/exc")
 def exc(request):
     raise Exception("Exc")
+
+
+@app.route("/exc-stream")
+def exc_stream(request):
+    return StreamingResponse(_generate_faulty_stream())
+
+
+def _generate_faulty_stream():
+    yield b"Ok"
+    raise Exception("Faulty Stream")
 
 
 @app.route("/no-response")
@@ -55,6 +65,10 @@ def test_custom_middleware(test_client_factory):
     with pytest.raises(Exception) as ctx:
         response = client.get("/exc")
     assert str(ctx.value) == "Exc"
+
+    with pytest.raises(Exception) as ctx:
+        response = client.get("/exc-stream")
+    assert str(ctx.value) == "Faulty Stream"
 
     with pytest.raises(RuntimeError):
         response = client.get("/no-response")

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -172,3 +172,12 @@ def test_fully_evaluated_response(test_client_factory):
     client = test_client_factory(app)
     response = client.get("/does_not_exist")
     assert response.text == "Custom"
+
+def test_exception_on_mounted_apps(test_client_factory):
+    sub_app = Starlette(routes=[Route("/", exc)])
+    app.mount("/sub", sub_app)
+
+    client = test_client_factory(app)
+    with pytest.raises(Exception) as ctx:
+        client.get("/sub/")
+    assert str(ctx.value) == "Exc"


### PR DESCRIPTION
The issue is observed when:

*  an application uses a BaseHTTPMiddleware subclass;
*  it provides StreamingResponse;
*  there is an exception raised inside the generator wrapped with StreamingResponse.

Prior to v0.17.0 the exception was raised and the traceback was printed to the server logs. Now it is silently ignored.

Edit by @Kludex : Closes #1433