### PR TITLE
Replace task cancellation in `BaseHTTPMiddleware` with `http.disconnect`+`recv_stream.close`

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -4,12 +4,13 @@ import anyio
 
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 RequestResponseEndpoint = typing.Callable[[Request], typing.Awaitable[Response]]
 DispatchFunction = typing.Callable[
     [Request, RequestResponseEndpoint], typing.Awaitable[Response]
 ]
+T = typing.TypeVar("T")
 
 
 class BaseHTTPMiddleware:
@@ -24,19 +25,52 @@ class BaseHTTPMiddleware:
             await self.app(scope, receive, send)
             return
 
+        response_sent = anyio.Event()
+
         async def call_next(request: Request) -> Response:
             app_exc: typing.Optional[Exception] = None
             send_stream, recv_stream = anyio.create_memory_object_stream()
+
+            async def receive_or_disconnect() -> Message:
+                if response_sent.is_set():
+                    return {"type": "http.disconnect"}
+
+                async with anyio.create_task_group() as task_group:
+
+                    async def wrap(func: typing.Callable[[], typing.Awaitable[T]]) -> T:
+                        result = await func()
+                        task_group.cancel_scope.cancel()
+                        return result
+
+                    task_group.start_soon(wrap, response_sent.wait)
+                    message = await wrap(request.receive)
+
+                if response_sent.is_set():
+                    return {"type": "http.disconnect"}
+
+                return message
+
+            async def close_recv_stream_on_response_sent() -> None:
+                await response_sent.wait()
+                recv_stream.close()
+
+            async def send_no_error(message: Message) -> None:
+                try:
+                    await send_stream.send(message)
+                except anyio.BrokenResourceError:
+                    # recv_stream has been closed, i.e. response_sent has been set.
+                    return
 
             async def coro() -> None:
                 nonlocal app_exc
 
                 async with send_stream:
                     try:
-                        await self.app(scope, request.receive, send_stream.send)
+                        await self.app(scope, receive_or_disconnect, send_no_error)
                     except Exception as exc:
                         app_exc = exc
 
+            task_group.start_soon(close_recv_stream_on_response_sent)
             task_group.start_soon(coro)
 
             try:
@@ -71,7 +105,7 @@ class BaseHTTPMiddleware:
             request = Request(scope, receive=receive)
             response = await self.dispatch_func(request, call_next)
             await response(scope, receive, send)
-            task_group.cancel_scope.cancel()
+            response_sent.set()
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -297,7 +297,7 @@ def test_app_receives_http_disconnect_while_sending_if_discarded(test_client_fac
             )
             pytest.fail(
                 "http.disconnect should have been received and canceled the scope"
-            )
+            )  # pragma: no cover
 
     app = DiscardingMiddleware(downstream_app)
 

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1,8 +1,10 @@
 import contextvars
 
+import anyio
 import pytest
 
 from starlette.applications import Starlette
+from starlette.background import BackgroundTask
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import PlainTextResponse, StreamingResponse
@@ -206,3 +208,139 @@ def test_contextvars(test_client_factory, middleware_cls: type):
     client = test_client_factory(app)
     response = client.get("/")
     assert response.status_code == 200, response.content
