### PR TITLE
Allow colons in routes again

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -108,7 +108,7 @@ PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?}")
 
 
 def compile_path(
-    path: str,
+    path: str, strip_port: bool = False
 ) -> typing.Tuple[typing.Pattern, str, typing.Dict[str, Convertor]]:
     """
     Given a path string, like: "/{username:str}", return a three-tuple
@@ -150,7 +150,8 @@ def compile_path(
         ending = "s" if len(duplicated_params) > 1 else ""
         raise ValueError(f"Duplicated param name{ending} {names} at path {path}")
 
-    path_regex += re.escape(path[idx:].split(":")[0]) + "$"
+    tail: str = path[idx:].split(":")[0] if strip_port else path[idx:]
+    path_regex += re.escape(tail) + "$"
     path_format += path[idx:]
 
     return re.compile(path_regex), path_format, param_convertors
@@ -432,7 +433,9 @@ class Host(BaseRoute):
         self.host = host
         self.app = app
         self.name = name
-        self.host_regex, self.host_format, self.param_convertors = compile_path(host)
+        self.host_regex, self.host_format, self.param_convertors = compile_path(
+            host, strip_port=True
+        )
 
     @property
     def routes(self) -> typing.List[BaseRoute]:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -713,13 +713,14 @@ def test_partial_async_ws_endpoint(test_client_factory):
 def test_duplicated_param_names():
     with pytest.raises(
         ValueError,
-        match="Duplicated param name id at path /{id}/{id}",
+        match="Duplicated param name id at path pattern /{id}/{id}",
     ):
         Route("/{id}/{id}", user)
 
     with pytest.raises(
         ValueError,
-        match="Duplicated param names id, name at path /{id}/{name}/{id}/{name}",
+        match="Duplicated param names id, name"
+        " at path pattern /{id}/{name}/{id}/{name}",
     ):
         Route("/{id}/{name}/{id}/{name}", user)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -18,6 +18,11 @@ def users(request):
     return Response("All users", media_type="text/plain")
 
 
+def disable_user(request):
+    content = "User " + request.path_params["username"] + " disabled"
+    return Response(content, media_type="text/plain")
+
+
 def user(request):
     content = "User " + request.path_params["username"]
     return Response(content, media_type="text/plain")
@@ -108,6 +113,7 @@ app = Router(
             routes=[
                 Route("/", endpoint=users),
                 Route("/me", endpoint=user_me),
+                Route("/{username}:disable", endpoint=disable_user, methods=["PUT"]),
                 Route("/{username}", endpoint=user),
                 Route("/nomatch", endpoint=user_no_match),
             ],
@@ -188,6 +194,11 @@ def test_router(client):
     assert response.status_code == 200
     assert response.url == "http://testserver/users/tomchristie"
     assert response.text == "User tomchristie"
+
+    response = client.put("/users/tomchristie:disable")
+    assert response.status_code == 200
+    assert response.url == "http://testserver/users/tomchristie:disable"
+    assert response.text == "User tomchristie disabled"
 
     response = client.get("/users/nomatch")
     assert response.status_code == 200


### PR DESCRIPTION
This fixes the issue that was brought up as https://github.com/tiangolo/fastapi/issues/4892
Due to starlette stripping any `:.*` ending when compiling path patterns, it became impossible to use colons in them.
This issue was introduced in #1322, because now the port suffix was stripped from host names. This is not necessary when compiling Route and Mount patterns however.

My use case, like the one of the original reporter, comes from following the google api design guide.
