### PR TITLE
Require typing-extensions>=3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "anyio>=3.4.0,<4",
-        "typing_extensions; python_version < '3.10'",
+        "typing_extensions>=3.10.0; python_version < '3.10'",
         "contextlib2 >= 21.6.0; python_version < '3.7'",
     ],
     extras_require={


### PR DESCRIPTION
Fixes https://github.com/encode/starlette/issues/1474

I manually verified that tests pass with `typing-extensions==3.10.0`. If we wanted to be really rigorous we could add a build to CI that specifically installs 3.10.0, in order to detect if any code is added that requires `typing-extensions>3.10` in the future. But I thought that might be overkill in this case.