### PR TITLE
Allow cross-origin requests by path regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv*/
 .python-version
 build/
 dist/
+.idea

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -69,6 +69,7 @@ The following arguments are supported:
 
 * `allow_origins` - A list of origins that should be permitted to make cross-origin requests. eg. `['https://example.org', 'https://www.example.org']`. You can use `['*']` to allow any origin.
 * `allow_origin_regex` - A regex string to match against origins that should be permitted to make cross-origin requests. eg. `'https://.*\.example\.org'`.
+* `allow_path_regex` - A regex string to match against path that should be permitted to make cross-origin requests. eg `"(.*)\\/docs\\/[a-f0-9]{32}$"`
 * `allow_methods` - A list of HTTP methods that should be allowed for cross-origin requests. Defaults to `['GET']`. You can use `['*']` to allow all standard methods.
 * `allow_headers` - A list of HTTP request headers that should be supported for cross-origin requests. Defaults to `[]`. You can use `['*']` to allow all headers. The `Accept`, `Accept-Language`, `Content-Language` and `Content-Type` headers are always allowed for CORS requests.
 * `allow_credentials` - Indicate that cookies should be supported for cross-origin requests. Defaults to `False`.

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -543,6 +543,6 @@ def test_cors_allowed_by_path_regex(test_client_factory):
     assert response.text == "Document"
 
     # Test pre-flight response
-    headers = {"Origin": "https://another.com"}
+    headers = {"Origin": "https://another.com", "Access-Control-Request-Method": "GET"}
     response = client.options(path, headers=headers)
     assert response.status_code == 200


### PR DESCRIPTION
### Issue
- Could not be able to allow cross-origin requests based on a path pattern, no matter where's the origin domain.

### Updated
- Added `allow_path_regex` param, CORSmiddleware will allow past the check on paths that match with defined param.
- Updated the docs for the new param.
- Add test case.