### PR TITLE
Use Tuple instead of List in test_client.py

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -164,8 +164,8 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
                 "scheme": scheme,
                 "query_string": query.encode(),
                 "headers": headers,
-                "client": ["testclient", 50000],
-                "server": [host, port],
+                "client": ("testclient", 50000),
+                "server": (host, port),
                 "subprotocols": subprotocols,
             }
             session = WebSocketTestSession(self.app, scope, self.portal_factory)


### PR DESCRIPTION
## Issue
Our uvicorn app works well when deployed, but the test suite fails with an exception related to our custom logger trying to print the client address.

## Proposal
In the uvicorn logger, it is attempting to print the client address directly from the value of the scope dictionary, so it’s expecting a Tuple not a List.
Perhaps this issue should be solved in uvicorn, but since the fix from starlette side is only happening on the test_client, I figured it’s easier to adapt here.

https://github.com/encode/uvicorn/blob/837fd217c2095c56df4ef1253f2a35e631f98bef/uvicorn/protocols/utils.py#L46

