### PR TITLE
Remove compat code for Python <= 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import os
 import re

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -3,11 +3,11 @@ import contextlib
 import functools
 import inspect
 import re
-import sys
 import traceback
 import types
 import typing
 import warnings
+from contextlib import asynccontextmanager
 from enum import Enum
 
 from starlette.concurrency import run_in_threadpool
@@ -18,11 +18,6 @@ from starlette.requests import Request
 from starlette.responses import PlainTextResponse, RedirectResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketClose
-
-if sys.version_info >= (3, 7):
-    from contextlib import asynccontextmanager  # pragma: no cover
-else:
-    from contextlib2 import asynccontextmanager  # pragma: no cover
 
 
 class NoMatchFound(Exception):

--- a/starlette/status.py
+++ b/starlette/status.py
@@ -5,7 +5,6 @@ https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 
 And RFC 2324 - https://tools.ietf.org/html/rfc2324
 """
-import sys
 import warnings
 from typing import List
 
@@ -187,11 +186,10 @@ def __getattr__(name: str) -> int:
     }
     deprecated = __deprecated__.get(name)
     if deprecated:
-        stacklevel = 3 if sys.version_info >= (3, 7) else 4
         warnings.warn(
             f"'{name}' is deprecated. Use '{deprecation_changes[name]}' instead.",
             category=DeprecationWarning,
-            stacklevel=stacklevel,
+            stacklevel=3,
         )
         return deprecated
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -1,5 +1,5 @@
 import os
-import sys
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -11,11 +11,6 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.routing import Host, Mount, Route, Router, WebSocketRoute
 from starlette.staticfiles import StaticFiles
-
-if sys.version_info >= (3, 7):
-    from contextlib import asynccontextmanager  # pragma: no cover
-else:
-    from contextlib2 import asynccontextmanager  # pragma: no cover
 
 
 async def error_500(request, exc):

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -1,6 +1,6 @@
-import asyncio
 import itertools
-import sys
+from asyncio import current_task as asyncio_current_task
+from contextlib import asynccontextmanager
 
 import anyio
 import pytest
@@ -12,13 +12,6 @@ from starlette.middleware import Middleware
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 from starlette.websockets import WebSocket, WebSocketDisconnect
-
-if sys.version_info >= (3, 7):  # pragma: no cover
-    from asyncio import current_task as asyncio_current_task
-    from contextlib import asynccontextmanager
-else:  # pragma: no cover
-    asyncio_current_task = asyncio.Task.current_task
-    from contextlib2 import asynccontextmanager
 
 
 def mock_service_endpoint(request):


### PR DESCRIPTION
The starting point for contributions should usually be [a discussion](https://github.com/encode/httpx/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise please ensure you've discussed your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes have been okayed by the maintainers.

- [x] Initially raised as discussion in https://gitter.im/encode/community

Some cleanup after dropping support for EOL Python 3.6 in https://github.com/encode/starlette/pull/1357.
