### PR TITLE
Add verbose return type hint to HTTPConnection.json method

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -236,7 +236,7 @@ class Request(HTTPConnection):
             self._body = b"".join(chunks)
         return self._body
 
-    async def json(self) -> typing.Any:
+    async def json(self) -> typing.Dict[str, typing.Any]:
         if not hasattr(self, "_json"):
             body = await self.body()
             self._json = json.loads(body)


### PR DESCRIPTION
The original return type hint here, `typing.Any`, is too vague. A more accurate and specific type hint can be added. Using `typing.Dict[str, typing.Any]` is more clear as this response should always be JSON, therefore `typing.Any` is misleading.

Initially raised as discussion #1596 