### PR TITLE
Raise `MultiPartException` when missing "name" field on `Content-Disposition` header

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ filterwarnings=
     error
     ignore: run_until_first_complete is deprecated and will be removed in a future version.:DeprecationWarning
     ignore: starlette\.middleware\.wsgi is deprecated and will be removed in a future release\.*:DeprecationWarning
+    ignore: Async generator 'starlette\.requests\.Request\.stream' was garbage collected before it had been exhausted.*:ResourceWarning
 
 [coverage:run]
 source_pkgs = starlette, tests

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -220,7 +220,13 @@ class MultiPartParser:
                     header_value = b""
                 elif message_type == MultiPartMessage.HEADERS_FINISHED:
                     disposition, options = parse_options_header(content_disposition)
-                    field_name = _user_safe_decode(options[b"name"], charset)
+                    try:
+                        field_name = _user_safe_decode(options[b"name"], charset)
+                    except KeyError:
+                        raise MultiPartException(
+                            'The Content-Disposition header field "name" must be '
+                            "provided."
+                        )
                     if b"filename" in options:
                         filename = _user_safe_decode(options[b"filename"], charset)
                         file = UploadFile(


### PR DESCRIPTION
- Closes #1303 