### PR TITLE
Fix documentation links to English

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -191,4 +191,4 @@ A response class that implements [Server-Sent Events](https://html.spec.whatwg.o
 
 #### [baize.asgi.FileResponse](https://baize.aber.sh/asgi#fileresponse)
 
-As a smooth replacement for Starlette [`FileResponse`](https://www.starlette.io/responses/#fileresponse), it will automatically handle [Head method](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Methods/HEAD) and [Range requests](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Range_requests).
+As a smooth replacement for Starlette [`FileResponse`](https://www.starlette.io/responses/#fileresponse), it will automatically handle [Head method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD) and [Range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests).


### PR DESCRIPTION
Fix for next PR https://github.com/encode/starlette/pull/1696

The contributor added links to Chinese documentation pages.

Changed to English.