### PR TITLE
Mark type for optional parameter as `Optional`.

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -13,7 +13,9 @@ DispatchFunction = typing.Callable[
 
 
 class BaseHTTPMiddleware:
-    def __init__(self, app: ASGIApp, dispatch: DispatchFunction = None) -> None:
+    def __init__(
+        self, app: ASGIApp, dispatch: typing.Optional[DispatchFunction] = None
+    ) -> None:
         self.app = app
         self.dispatch_func = self.dispatch if dispatch is None else dispatch
 


### PR DESCRIPTION
This makes it compatible with strict type checking for subclasses.