### PR TITLE
SessionMiddleware uses an explicit path=..., instead of defaulting to the ASGI 'root_path'.

### DIFF
--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -17,6 +17,7 @@ class SessionMiddleware:
         secret_key: typing.Union[str, Secret],
         session_cookie: str = "session",
         max_age: typing.Optional[int] = 14 * 24 * 60 * 60,  # 14 days, in seconds
+        path: str = "/",
         same_site: str = "lax",
         https_only: bool = False,
     ) -> None:
@@ -24,6 +25,7 @@ class SessionMiddleware:
         self.signer = itsdangerous.TimestampSigner(str(secret_key))
         self.session_cookie = session_cookie
         self.max_age = max_age
+        self.path = path
         self.security_flags = "httponly; samesite=" + same_site
         if https_only:  # Secure flag can be used with HTTPS only
             self.security_flags += "; secure"
@@ -49,7 +51,6 @@ class SessionMiddleware:
 
         async def send_wrapper(message: Message) -> None:
             if message["type"] == "http.response.start":
-                path = scope.get("root_path", "") or "/"
                 if scope["session"]:
                     # We have session data to persist.
                     data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
@@ -58,7 +59,7 @@ class SessionMiddleware:
                     header_value = "{session_cookie}={data}; path={path}; {max_age}{security_flags}".format(  # noqa E501
                         session_cookie=self.session_cookie,
                         data=data.decode("utf-8"),
-                        path=path,
+                        path=self.path,
                         max_age=f"Max-Age={self.max_age}; " if self.max_age else "",
                         security_flags=self.security_flags,
                     )
@@ -66,10 +67,12 @@ class SessionMiddleware:
                 elif not initial_session_was_empty:
                     # The session has been cleared.
                     headers = MutableHeaders(scope=message)
-                    header_value = "{}={}; {}".format(
-                        self.session_cookie,
-                        f"null; path={path}; expires=Thu, 01 Jan 1970 00:00:00 GMT;",
-                        self.security_flags,
+                    header_value = "{session_cookie}={data}; path={path}; {expires}{security_flags}".format(  # noqa E501
+                        session_cookie=self.session_cookie,
+                        data="null",
+                        path=self.path,
+                        expires="expires=Thu, 01 Jan 1970 00:00:00 GMT; ",
+                        security_flags=self.security_flags,
                     )
                     headers.append("Set-Cookie", header_value)
             await send(message)

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -122,7 +122,9 @@ def test_session_cookie_subpath(test_client_factory):
         routes=[
             Route("/update_session", endpoint=update_session, methods=["POST"]),
         ],
-        middleware=[Middleware(SessionMiddleware, secret_key="example")],
+        middleware=[
+            Middleware(SessionMiddleware, secret_key="example", path="/second_app")
+        ],
     )
     app = Starlette(routes=[Mount("/second_app", app=second_app)])
     client = test_client_factory(app, base_url="http://testserver/second_app")


### PR DESCRIPTION
Closes https://github.com/encode/starlette/issues/1261

This pull request reverts https://github.com/encode/starlette/pull/1147.

I'd obviously made the wrong call on that.

The intent was "okay, let's limit the path against which session cookies are applied. Our server might be submounted to a given path, and we shouldn't cookie to / in that case." - Which is reasonable enough idea if it only applied to where the main app was mounted, but as it happens actually just breaks all sorts of cases for us. Because we allow for submounted apps too.

Instead we support a configurable path="/" on SessionMiddleware. This doesn't magically pick up any root path that the server might be mounted to, but *does* allow users to configure the path if they need too.

Also refs https://github.com/encode/starlette/issues/233, #1351.

Prompted by [this discussion](https://github.com/encode/starlette/discussions/1511#discussioncomment-2172604).
