### PR TITLE
fix cython error after #984

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -49,7 +49,7 @@ def iscoroutinefunction_or_partial(obj: typing.Any) -> bool:  # pragma: no cover
     )
     while isinstance(obj, functools.partial):
         obj = obj.func
-    return inspect.iscoroutinefunction(obj)
+    return asyncio.iscoroutinefunction(obj)
 
 
 def request_response(func: typing.Callable) -> ASGIApp:


### PR DESCRIPTION
fix cython error after fe961dd22ca69741831d1beb5eac5de0da7d8878
```
  File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/base.py", line 46, in call_next
    raise app_exc
  File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/base.py", line 36, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/exceptions.py", line 93, in __call__
    raise exc
  File "/usr/local/lib/python3.8/dist-packages/starlette/exceptions.py", line 82, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.8/dist-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/usr/local/lib/python3.8/dist-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 670, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 266, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 68, in app
    await response(scope, receive, send)
TypeError: '_cython_3_0_0a10.coroutine' object is not callable
```

The starting point for contributions should usually be [a discussion](https://github.com/encode/starlette/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise please ensure you've discussed your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes have been okayed by the maintainers.

- [ ] Initially raised as discussion #...
