### PR TITLE
Document `status_code` parameter on `requires` when using WebSockets

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -115,6 +115,10 @@ async def dashboard(request):
     ...
 ```
 
+!!! note
+    The `status_code` parameter is not supported with WebSockets. The 403 (Forbidden)
+    status code will always be used for those.
+
 Alternatively you might want to redirect unauthenticated users to a different
 page.
 


### PR DESCRIPTION
Without implementing the [WebSocket Denial Response](https://asgi.readthedocs.io/en/latest/extensions.html#websocket-denial-response) the application will not have control of which status code should be sent. The server takes care of it - and it returns 403 by default. 

- Closes #1362