### PR TITLE
Add custom exception to handle missing boundary error

### DIFF
--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -9,7 +9,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 class MissingBoundaryException(Exception):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("Form data is missing boundary parameter")
 
 

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -8,6 +8,11 @@ from starlette.responses import PlainTextResponse, Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
+class MissingBoundaryException(Exception):
+    def __init__(self):
+        super().__init__("Form data is missing boundary parameter")
+
+
 class HTTPException(Exception):
     def __init__(
         self, status_code: int, detail: str = None, headers: dict = None

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -154,12 +154,17 @@ class MultiPartParser:
         self.messages.append(message)
 
     async def parse(self) -> FormData:
+        from starlette.exceptions import MissingBoundaryException
+
         # Parse the Content-Type header to get the multipart boundary.
         content_type, params = parse_options_header(self.headers["Content-Type"])
         charset = params.get(b"charset", "utf-8")
         if type(charset) == bytes:
             charset = charset.decode("latin-1")
-        boundary = params[b"boundary"]
+        try:
+            boundary = params[b"boundary"]
+        except KeyError:
+            raise MissingBoundaryException
 
         # Callbacks dictionary.
         callbacks = {

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -3,6 +3,7 @@ import typing
 
 import pytest
 
+from starlette.exceptions import MissingBoundaryException
 from starlette.formparsers import UploadFile, _user_safe_decode
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -392,7 +393,7 @@ def test_user_safe_decode_ignores_wrong_charset():
 
 def test_missing_boundary_parameter(test_client_factory):
     client = test_client_factory(app)
-    with pytest.raises(KeyError, match="boundary"):
+    with pytest.raises(MissingBoundaryException):
         client.post(
             "/",
             data=(


### PR DESCRIPTION
Closes #1542

## Outline
As per [#1542](https://github.com/encode/starlette/issues/1542), I've added a custom exception (`MissingBoundaryException`) to handle boundary parameter related error

## Background
When form data is missing boundary parameter, the following line causes the KeyError
https://github.com/encode/starlette/blob/master/starlette/formparsers.py#L162

In the following discussion, it has been decided to use custom exception instead of using KeyError directly
https://github.com/encode/starlette/pull/1349#issuecomment-1028902007

I've added a custom exception (`MissingBoundaryException`) in this PR for that
