### PR TITLE
Make router decorators gentle towards types

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -11,6 +11,9 @@ from starlette.routing import BaseRoute, Router
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 
+_C = typing.TypeVar("_C", bound=typing.Callable)
+
+
 class Starlette:
     """
     Creates an application instance.
@@ -163,8 +166,8 @@ class Starlette:
 
     def exception_handler(
         self, exc_class_or_status_code: typing.Union[int, typing.Type[Exception]]
-    ) -> typing.Callable:
-        def decorator(func: typing.Callable) -> typing.Callable:
+    ) -> typing.Callable[[_C], _C]:
+        def decorator(func: _C) -> _C:
             self.add_exception_handler(exc_class_or_status_code, func)
             return func
 
@@ -176,8 +179,8 @@ class Starlette:
         methods: typing.List[str] = None,
         name: str = None,
         include_in_schema: bool = True,
-    ) -> typing.Callable:
-        def decorator(func: typing.Callable) -> typing.Callable:
+    ) -> typing.Callable[[_C], _C]:
+        def decorator(func: _C) -> _C:
             self.router.add_route(
                 path,
                 func,
@@ -189,19 +192,19 @@ class Starlette:
 
         return decorator
 
-    def websocket_route(self, path: str, name: str = None) -> typing.Callable:
-        def decorator(func: typing.Callable) -> typing.Callable:
+    def websocket_route(self, path: str, name: str = None) -> typing.Callable[[_C], _C]:
+        def decorator(func: _C) -> _C:
             self.router.add_websocket_route(path, func, name=name)
             return func
 
         return decorator
 
-    def middleware(self, middleware_type: str) -> typing.Callable:
+    def middleware(self, middleware_type: str) -> typing.Callable[[_C], _C]:
         assert (
             middleware_type == "http"
         ), 'Currently only middleware("http") is supported.'
 
-        def decorator(func: typing.Callable) -> typing.Callable:
+        def decorator(func: _C) -> _C:
             self.add_middleware(BaseHTTPMiddleware, dispatch=func)
             return func
 

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -10,7 +10,6 @@ from starlette.responses import Response
 from starlette.routing import BaseRoute, Router
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-
 _C = typing.TypeVar("_C", bound=typing.Callable)
 
 


### PR DESCRIPTION
What does this do? These decorators currently destroy the signatures of the functions they're applied to. We remedy this by using a typevar, which makes the signature of the decorators say the equivalent of "I take any callable, and I will return the exact type that I'm given".

With this example:

```python
from starlette.applications import Starlette
from starlette.requests import Request
from starlette.responses import Response

app = Starlette()


@app.route("/")
def handle_request(request: Request) -> Response:
    return Response()

reveal_type(handle_request)
```

The current behavior is:

```
demo.py:12: note: Revealed type is "Any"
```

But with this PR applied:

```
demo.py:12: note: Revealed type is "def (request: starlette.requests.Request) -> starlette.responses.Response"
```