### PR TITLE
Shield send "http.response.start" from cancellation (BaseHTTPMiddleware)

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -30,9 +30,11 @@ class BaseHTTPMiddleware:
 
             async def send(msg: Message) -> None:
                 # Shield send "http.response.start" from cancellation.
-                # Otherwise, `await recv_stream.receive()` will raise `anyio.EndOfStream` if request is disconnected,
-                # due to `task_group.cancel_scope.cancel()` in `StreamingResponse.__call__.<locals>.wrap`
-                # and cancellation check in `await checkpoint()` of `MemoryObjectSendStream.send`,
+                # Otherwise, `await recv_stream.receive()` will raise
+                # `anyio.EndOfStream` if request is disconnected,
+                # due to `task_group.cancel_scope.cancel()` in
+                # `StreamingResponse.__call__.<locals>.wrap` and cancellation check
+                # during `await checkpoint()` in `MemoryObjectSendStream.send`,
                 # and then `RuntimeError: No response returned.` will be raised below.
                 shield = msg["type"] == "http.response.start"
                 with anyio.CancelScope(shield=shield):

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -31,11 +31,13 @@ class BaseHTTPMiddleware:
             async def send(msg: Message) -> None:
                 # Shield send "http.response.start" from cancellation.
                 # Otherwise, `await recv_stream.receive()` will raise
-                # `anyio.EndOfStream` if request is disconnected,
+                # `anyio.EndOfStream` if the connection is disconnected,
                 # due to `task_group.cancel_scope.cancel()` in
-                # `StreamingResponse.__call__.<locals>.wrap` and cancellation check
-                # during `await checkpoint()` in `MemoryObjectSendStream.send`,
-                # and then `RuntimeError: No response returned.` will be raised below.
+                # `StreamingResponse.__call__.<locals>.wrap`
+                # and cancellation check during `await checkpoint()` in
+                # `MemoryObjectSendStream.send`.
+                # This would trigger the check we have in this middleware resulting in
+                # `RuntimeError: No response returned.` being raised below.
                 shield = msg["type"] == "http.response.start"
                 with anyio.CancelScope(shield=shield):
                     await send_stream.send(msg)

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1,13 +1,16 @@
 import contextvars
+from contextlib import AsyncExitStack
+from typing import AsyncGenerator, Awaitable, Callable
 
 import pytest
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import PlainTextResponse, StreamingResponse
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response, StreamingResponse
 from starlette.routing import Route, WebSocketRoute
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 class CustomMiddleware(BaseHTTPMiddleware):
@@ -206,3 +209,41 @@ def test_contextvars(test_client_factory, middleware_cls: type):
     client = test_client_factory(app)
     response = client.get("/")
     assert response.status_code == 200, response.content
+
+
+@pytest.mark.anyio
+async def test_client_disconnects_before_response_is_sent() -> None:
+    app: ASGIApp
+
+    async def homepage(request: Request):
+        # await anyio.sleep(5)
+        return PlainTextResponse("hi!")
+
+    async def dispatch(
+        request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        return await call_next(request)
+
+    app = BaseHTTPMiddleware(Route("/", homepage), dispatch=dispatch)
+    app = BaseHTTPMiddleware(app, dispatch=dispatch)
+
+    async def recv_gen() -> AsyncGenerator[Message, None]:
+        yield {"type": "http.request"}
+        yield {"type": "http.disconnect"}
+        yield {"type": "http.disconnect"}
+
+    async def send_gen() -> AsyncGenerator[None, Message]:
+        msg = yield
+        assert msg["type"] == "http.response.start"
+        msg = yield
+        raise AssertionError("Should not be called")
+
+    scope = {"type": "http", "method": "GET", "path": "/"}
+
+    async with AsyncExitStack() as stack:
+        recv = recv_gen()
+        stack.push_async_callback(recv.aclose)
+        send = send_gen()
+        stack.push_async_callback(send.aclose)
+        await send.__anext__()
+        await app(scope, recv.__aiter__().__anext__, send.asend)

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -236,7 +236,7 @@ async def test_client_disconnects_before_response_is_sent() -> None:
         msg = yield
         assert msg["type"] == "http.response.start"
         msg = yield
-        raise AssertionError("Should not be called")
+        raise AssertionError("Should not be called")  # pragma: no cover
 
     scope = {"type": "http", "method": "GET", "path": "/"}
 


### PR DESCRIPTION
Fixes #1634 
- Discussion #1527 
- Caused by #1157 

`await recv_stream.receive()` will raise `anyio.EndOfStream` if request is disconnected, due to:
- `task_group.cancel_scope.cancel()` in `StreamingResponse.__call__.<locals>.wrap` and
- cancellation check in `await checkpoint()` of `MemoryObjectSendStream.send`,

and then `RuntimeError: No response returned.` will be raised in `BaseHTTPMiddleware`.

Let's shield send "http.response.start" from cancellation, since the message is ready to be sent to the receiver.

This is an alternative implementation of #1706 in `BaseHTTPMiddleware` instead of `StreamingResponse`.
We should not force the shielding in `StreamingResponse`, since the cancellation check is an intended feature of `MemoryObjectSendStream`. `BaseHTTPMiddleware`, which uses both, should be responsible for the compatibility.