### PR TITLE
Bump black to 22.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Testing
 autoflake==1.4
-black==22.1.0
+black==22.3.0
 coverage==6.2
 databases[sqlite]==0.5.5
 flake8==4.0.1


### PR DESCRIPTION
Same as https://github.com/encode/httpx/pull/2153

This PR fixes the pipeline due to `black`/`click` issue.