### PR TITLE
Ignore mypy issue on `jinja2.contextfunction` function 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pytest==7.0.1
 trio==0.19.0
 
 # Documentation
-mkdocs==1.2.3
+mkdocs==1.2.4
 mkdocs-material==8.1.3
 mkautodoc==0.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # Optionals
 -e .[full]
 
+# temporary pin until mkdocs release
+jinja2==3.0.3
+
 # Testing
 autoflake==1.4
 black==22.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 # Optionals
 -e .[full]
 
-# temporary pin until mkdocs release
-jinja2==3.0.3
-
 # Testing
 autoflake==1.4
 black==22.1.0

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -12,7 +12,7 @@ try:
     if hasattr(jinja2, "pass_context"):
         pass_context = jinja2.pass_context
     else:  # pragma: nocover
-        pass_context = jinja2.contextfunction
+        pass_context = jinja2.contextfunction  # type: ignore[attr-defined]
 except ImportError:  # pragma: nocover
     jinja2 = None  # type: ignore
 


### PR DESCRIPTION
`jinja2` released a [new version](https://jinja.palletsprojects.com/en/3.1.x/changes/), and as a consequence our pipeline broke.

EDIT: we need to pin `jinja2` on our pipeline because `mkdocs` doesn't work with the latest `jinja2`.