### PR TITLE
copy over some tests from alternative implementation

### DIFF
--- a/tests/middleware/test_http.py
+++ b/tests/middleware/test_http.py
@@ -1,32 +1,27 @@
-import contextvars
-from typing import AsyncGenerator, Optional
+from typing import Any, AsyncGenerator, Callable, Optional
 
 import pytest
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.http import HTTPMiddleware
-from starlette.requests import HTTPConnection
+from starlette.requests import HTTPConnection, Request
 from starlette.responses import PlainTextResponse, Response, StreamingResponse
 from starlette.routing import Route, WebSocketRoute
+from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.websockets import WebSocket
 
 
-class CustomMiddleware(HTTPMiddleware):
-    async def dispatch(self, conn: HTTPConnection) -> AsyncGenerator[None, Response]:
-        response = yield
-        response.headers["Custom-Header"] = "Example"
-
-
-def homepage(request):
+def homepage(request: Request) -> Response:
     return PlainTextResponse("Homepage")
 
 
-def exc(request):
+def exc(request: Request) -> Response:
     raise Exception("Exc")
 
 
-def exc_stream(request):
+def exc_stream(request: Request) -> Response:
     return StreamingResponse(_generate_faulty_stream())
 
 
@@ -36,20 +31,26 @@ def _generate_faulty_stream():
 
 
 class NoResponse:
-    def __init__(self, scope, receive, send):
+    def __init__(self, scope: Scope, receive: Receive, send: Send) -> None:
         pass
 
-    def __await__(self):
+    def __await__(self) -> Any:
         return self.dispatch().__await__()
 
-    async def dispatch(self):
+    async def dispatch(self) -> None:
         pass
 
 
-async def websocket_endpoint(session):
+async def websocket_endpoint(session: WebSocket):
     await session.accept()
     await session.send_text("Hello, world!")
     await session.close()
