### PR TITLE
deprecate non-asgi compliant scope state

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ filterwarnings=
     ignore: run_until_first_complete is deprecated and will be removed in a future version.:DeprecationWarning
     ignore: starlette\.middleware\.wsgi is deprecated and will be removed in a future release\.*:DeprecationWarning
     ignore: Async generator 'starlette\.requests\.Request\.stream' was garbage collected before it had been exhausted.*:ResourceWarning
+    ignore: .*is deprecated, use scope\["extensions"\]\["starlette"\]\.*:DeprecationWarning
 
 [coverage:run]
 source_pkgs = starlette, tests

--- a/starlette/_deprecated_scope.py
+++ b/starlette/_deprecated_scope.py
@@ -17,10 +17,6 @@ class DeprecatedScope(Dict[str, Any]):
 
     def __init__(self, scope: Mapping[str, Any]) -> None:
         super().__init__(scope)
-        self["extensions"] = extensions = self.get("extensions", None) or {}
-        extensions["starlette"] = self.extension = (
-            extensions.get("starlette", None) or {}
-        )
 
     def __getitem__(self, __k: str) -> Any:
         if __k in self._deprecated_scope_keys:
@@ -29,10 +25,4 @@ class DeprecatedScope(Dict[str, Any]):
                 f'scope["extensions"]["starlette"]["{__k}"] instead'
             )
             warn(msg, DeprecationWarning)
-            return self.extension[__k]
         return super().__getitem__(__k)
-
-    def __setitem__(self, __k: str, __v: Any) -> None:
-        if __k in self._deprecated_scope_keys:
-            self.extension[__k] = __v
-        return super().__setitem__(__k, __v)

--- a/starlette/_deprecated_scope.py
+++ b/starlette/_deprecated_scope.py
@@ -1,0 +1,38 @@
+from typing import Any, Dict, Mapping, Set
+from warnings import warn
+
+
+class DeprecatedScope(Dict[str, Any]):
+    _deprecated_scope_keys: Set[str] = {
+        "app",
+        "session",
+        "auth",
+        "user",
+        "state",
+        "endpoint",
+        "path_params",
+        "app_root_path",
+        "router",
+    }
+
+    def __init__(self, scope: Mapping[str, Any]) -> None:
+        super().__init__(scope)
+        self["extensions"] = extensions = self.get("extensions", None) or {}
+        extensions["starlette"] = self.extension = (
+            extensions.get("starlette", None) or {}
+        )
+
+    def __getitem__(self, __k: str) -> Any:
+        if __k in self._deprecated_scope_keys:
+            msg = (
+                f'scope["{__k}"] is deprecated, use '
+                f'scope["extensions"]["starlette"]["{__k}"] instead'
+            )
+            warn(msg, DeprecationWarning)
+            return self.extension[__k]
+        return super().__getitem__(__k)
+
+    def __setitem__(self, __k: str, __v: Any) -> None:
+        if __k in self._deprecated_scope_keys:
+            self.extension[__k] = __v
+        return super().__setitem__(__k, __v)

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -10,3 +10,11 @@ def is_async_callable(obj: typing.Any) -> bool:
     return asyncio.iscoroutinefunction(obj) or (
         callable(obj) and asyncio.iscoroutinefunction(obj.__call__)
     )
+
+
+def get_or_create_extension(
+    scope: typing.MutableMapping[str, typing.Any]
+) -> typing.MutableMapping[str, typing.Any]:
+    scope["extensions"] = extensions = scope.get("extensions", None) or {}
+    extension = extensions["starlette"] = extensions.get("starlette", None) or {}
+    return extension

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -1,5 +1,6 @@
 import typing
 
+from starlette._deprecated_scope import DeprecatedScope
 from starlette.datastructures import State, URLPath
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -120,6 +121,7 @@ class Starlette:
         return self.router.url_path_for(name, **path_params)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        scope = DeprecatedScope(scope)
         scope["app"] = self
         await self.middleware_stack(scope, receive, send)
 

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -1,6 +1,7 @@
 import typing
 
 from starlette._deprecated_scope import DeprecatedScope
+from starlette._utils import get_or_create_extension
 from starlette.datastructures import State, URLPath
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -122,7 +123,7 @@ class Starlette:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope = DeprecatedScope(scope)
-        scope["app"] = self
+        scope["app"] = get_or_create_extension(scope)["app"] = self
         await self.middleware_stack(scope, receive, send)
 
     # The following usages are now discouraged in favour of configuration

