### PR TITLE
Override Request.__new__ to always return the same instance

### DIFF
--- a/starlette/_asgi_extension.py
+++ b/starlette/_asgi_extension.py
@@ -1,0 +1,18 @@
+import typing
+
+from starlette.types import Scope
+
+
+def get_extension_from_scope(scope: Scope) -> typing.Dict[str, typing.Any]:
+    extensions = scope["extensions"] = scope.get("extensions", None) or {}
+    extension = extensions["starlette"] = (
+        scope["extensions"].get("starlette", None) or {}
+    )
+    return extension
+
+
+def get_from_extension(scope: Scope, key: str, default: typing.Any) -> typing.Any:
+    starlette_extension_scope = get_extension_from_scope(scope)
+    if key in starlette_extension_scope:
+        return starlette_extension_scope[key]
+    return default

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -207,7 +207,6 @@ class Request(HTTPConnection):
         instance = get_extension_from_scope(scope)["connection"] = object.__new__(
             Request
         )
-        instance.__init__(scope, receive, send)
         return instance
 
     @property

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -331,13 +331,8 @@ def test_websocket_scope_interface():
         send=mock_send,
     )
     assert websocket["type"] == "websocket"
-    assert dict(websocket) == {
-        "type": "websocket",
-        "path": "/abc/",
-        "headers": [],
-        "extensions": {"starlette": {"connection": websocket}},
-    }
-    assert len(websocket) == 4
+    assert dict(websocket) == {"type": "websocket", "path": "/abc/", "headers": []}
+    assert len(websocket) == 3
 
     # check __eq__ and __hash__
     assert websocket != WebSocket(

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -331,8 +331,13 @@ def test_websocket_scope_interface():
         send=mock_send,
     )
     assert websocket["type"] == "websocket"
-    assert dict(websocket) == {"type": "websocket", "path": "/abc/", "headers": []}
-    assert len(websocket) == 3
+    assert dict(websocket) == {
+        "type": "websocket",
+        "path": "/abc/",
+        "headers": [],
+        "extensions": {"starlette": {"connection": websocket}},
+    }
+    assert len(websocket) == 4
 
     # check __eq__ and __hash__
     assert websocket != WebSocket(


### PR DESCRIPTION
Exploring alternatives to #1479.

I also tried:

```python
class Request:
    @staticmethod
    def from_asgi(scope: Scope, ...) -> Request:
        ...
```

Which is the same as this except then you have to say "you should always construct Request by calling Request.from_asgi " which sounds an awful lot like trying to re-invent __new__.

Aside from the API differences, the main difference between this and #1497 is that #1497 shares __dict__, which means that:

```python
conn = HTTPConnection(...)
req = Request(...)
assert req.query_params is conn.query_params  # same instance
```

In practice, this means that if a middleware or something creates an `HTTPConnection` to look at headers (perhaps so that it is agnostic of websockets / requests) the framework saves the overhead of parsing query/path/headers multiple times since it will be shared amongst all instances of all subclasses of `HTTPConnection`.