### PR TITLE
Document `BaseHTTPMiddleware` bugs

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -215,7 +215,6 @@ class CustomHeaderMiddleware(BaseHTTPMiddleware):
         return response
 
 
-
 middleware = [
     Middleware(CustomHeaderMiddleware, header_value='Customized')
 ]
@@ -226,6 +225,12 @@ app = Starlette(routes=routes, middleware=middleware)
 Middleware classes should not modify their state outside of the `__init__` method.
 Instead you should keep any state local to the `dispatch` method, or pass it
 around explicitly, rather than mutating the middleware instance.
+
+!!! bug
+    Currently, the `BaseHTTPMiddleware` has two known issues:
+
+    - It's not possible to use multiple `BaseHTTPMiddleware` based middlewares.
+    - It's not possible to use `BackgroundTasks` with `BaseHTTPMiddleware`.
 
 ## Using middleware in other frameworks
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -227,10 +227,11 @@ Instead you should keep any state local to the `dispatch` method, or pass it
 around explicitly, rather than mutating the middleware instance.
 
 !!! bug
-    Currently, the `BaseHTTPMiddleware` has two known issues:
+    Currently, the `BaseHTTPMiddleware` has some known issues:
 
     - It's not possible to use multiple `BaseHTTPMiddleware` based middlewares.
     - It's not possible to use `BackgroundTasks` with `BaseHTTPMiddleware`.
+    - Using `BaseHTTPMiddleware` will prevent changes to `contextlib.ContextVar`s from propagating upwards. That is, if you set a value for a `ContextVar` in your endpoint and try to read it from a middleware you will find that the value is not the same value you set in your endpoint (see [this test](https://github.com/encode/starlette/blob/621abc747a6604825190b93467918a0ec6456a24/tests/middleware/test_base.py#L192-L223) for an example of this behavior).
 
 ## Using middleware in other frameworks
 


### PR DESCRIPTION
- Closes #1029

Unfortunately we have those bugs.

I think it would be a good idea to document them.

## How does it look like

<img width="785" alt="image" src="https://user-images.githubusercontent.com/7353520/169148388-b642c2e6-9800-49a2-9e06-7b58590fd4a4.png">


## Questions

- Should we document how to create middlewares in plain ASGI?
- Should we link the issues for those bugs? Which ones are those... ?