+
+
+class CustomMiddleware(HTTPMiddleware):
+    async def dispatch(self, request: HTTPConnection) -> AsyncGenerator[None, Response]:
+        response = yield
+        response.headers["Custom-Header"] = "Example"
 
 
 app = Starlette(
@@ -64,7 +65,9 @@ app = Starlette(
 )
 
 
-def test_custom_middleware(test_client_factory):
+def test_custom_middleware(
+    test_client_factory: Callable[[ASGIApp], TestClient]
+) -> None:
     client = test_client_factory(app)
     response = client.get("/")
     assert response.headers["Custom-Header"] == "Example"
@@ -77,7 +80,7 @@ def test_custom_middleware(test_client_factory):
         response = client.get("/exc-stream")
     assert str(ctx.value) == "Faulty Stream"
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(AssertionError):  # from TestClient
         response = client.get("/no-response")
 
     with client.websocket_connect("/ws") as session:
@@ -85,41 +88,34 @@ def test_custom_middleware(test_client_factory):
         assert text == "Hello, world!"
 
 
-def test_state_data_across_multiple_middlewares(test_client_factory):
+def test_state_data_across_multiple_middlewares(
+    test_client_factory: Callable[[ASGIApp], TestClient]
+) -> None:
     expected_value1 = "foo"
     expected_value2 = "bar"
 
-    class aMiddleware(HTTPMiddleware):
-        async def dispatch(
-            self, conn: HTTPConnection
-        ) -> AsyncGenerator[None, Response]:
-            conn.state.foo = expected_value1
-            yield
+    async def middleware_a(request: HTTPConnection) -> AsyncGenerator[None, None]:
+        request.state.foo = expected_value1
+        yield
 
-    class bMiddleware(HTTPMiddleware):
-        async def dispatch(
-            self, conn: HTTPConnection
-        ) -> AsyncGenerator[None, Response]:
-            conn.state.bar = expected_value2
-            response = yield
-            response.headers["X-State-Foo"] = conn.state.foo
+    async def middleware_b(request: HTTPConnection) -> AsyncGenerator[None, Response]:
+        request.state.bar = expected_value2
+        response = yield
+        response.headers["X-State-Foo"] = request.state.foo
 
-    class cMiddleware(HTTPMiddleware):
-        async def dispatch(
-            self, conn: HTTPConnection
-        ) -> AsyncGenerator[None, Response]:
-            response = yield
-            response.headers["X-State-Bar"] = conn.state.bar
+    async def middleware_c(request: HTTPConnection) -> AsyncGenerator[None, Response]:
+        response = yield
+        response.headers["X-State-Bar"] = request.state.bar
 
-    def homepage(request):
+    def homepage(request: Request) -> Response:
         return PlainTextResponse("OK")
 
     app = Starlette(
         routes=[Route("/", homepage)],
         middleware=[
-            Middleware(aMiddleware),
-            Middleware(bMiddleware),
-            Middleware(cMiddleware),
+            Middleware(HTTPMiddleware, dispatch=middleware_a),
+            Middleware(HTTPMiddleware, dispatch=middleware_b),
+            Middleware(HTTPMiddleware, dispatch=middleware_c),
         ],
     )
 
@@ -130,160 +126,77 @@ def test_state_data_across_multiple_middlewares(test_client_factory):
     assert response.headers["X-State-Bar"] == expected_value2
 
 
-def test_dispatch_argument(test_client_factory):
-    def homepage(request):
-        return PlainTextResponse("Homepage")
+def test_modify_content_type(
+    test_client_factory: Callable[[ASGIApp], TestClient]
+) -> None:
+    async def dispatch(request: HTTPConnection) -> AsyncGenerator[None, Response]:
+        resp = yield
+        resp.media_type = "text/csv"
 
-    async def dispatch(conn: HTTPConnection) -> AsyncGenerator[None, Response]:
-        response = yield
-        response.headers["Custom-Header"] = "Example"
+    def homepage(request: Request) -> Response:
+        return PlainTextResponse("OK")
 
     app = Starlette(
         routes=[Route("/", homepage)],
-        middleware=[Middleware(HTTPMiddleware, dispatch=dispatch)],
+        middleware=[
+            Middleware(HTTPMiddleware, dispatch=dispatch),
+        ],
     )
 
     client = test_client_factory(app)
     response = client.get("/")
-    assert response.headers["Custom-Header"] == "Example"
+    assert response.text == "OK"
+    assert response.headers["Content-Type"] == "text/csv; charset=utf-8"
 
 
-def test_middleware_repr():
-    middleware = Middleware(CustomMiddleware)
-    assert repr(middleware) == "Middleware(CustomMiddleware)"
-
-
-def test_early_response(test_client_factory):
-    async def index(request):
-        return PlainTextResponse("Hello, world!")
-
-    class CustomMiddleware(HTTPMiddleware):
-        async def dispatch(
-            self, conn: HTTPConnection
-        ) -> AsyncGenerator[Optional[Response], Response]:
-            if conn.headers.get("X-Early") == "true":
-                yield Response(status_code=401)
-            else:
-                yield None
+def test_early_response(test_client_factory: Callable[[ASGIApp], TestClient]) -> None:
+    async def dispatch(request: HTTPConnection) -> AsyncGenerator[Response, None]:
+        yield Response(status_code=401)
 
     app = Starlette(
-        routes=[Route("/", index)],
-        middleware=[Middleware(CustomMiddleware)],
+        middleware=[
+            Middleware(HTTPMiddleware, dispatch=dispatch),
+        ],
     )
 
     client = test_client_factory(app)
     response = client.get("/")
-    assert response.status_code == 200
-    assert response.text == "Hello, world!"
-    response = client.get("/", headers={"X-Early": "true"})
     assert response.status_code == 401
 
 
-def test_too_many_yields(test_client_factory) -> None:
-    class CustomMiddleware(HTTPMiddleware):
-        async def dispatch(
-            self, conn: HTTPConnection
-        ) -> AsyncGenerator[None, Response]:
-            _ = yield
-            yield
-
-    app = Starlette(middleware=[Middleware(CustomMiddleware)])
-
-    client = test_client_factory(app)
-    with pytest.raises(RuntimeError, match="should yield exactly once"):
-        client.get("/")
-
-
-def test_error_response(test_client_factory) -> None:
-    class Failed(Exception):
-        pass
-
-    async def failure(request):
-        raise Failed()
-
-    class CustomMiddleware(HTTPMiddleware):
-        async def dispatch(
-            self, conn: HTTPConnection
-        ) -> AsyncGenerator[Optional[Response], Response]:
-            try:
-                yield None
-            except Failed:
-                yield Response("Failed", status_code=500)
-
-    app = Starlette(
-        routes=[Route("/fail", failure)],
-        middleware=[Middleware(CustomMiddleware)],
-    )
-
-    client = test_client_factory(app)
-    response = client.get("/fail")
-    assert response.text == "Failed"
-    assert response.status_code == 500
-
-
-def test_no_error_response(test_client_factory) -> None:
-    class Failed(Exception):
-        pass
-
-    async def index(request):
-        raise Failed()
-
-    class CustomMiddleware(HTTPMiddleware):
-        async def dispatch(
-            self, conn: HTTPConnection
-        ) -> AsyncGenerator[None, Response]:
-            try:
-                yield
-            except Failed:
-                pass
-
-    app = Starlette(
-        routes=[Route("/", index)],
-        middleware=[Middleware(CustomMiddleware)],
-    )
-
-    client = test_client_factory(app)
-    with pytest.raises(RuntimeError, match="no response was returned"):
-        client.get("/")
-
-
-ctxvar: contextvars.ContextVar[str] = contextvars.ContextVar("ctxvar")
-
-
-class PureASGICustomMiddleware:
-    def __init__(self, app: ASGIApp) -> None:
-        self.app = app
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        ctxvar.set("set by middleware")
-        await self.app(scope, receive, send)
-        assert ctxvar.get() == "set by endpoint"
-
-
-class HTTPCustomMiddleware(HTTPMiddleware):
-    async def dispatch(self, conn: HTTPConnection) -> AsyncGenerator[None, Response]:
-        ctxvar.set("set by middleware")
+def test_generator_does_not_stop_no_early_return(
+    test_client_factory: Callable[..., TestClient]
+) -> None:
+    async def bad_dispatch(request: HTTPConnection) -> AsyncGenerator[None, None]:
         yield
-        assert ctxvar.get() == "set by endpoint"
-
-
-@pytest.mark.parametrize(
-    "middleware_cls",
-    [
-        PureASGICustomMiddleware,
-        HTTPCustomMiddleware,
-    ],
-)
-def test_contextvars(test_client_factory, middleware_cls: type):
-    async def homepage(request):
-        assert ctxvar.get() == "set by middleware"
-        ctxvar.set("set by endpoint")
-        return PlainTextResponse("Homepage")
+        yield
 
     app = Starlette(
-        middleware=[Middleware(middleware_cls)], routes=[Route("/", homepage)]
+        middleware=[
+            Middleware(HTTPMiddleware, dispatch=bad_dispatch),
+        ],
     )
 
     client = test_client_factory(app)
-    response = client.get("/")
-    assert response.status_code == 200, response.content
+    with pytest.raises(RuntimeError, match=r"dispatch\(\) should yield exactly once"):
+        client.get("/")
+
+
+def test_generator_does_not_stop_early_return(
+    test_client_factory: Callable[..., TestClient]
+) -> None:
+    async def bad_dispatch(
+        request: HTTPConnection,
+    ) -> AsyncGenerator[Optional[Response], None]:
+        yield Response(status_code=204)
+        yield None
+
+    app = Starlette(
+        middleware=[
+            Middleware(HTTPMiddleware, dispatch=bad_dispatch),
+        ],
+    )
+
+    client = test_client_factory(app)
+    with pytest.raises(RuntimeError, match=r"dispatch\(\) should yield exactly once"):
+        client.get("/")

--- a/tests/middleware/test_http.py
+++ b/tests/middleware/test_http.py
@@ -165,7 +165,7 @@ def test_early_response(test_client_factory: Callable[[ASGIApp], TestClient]) ->
 
 
 def test_generator_does_not_stop_no_early_return(
-    test_client_factory: Callable[..., TestClient]
+    test_client_factory: Callable[[ASGIApp], TestClient]
 ) -> None:
     async def bad_dispatch(request: HTTPConnection) -> AsyncGenerator[None, None]:
         yield
@@ -183,7 +183,7 @@ def test_generator_does_not_stop_no_early_return(
 
 
 def test_generator_does_not_stop_early_return(
-    test_client_factory: Callable[..., TestClient]
+    test_client_factory: Callable[[ASGIApp], TestClient]
 ) -> None:
     async def bad_dispatch(
         request: HTTPConnection,


### PR DESCRIPTION
Copying over tests from my implementation.

This drops the `contextvar` tests which in my opinion are unnecessary with this implementation.
It also adds types to the test file.

There's two main test cases being added:
1. yielding after an early response (I added the fix for this, it's pretty straightforward)
2. Modifying `Response.media_type`. In my implementation I was detecting this and overwriting the header, but I guess we could subclass `Response` and raise an exception if someone attempts to assign it?