### PR TITLE
Explain 'TestClient(app) as client' vs 'client = TestClient(app)' (#1…

### DIFF
--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -64,12 +64,10 @@ case you should use `client = TestClient(app, raise_server_exceptions=False)`.
 
 !!! note
 
-    The `TestClient` can also be used as a context manager which slightly
-    changes its behavior. For example, if you want to use `on_startup`,
-    `on_shutdown`, or `lifespan` events, you will need to use the `TestClient`
-    as a context manager. If not, then those events will not be triggered when
-    the `TestClient` is instantiated. You can learn more about it [here
-    ](/events/#running-event-handlers-in-tests).
+    If you want the `TestClient` to run `lifespan` events (`on_startup`, `on_shutdown`, or `lifespan`),
+    you will need to use the `TestClient` as a context manager. Otherwise, the events
+    will not be triggered when the `TestClient` is instantiated. You can learn more about it
+    [here](/events/#running-event-handlers-in-tests).
 
 ### Selecting the Async backend
 

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -62,7 +62,7 @@ application. Occasionally you might want to test the content of 500 error
 responses, rather than allowing client to raise the server exception. In this
 case you should use `client = TestClient(app, raise_server_exceptions=False)`.
 
-!!! notes
+!!! note
 
     The `TestClient` can also be used as a context manager which slightly
     changes its behavior. For example, if you want to use `on_startup`,

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -66,7 +66,7 @@ case you should use `client = TestClient(app, raise_server_exceptions=False)`.
 
     The `TestClient` can also be used as a context manager which slightly
     changes its behavior. For example, if you want to use `on_startup`,
-    `on_shutdown`, or `lifetime` events, you will need to use the `TestClient`
+    `on_shutdown`, or `lifespan` events, you will need to use the `TestClient`
     as a context manager. If not, then those events will not be triggered when
     the `TestClient` is instantiated. You can learn more about it [here
     ](/events/#running-event-handlers-in-tests).

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -66,7 +66,7 @@ case you should use `client = TestClient(app, raise_server_exceptions=False)`.
 
     The `TestClient` can also be used as a context manager which slightly
     changes its behavior. For example, if you want to use `on_startup`,
-    `on_shutdown` , or `lifetime` events, you will need to use the `TestClient`
+    `on_shutdown`, or `lifetime` events, you will need to use the `TestClient`
     as a context manager. If not, then those events will not be triggered when
     the `TestClient` is instantiated. You can learn more about it [here
     ](/events/#running-event-handlers-in-tests).

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -62,6 +62,16 @@ application. Occasionally you might want to test the content of 500 error
 responses, rather than allowing client to raise the server exception. In this
 case you should use `client = TestClient(app, raise_server_exceptions=False)`.
 
+!!! notes
+
+    The `TestClient` can also be used as a context manager which slightly
+    changes its behavior. For example, if you want to use `on_startup`,
+    `on_shutdown` , or `lifetime` events, you will need to use the `TestClient`
+    as a context manager. If not, then those events will not be triggered when
+    the `TestClient` is instantiated. You can learn more about it [here
+    ](/events/#running-event-handlers-in-tests).
+
+
 ### Selecting the Async backend
 
 `TestClient` takes arguments `backend` (a string) and `backend_options` (a dictionary).

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -71,7 +71,6 @@ case you should use `client = TestClient(app, raise_server_exceptions=False)`.
     the `TestClient` is instantiated. You can learn more about it [here
     ](/events/#running-event-handlers-in-tests).
 
-
 ### Selecting the Async backend
 
 `TestClient` takes arguments `backend` (a string) and `backend_options` (a dictionary).


### PR DESCRIPTION
This PR adds a note to the documentation that points to the example which explains the difference between `TestClient(app) as client` and `client = TestClient(app)`. 

@Kludex [mentioned](https://github.com/encode/starlette/issues/1733#issuecomment-1173397221) in #1733 that this behavior is already explained in the [Events](https://www.starlette.io/events/#running-event-handlers-in-tests) section of the docs. 