+
+
+@pytest.mark.anyio
+async def test_run_background_tasks_even_if_client_disconnects():
+    # test for https://github.com/encode/starlette/issues/1438
+    request_body_sent = False
+    response_complete = anyio.Event()
+    background_task_run = anyio.Event()
+
+    async def sleep_and_set():
+        # small delay to give BaseHTTPMiddleware a chance to cancel us
+        # this is required to make the test fail prior to fixing the issue
+        # so do not be surprised if you remove it and the test still passes
+        await anyio.sleep(0.1)
+        background_task_run.set()
+
+    async def endpoint_with_background_task(_):
+        return PlainTextResponse(background=BackgroundTask(sleep_and_set))
+
+    async def passthrough(request, call_next):
+        return await call_next(request)
+
+    app = Starlette(
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=passthrough)],
+        routes=[Route("/", endpoint_with_background_task)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+    }
+
+    async def receive():
+        nonlocal request_body_sent
+        if not request_body_sent:
+            request_body_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        # We simulate a client that disconnects immediately after receiving the response
+        await response_complete.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.body":
+            if not message.get("more_body", False):
+                response_complete.set()
+
+    await app(scope, receive, send)
+
+    assert background_task_run.is_set()
+
+
+def test_app_receives_http_disconnect_while_sending_if_discarded(test_client_factory):
+    class DiscardingMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            await call_next(request)
+            return PlainTextResponse("Custom")
+
+    async def downstream_app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"text/plain"),
+                ],
+            }
+        )
+        async with anyio.create_task_group() as task_group:
+
+            async def cancel_on_disconnect():
+                while True:
+                    message = await receive()
+                    if message["type"] == "http.disconnect":
+                        task_group.cancel_scope.cancel()
+                        break
+
+            task_group.start_soon(cancel_on_disconnect)
+
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b"chunk",
+                    "more_body": True,
+                }
+            )
+            pytest.fail(
+                "http.disconnect should have been received and canceled the scope"
+            )
+
+    app = DiscardingMiddleware(downstream_app)
+
+    client = test_client_factory(app)
+    response = client.get("/does_not_exist")
+    assert response.text == "Custom"
+
+
+def test_app_receives_http_disconnect_after_sending_if_discarded(test_client_factory):
+    class DiscardingMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            await call_next(request)
+            return PlainTextResponse("Custom")
+
+    async def downstream_app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"text/plain"),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"first chunk, ",
+                "more_body": True,
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"second chunk",
+                "more_body": True,
+            }
+        )
+        message = await receive()
+        assert message["type"] == "http.disconnect"
+
+    app = DiscardingMiddleware(downstream_app)
+
+    client = test_client_factory(app)
+    response = client.get("/does_not_exist")
+    assert response.text == "Custom"

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -288,13 +288,18 @@ def test_app_receives_http_disconnect_while_sending_if_discarded(test_client_fac
 
             task_group.start_soon(cancel_on_disconnect)
 
-            await send(
-                {
-                    "type": "http.response.body",
-                    "body": b"chunk",
-                    "more_body": True,
-                }
-            )
+            # A timeout is set for 0.1 second in order to ensure that
+            # cancel_on_disconnect is scheduled by the event loop
+            with anyio.move_on_after(0.1):
+                while True:
+                    await send(
+                        {
+                            "type": "http.response.body",
+                            "body": b"chunk ",
+                            "more_body": True,
+                        }
+                    )
+
             pytest.fail(
                 "http.disconnect should have been received and canceled the scope"
             )  # pragma: no cover


### PR DESCRIPTION
- [x] This is a followup on the issues that are the root cause for #1438 
- [x] This pull request is also a followup on the discussion surrounding task cancellation and handling of unfinished/deadlocked coroutines in the comments on #1697 

There have been various issues related to the way that `BaseHTTPMiddleware` works, and in particular, related to the way that it uses task cancellation in order to force the downstream ASGI app to shut down.

In particular, I would like to highlight that:

 * In a series of issues related to the way that `BaseHTTPMiddleware`, cancellation is used in order to get out of a deadlock between a call to `send_stream.send` that never finishes and blocks a downstream `app` from completing, and a call to `recv_stream.receive` that is never made because the `body_stream` iterator has been orphaned by the `dispatch` method implementation;
 * In #1697, @florimondmanca expresses his opinion that "AFAIK there’s no way in the ASGI spec to just discard a streaming body even though more_body is True. In fact I believe the spec says servers MUST pull until that becomes False." - in other words, using task cancellation on a downstream app may not be permitted by ASGI. I would note that, as ASGI is agnostic to the async framework in use, and as e.g. native `asyncio` and `trio` have very different cancellation semantics, that may be the only practical position that ASGI can take;

I believe that this pull request outlines a solution that avoids both using task cancellation on the downstream ASGI application, and also avoids deadlocking the downstream ASGI application. It does that by replacing task cancellation with the following features:
 * Instead of triggering task cancellation on the task group that runs the downstream ASGI application, an `anyio.Event` `app_disconnected` is set, that triggers the following consequences:
   * It hooks the `receive` function that is passed to the downstream ASGI application so that, if `app_disconnected` is set, a message with type `http.disconnect` will be returned (instead of waiting for the next message from `request.receive`);
   * It closes the `recv_stream`, which has the effect of removing the root cause of the known deadlock issue. However, as `send_stream.send` raises an `anyio.BrokenResourceError` in that case, we need to wrap `send_stream.send` before passing it to the downstream ASGI application;

What are the consequences of that proposed change?

1. We cannot rely on task cancellation to force the downstream ASGI application to stop its processing. However, as task cancellation is a behavior that only happens when a `BaseHTTPMiddleware` is found in an ASGI middleware chain, and that is completely unexpected by ASGI applications (even Starlette's own response classes do not take that possibility in account), that may not be an actual loss of functionality;
2. By sending a `{"type":"http.disconnect"}` message, we allow ASGI applications that listen to that event (such as Starlette's `StreamingResponse`) to potentially wrap up their processing once it becomes clear that their work will be discarded and start cleanup and finalization (e.g. something may be added to `FileResponse`);
3. By closing the `recv_stream` once the response has been completely sent, we remove the root cause of the deadlock, and ensure that it cannot happen even e.g. in the face of a fully cancellation-shielded application;

There are two larger points that concern conformance to the ASGI specification / expected behavior (however, I do not know even with whom we could raise these points):
 * Should we confirm whether task cancellation can be used (or not) to interrupt a running ASGI application?
 * Should we confirm whether the usage of `{"type":"http.disconnect"}`, in order to signal to the application "Your link with the HTTP client has been severed, there is no need to continue producing `http.response.body` messages", is semantically compatible with what ASGI specifies?

~~This PR is a draft because, as I did not have validation from the maintainers to propose such a change, I did not add the tests that would prove that various issues (some of them the same as those fixed by the many other PRs on the same subject) are actually fixed by my proposal. In case any maintainer expresses interest in actually trying to integrate this proposal, I will gladly work to complete this PR with the necessary tests.~~

This PR is not a draft anymore, and:
 * fixes #919
 * fixes #1438
 * closes #1699
 * closes #1700
 * closes #1710 