### PR TITLE
Skip test when brotli is installed

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional
 
 import anyio
@@ -36,6 +37,10 @@ def test_request_query_params(test_client_factory):
     assert response.json() == {"params": {"a": "123", "b": "456"}}
 
 
+@pytest.mark.skipif(
+    any(module in sys.modules for module in ("brotli", "brotlicffi")),
+    reason="When brotli is installed urllib3 includes it to the headers.",
+)
 def test_request_headers(test_client_factory):
     async def app(scope, receive, send):
         request = Request(scope, receive)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -39,7 +39,7 @@ def test_request_query_params(test_client_factory):
 
 @pytest.mark.skipif(
     any(module in sys.modules for module in ("brotli", "brotlicffi")),
-    reason="When brotli is installed urllib3 includes it to the headers.",
+    reason='urllib3 includes "br" to the "accept-encoding" headers.',
 )
 def test_request_headers(test_client_factory):
     async def app(scope, receive, send):

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -52,7 +52,7 @@ def test_websocket_query_params(test_client_factory):
 
 @pytest.mark.skipif(
     any(module in sys.modules for module in ("brotli", "brotlicffi")),
-    reason="When brotli is installed urllib3 includes it to the headers.",
+    reason='urllib3 includes "br" to the "accept-encoding" headers.',
 )
 def test_websocket_headers(test_client_factory):
     async def app(scope: Scope, receive: Receive, send: Send) -> None:

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,3 +1,5 @@
+import sys
+
 import anyio
 import pytest
 
@@ -48,6 +50,10 @@ def test_websocket_query_params(test_client_factory):
         assert data == {"params": {"a": "abc", "b": "456"}}
 
 
+@pytest.mark.skipif(
+    any(module in sys.modules for module in ("brotli", "brotlicffi")),
+    reason="When brotli is installed urllib3 includes it to the headers.",
+)
 def test_websocket_headers(test_client_factory):
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         websocket = WebSocket(scope, receive=receive, send=send)


### PR DESCRIPTION
- Closes #1619

cc @mgorny

Alternative:
- Add `br` to "accept-encoding" in the test if Brotli is installed.