### PR TITLE
Downgrade flake8 from 4.0.1 to 3.9.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ autoflake==1.4
 black==22.3.0
 coverage==6.2
 databases[sqlite]==0.5.5
-flake8==4.0.1
+flake8==3.9.2
 isort==5.10.1
 mypy==0.942
 types-requests==2.26.3


### PR DESCRIPTION
Flake8 is preventing all the other packages to upgrade, due to:

```
The conflict is caused by:
    flake8 4.0.1 depends on importlib-metadata<4.3; python_version < "3.8"
    pytest 7.0.1 depends on importlib-metadata>=0.12; python_version < "3.8"
    mkdocs 1.3.0 depends on importlib-metadata>=4.3

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```

I suggest to downgrade it, and give preference to the other packages.