### PR TITLE
GZIP content length mismatch fix

### DIFF
--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -26,7 +26,7 @@ class GZipMiddleware:
         await self.app(scope, receive, send)
 
 
-class GZipResponder:  # noqa: WPS230
+class GZipResponder:
     def __init__(self, app: ASGIApp, minimum_size: int, compresslevel: int = 9) -> None:
         self.app = app
         self.minimum_size = minimum_size
@@ -35,7 +35,8 @@ class GZipResponder:  # noqa: WPS230
         self.started = False
         self.gzip_buffer = io.BytesIO()
         self.gzip_file = gzip.GzipFile(
-            mode="wb", fileobj=self.gzip_buffer, compresslevel=compresslevel)
+            mode="wb", fileobj=self.gzip_buffer, compresslevel=compresslevel
+        )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         self.send = send
@@ -55,7 +56,7 @@ class GZipResponder:  # noqa: WPS230
                 # Don't apply GZip to small outgoing responses.
                 await self.send(self.initial_message)
                 await self.send(message)
-            elif not more_body:  # noqa: WPS504
+            elif not more_body:
                 # Standard GZip response.
                 body = self._set_response_body(body, more_body)
 
@@ -72,7 +73,7 @@ class GZipResponder:  # noqa: WPS230
                 headers = MutableHeaders(raw=self.initial_message["headers"])
                 headers["Content-Encoding"] = "gzip"
                 headers.add_vary_header("Accept-Encoding")
-                del headers["Content-Length"]  # noqa: WPS420
+                del headers["Content-Length"]
 
                 message["body"] = self._set_response_body(body, more_body)
                 await self.send(self.initial_message)


### PR DESCRIPTION
This addresses concerns raised by the following discussions:
 - [Gzip Middleware content-length is incorrect #803](https://github.com/encode/starlette/issues/803)
 - [GZip Middleware Throws "Response content longer than Content-Length" when given a 304 empty-body response #4050](https://github.com/tiangolo/fastapi/issues/4050)
 - [Gzip middleware randomly raise RuntimeError but does not affect use , what are the possible causes?](https://github.com/tiangolo/fastapi/issues/2818)

We encountered this problem when developing our internal application, when we implemented both Brotli and GZIP compression. We tested the following fix using several use cases.

The solution tries to address the problem using two(2) approaches:
- Setting the respond body if NULL bytes are detected
- Not writing the message body when its empty or contains NULL byte char

- [x] Initially raised as discussion #803
