### PR TITLE
Fixed TypeError on any request

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -81,6 +81,7 @@ class Response:
         if (
             body is not None
             and populate_content_length
+            and self.status_code is not None
             and not (self.status_code < 200 or self.status_code in (204, 304))
         ):
             content_length = str(len(body))


### PR DESCRIPTION
[Original discussion](https://github.com/strawberry-graphql/strawberry/pull/1594)
I've been able to fix the error by simply adding a one-line fix on `requests.py`, more precisely a check for None on the `status_code` variable.
It's worked perfectly for me since I've applied it and I thought I'd share it in case it fixes the annoying bug.