### PR TITLE
Remove routing decorators in `test_trusted_hosts.py`

### DIFF
--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -1,18 +1,22 @@
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import PlainTextResponse
+from starlette.routing import Route
 
 
 def test_trusted_host_middleware(test_client_factory):
-    app = Starlette()
-
-    app.add_middleware(
-        TrustedHostMiddleware, allowed_hosts=["testserver", "*.testserver"]
-    )
-
-    @app.route("/")
     def homepage(request):
         return PlainTextResponse("OK", status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[
+            Middleware(
+                TrustedHostMiddleware, allowed_hosts=["testserver", "*.testserver"]
+            )
+        ],
+    )
 
     client = test_client_factory(app)
     response = client.get("/")
@@ -34,13 +38,15 @@ def test_default_allowed_hosts():
 
 
 def test_www_redirect(test_client_factory):
-    app = Starlette()
-
-    app.add_middleware(TrustedHostMiddleware, allowed_hosts=["www.example.com"])
-
-    @app.route("/")
     def homepage(request):
         return PlainTextResponse("OK", status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[
+            Middleware(TrustedHostMiddleware, allowed_hosts=["www.example.com"])
+        ],
+    )
 
     client = test_client_factory(app, base_url="https://example.com")
     response = client.get("/")


### PR DESCRIPTION
Subset of #1481 drops usage of routing decorators.