### PR TITLE
Upgrade mkdocs-material to 8.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ trio==0.19.0
 
 # Documentation
 mkdocs==1.3.0
-mkdocs-material==8.2.8
+mkdocs-material==8.3.3
 mkautodoc==0.1.0
 
 # Packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ trio==0.19.0
 
 # Documentation
 mkdocs==1.3.0
-mkdocs-material==8.3.3
+mkdocs-material==8.2.8
 mkautodoc==0.1.0
 
 # Packaging


### PR DESCRIPTION
I faced this in https://github.com/encode/starlette/pull/1683 and checking [here](https://pypi.org/project/mkdocs-material/#history) seems like mkdocs-material 8.2.8 is not available anymore.