### PR TITLE
Shield send "http.response.start" from cancellation

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -240,13 +240,14 @@ class StreamingResponse(Response):
                 break
 
     async def stream_response(self, send: Send) -> None:
-        await send(
-            {
-                "type": "http.response.start",
-                "status": self.status_code,
-                "headers": self.raw_headers,
-            }
-        )
+        with anyio.CancelScope(shield=True):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": self.status_code,
+                    "headers": self.raw_headers,
+                }
+            )
         async for chunk in self.body_iterator:
             if not isinstance(chunk, bytes):
                 chunk = chunk.encode(self.charset)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -396,9 +396,10 @@ def test_streaming_response_known_size(test_client_factory):
 
 
 @pytest.mark.anyio
-async def test_streaming_response_disconnect_should_cancel_after_send_http_response_start_returns():
+async def test_streaming_response_disconnect_should_cancel_after_send_start_returns():
     """
-    Test that StreamingResponse cancels after send "http.response.start" returns, even if there is a checkpoint in send.
+    Test that StreamingResponse cancels after send "http.response.start" returns,
+    even if there is a checkpoint in send.
     """
     send_to_receiver = False
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -414,6 +414,6 @@ async def test_streaming_response_disconnect_should_cancel_after_send_start_retu
 
     scope = {"type": "http", "method": "GET", "path": "/"}
 
-    response = StreamingResponse("")
+    response = StreamingResponse(iter(""))
     await response(scope, receive, send)
     assert send_to_receiver


### PR DESCRIPTION
Fixes #1634 
- Discussion #1527 
- Caused by #1157 

`RuntimeError: No response returned.` is raised in `BaseHTTPMiddleware` if request is disconnected, due to `task_group.cancel_scope.cancel()` in `StreamingResponse.__call__.<locals>.wrap` and cancellation check in `await checkpoint()` of `MemoryObjectSendStream.send`.

Let's fix this behaviour change caused by anyio integration in 0.15.0.

---

I managed to make this error reproducible in 0.14.2 by partially emulating 0.15.0 logic: https://github.com/acjh/starlette/commit/37dd8ace69993bf437712bc54a2fdb93116ab918

starlette/concurrency.py:

```diff
  async def run_until_first_complete(*args: typing.Tuple[typing.Callable, dict]) -> None:
+     async def run(func: typing.Callable[[], typing.Coroutine]) -> None:
+         await func()
+         # (starlette 0.15.0) starlette.concurrency.run_until_first_complete `task_group.cancel_scope.cancel()`
+         for task in tasks:
+             if not task.done() and task != asyncio.current_task():
+                 task.cancel()
+
-     tasks = [create_task(handler(**kwargs)) for handler, kwargs in args]
+     tasks = [create_task(run(functools.partial(handler, **kwargs))) for handler, kwargs in args]
      (done, pending) = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
      [task.cancel() for task in pending]
-     [task.result() for task in done]
+     for task in done:
+         try:
+             task.result()
+         except asyncio.CancelledError:
+             pass
```

starlette/middleware/base.py:

```diff
  class BaseHTTPMiddleware:
      ...

      async def call_next(self, request: Request) -> Response:
          ...
-         send = queue.put
+
+         async def send(item: typing.Any) -> None:
+             await asyncio.sleep(0)  # anyio.streams.memory.MemoryObjectSendStream.send `await checkpoint()`
+             await queue.put(item)

          ...
```