--- a/starlette/middleware/authentication.py
+++ b/starlette/middleware/authentication.py
@@ -1,5 +1,6 @@
 import typing
 
+from starlette._utils import get_or_create_extension
 from starlette.authentication import (
     AuthCredentials,
     AuthenticationBackend,
@@ -45,6 +46,8 @@ class AuthenticationMiddleware:
         if auth_result is None:
             auth_result = AuthCredentials(), UnauthenticatedUser()
         scope["auth"], scope["user"] = auth_result
+        extension = get_or_create_extension(scope)
+        extension["auth"], extension["user"] = auth_result
         await self.app(scope, receive, send)
 
     @staticmethod

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -6,6 +6,7 @@ from base64 import b64decode, b64encode
 import itsdangerous
 from itsdangerous.exc import BadSignature
 
+from starlette._utils import get_or_create_extension
 from starlette.datastructures import MutableHeaders, Secret
 from starlette.requests import HTTPConnection
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -54,6 +55,7 @@ class SessionMiddleware:
                 scope["session"] = {}
         else:
             scope["session"] = {}
+        get_or_create_extension(scope)["session"] = scope["session"]
 
         async def send_wrapper(message: Message) -> None:
             if message["type"] == "http.response.start":

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -5,6 +5,7 @@ from http import cookies as http_cookies
 
 import anyio
 
+from starlette._utils import get_or_create_extension
 from starlette.datastructures import URL, Address, FormData, Headers, QueryParams, State
 from starlette.exceptions import HTTPException
 from starlette.formparsers import FormParser, MultiPartException, MultiPartParser
@@ -167,10 +168,11 @@ class HTTPConnection(Mapping):
     def state(self) -> State:
         if not hasattr(self, "_state"):
             # Ensure 'state' has an empty dict if it's not already populated.
-            self.scope.setdefault("state", {})
+            extension = get_or_create_extension(self.scope)
+            extension["state"] = state = extension.get("state", None) or {}
             # Create a state instance with a reference to the dict in which it should
             # store info
-            self._state = State(self.scope["state"])
+            self._state = State(state)
         return self._state
 
     def url_for(self, name: str, **path_params: typing.Any) -> str:

--- a/tests/test_asgi_state.py
+++ b/tests/test_asgi_state.py
@@ -1,0 +1,38 @@
+import warnings
+from typing import Callable
+
+import pytest
+
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.testclient import TestClient
+
+
+def test_scope_key_deprecation(
+    test_client_factory: Callable[[Starlette], TestClient]
+) -> None:
+    async def route_accesses_deprecated_key(request: Request) -> Response:
+        app = request.scope["app"]
+        request.scope["app"] = app
+        return Response()
+
+    async def route_accesses_extension_key(request: Request) -> Response:
+        app = request.scope["extensions"]["starlette"]["app"]
+        request.scope["extensions"]["starlette"]["app"] = app
+        return Response()
+
+    app = Starlette(
+        routes=[
+            Route("/good", route_accesses_extension_key),
+            Route("/bad", route_accesses_deprecated_key),
+        ]
+    )
+    client = test_client_factory(app)
+
+    with pytest.warns(DeprecationWarning, match=r"scope\[\"app\"\] is deprecated"):
+        client.get("/bad")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        client.get("/good")

--- a/tests/test_asgi_state.py
+++ b/tests/test_asgi_state.py
@@ -4,9 +4,9 @@ from typing import Callable
 import pytest
 
 from starlette.applications import Starlette
-from starlette.routing import Route
 from starlette.requests import Request
 from starlette.responses import Response
+from starlette.routing import Route
 from starlette.testclient import TestClient
 
 


### PR DESCRIPTION
#1511 

This is the smallest change I could come up with to:
1. Start storing these keys in an extension namespace
2. Emit a deprecation warning when accessing them via the top level scope without breaking things

Issues:
1. We call `scope.setdefault` and `scope.update`. Do we really want to implement shims for _every_ dict method? `scope.update` is particularly tricky: do we do a "deep" update? _I ended up just updating the extension as well_
2. Where do we install the shim dict? I chose `Starlette.__call__`, but that means that anything using a `Route` as an ASGI app on its own would be sorta broken. _I decided to write to both places but always read from the deprecated key to avoid breaking any user code writing to the deprecated key_