### PR TITLE
Add apiman to third-party-packages document 

### DIFF
--- a/docs/third-party-packages.md
+++ b/docs/third-party-packages.md
@@ -168,3 +168,9 @@ A flexible and extendable web framework built on top of Starlette, Pydantic and 
 
 <a href="https://github.com/adriangb/xpresso" target="_blank">GitHub</a> |
 <a href=https://xpresso-api.dev/" target="_blank">Documentation</a>
+
+### Apiman
+
+A extension to integrate Swagger/OpenAPI document easily for starlette project and provide [SwaggerUI](http://swagger.io/swagger-ui/) and [RedocUI](https://rebilly.github.io/ReDoc/).
+
+<a href="https://github.com/strongbugman/apiman" target="_blank">GitHub</a>

--- a/docs/third-party-packages.md
+++ b/docs/third-party-packages.md
@@ -171,6 +171,6 @@ A flexible and extendable web framework built on top of Starlette, Pydantic and 
 
 ### Apiman
 
-A extension to integrate Swagger/OpenAPI document easily for starlette project and provide [SwaggerUI](http://swagger.io/swagger-ui/) and [RedocUI](https://rebilly.github.io/ReDoc/).
+An extension to integrate Swagger/OpenAPI document easily for Starlette project and provide [SwaggerUI](http://swagger.io/swagger-ui/) and [RedocUI](https://rebilly.github.io/ReDoc/).
 
 <a href="https://github.com/strongbugman/apiman" target="_blank">GitHub</a>


### PR DESCRIPTION
# Just add third-party-packages

Apiman is a extension to integrate Swagger/OpenAPI document easily for starlette project and provide [SwaggerUI](http://swagger.io/swagger-ui/) and [RedocUI](https://rebilly.github.io/ReDoc/).

It worked great for my daily work, hope it can help other people.