### PR TITLE
Adding __reduce__ to HTTPException to enable pickle/unpickle

### DIFF
--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -22,7 +22,7 @@ class HTTPException(Exception):
         class_name = self.__class__.__name__
         return f"{class_name}(status_code={self.status_code!r}, detail={self.detail!r})"
 
-    def __reduce__(self) -> tuple[typing.Any, ...]:
+    def __reduce__(self) -> typing.Tuple[typing.Any, ...]:
         return type(self), (self.status_code, self.detail, self.headers)
 
 

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -22,6 +22,9 @@ class HTTPException(Exception):
         class_name = self.__class__.__name__
         return f"{class_name}(status_code={self.status_code!r}, detail={self.detail!r})"
 
+    def __reduce__(self) -> tuple[typing.Any, ...]:
+        return type(self), (self.status_code, self.detail, self.headers)
+
 
 __deprecated__ = "ExceptionMiddleware"
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,7 @@
 import warnings
 
 import pytest
+import pickle
 
 from starlette.exceptions import HTTPException
 from starlette.middleware.exceptions import ExceptionMiddleware
@@ -146,3 +147,8 @@ def test_exception_middleware_deprecation() -> None:
 
     with pytest.warns(DeprecationWarning):
         starlette.exceptions.ExceptionMiddleware
+
+
+def test_exception_pickle() -> None:
+    assert pickle.loads(pickle.dumps(HTTPException(404))).status_code == 404
+    assert pickle.loads(pickle.dumps(HTTPException(status_code=404))).status_code == 404

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,7 @@
+import pickle
 import warnings
 
 import pytest
-import pickle
 
 from starlette.exceptions import HTTPException
 from starlette.middleware.exceptions import ExceptionMiddleware


### PR DESCRIPTION
[HTTPException pickle fails when constructed using named parameter status_code](https://github.com/encode/starlette/discussions/1669)