### PR TITLE
Added support for middleware as: `func(request, next)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv*/
 .python-version
 build/
 dist/
+.vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,11 @@ coverage==6.4.2
 databases[sqlite]==0.5.5
 flake8==3.9.2
 isort==5.10.1
-mypy==0.961
+mypy==0.971
 typing_extensions==4.3.0
 types-requests==2.26.3
 types-contextvars==2.4.7
-types-PyYAML==6.0.4
+types-PyYAML==6.0.11
 types-dataclasses==0.6.6
 pytest==7.1.2
 trio==0.21.0
@@ -20,7 +20,7 @@ trio==0.21.0
 greenlet==2.0.0a2; python_version >= "3.11"
 
 # Documentation
-mkdocs==1.3.0
+mkdocs==1.3.1
 mkdocs-material==8.3.9
 mkautodoc==0.1.0
 

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -186,11 +186,15 @@ class Starlette:
         path: str,
         route: typing.Callable,
         methods: typing.Optional[typing.List[str]] = None,
+        middlewares: typing.Optional[typing.Union[
+            typing.Callable[[Request, typing.Callable[[], typing.Any]], typing.Any],
+            typing.Sequence[typing.Callable[[Request, typing.Callable[[], typing.Any]], typing.Any]]
+        ]] = None,
         name: typing.Optional[str] = None,
         include_in_schema: bool = True,
     ) -> None:  # pragma: no cover
         self.router.add_route(
-            path, route, methods=methods, name=name, include_in_schema=include_in_schema
+            path, route, methods=methods, middlewares = middlewares, name=name, include_in_schema=include_in_schema
         )
 
     def add_websocket_route(
@@ -211,6 +215,10 @@ class Starlette:
         self,
         path: str,
         methods: typing.Optional[typing.List[str]] = None,
+        middlewares: typing.Optional[typing.Union[
+            typing.Callable[[Request, typing.Callable[[], typing.Any]], typing.Any],
+            typing.Sequence[typing.Callable[[Request, typing.Callable[[], typing.Any]], typing.Any]]
+        ]] = None,
         name: typing.Optional[str] = None,
         include_in_schema: bool = True,
     ) -> typing.Callable:  # pragma: nocover
@@ -231,6 +239,7 @@ class Starlette:
                 path,
                 func,
                 methods=methods,
+                middlewares = middlewares,
                 name=name,
                 include_in_schema=include_in_schema,
             )

--- a/starlette/handler.py
+++ b/starlette/handler.py
@@ -1,0 +1,69 @@
+import typing
+
+
+from starlette._utils import is_async_callable
+from starlette.concurrency import run_in_threadpool
+from starlette.requests import Request
+from starlette.types import Receive, Scope, Send
+
+
+class RouteHandler:
+
+    def __init__(
+        self,
+        handler: typing.Callable[[Request], typing.Any],
+        middlewares: typing.Optional[typing.Sequence[
+            typing.Callable[[Request, typing.Callable[[], typing.Any]], typing.Any]
+        ]] = None,
+        is_class: typing.Optional[bool] = False,
+        is_coroutine: typing.Optional[bool] = False
+    ) -> None:
+
+        self.middlewares = middlewares
+        self.handler = handler
+        self.idx = 0
+
+        self.is_class = is_class
+        self.is_coroutine = is_coroutine
+
+        
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        self.request = Request(scope, receive=receive, send=send)
+        self.scope, self.receive, self.send = scope, receive, send
+        if self.middlewares is None:
+            response = await self.call_handler()
+        else:
+            self.middleware_count = len(self.middlewares)
+            response = await self.call_middleware()
+
+        await response(self.scope, self.receive, self.send)
+
+    async def call_handler(self) -> typing.Any:
+        if not self.is_class:
+            if self.is_coroutine:
+                response = await self.handler(self.request)
+            else:
+                response = await run_in_threadpool(self.handler, self.request)
+        else:
+            assert self.scope["type"] == "http"
+            response = await self.handler(self.request)
+        return response
+
+
+    async def call_middleware(self):
+        if self.middleware_count <= self.idx:
+            return await self.call_handler()
+        
+        
+        async def next():
+            self.idx += 1
+            return await self.call_middleware()
+        
+        mid = self.middlewares[self.idx]
+        if is_async_callable(mid):
+            response = await mid(self.request, next)
+        else:
+            response = await run_in_threadpool(mid, self.request, next)
+        return response
+            
+

--- a/starlette/handler.py
+++ b/starlette/handler.py
@@ -1,0 +1,68 @@
+import typing
+
+from requests import request
+from starlette.requests import Request
+from starlette._utils import is_async_callable
+from starlette.concurrency import run_in_threadpool
+from starlette.types import Receive, Scope, Send
+
+class RouteHandler:
+
+    def __init__(
+        self,
+        handler: typing.Callable[[Request], typing.Any],
+        middlewares: typing.Optional[typing.Sequence[
+            typing.Callable[[Request, typing.Callable[[], typing.Any]], typing.Any]
+        ]] = None,
+        is_class: typing.Optional[bool] = False,
+        is_coroutine: typing.Optional[bool] = False
+    ) -> None:
+
+        self.middlewares = middlewares
+        self.handler = handler
+        self.idx = 0
+
+        self.is_class = is_class
+        self.is_coroutine = is_coroutine
+
+        
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        self.request = Request(scope, receive=receive, send=send)
+        self.scope, self.receive, self.send = scope, receive, send
+        if self.middlewares is None:
+            response = await self.call_handler()
+        else:
+            self.middleware_count = len(self.middlewares)
+            response = await self.call_middleware()
+
+        await response(self.scope, self.receive, self.send)
+
+    async def call_handler(self) -> typing.Any:
+        if not self.is_class:
+            if self.is_coroutine:
+                response = await self.handler(self.request)
+            else:
+                response = await run_in_threadpool(self.handler, self.request)
+        else:
+            assert self.scope["type"] == "http"
+            response = await self.handler(request)
+        return response
+
+
+    async def call_middleware(self):
+        if self.middleware_count <= self.idx:
+            return await self.call_handler()
+        
+        
+        async def next():
+            self.idx += 1
+            return await self.call_middleware()
+        
+        mid = self.middlewares[self.idx]
+        if is_async_callable(mid):
+            response = await mid(self.request, next)
+        else:
+            response = await run_in_threadpool(mid, self.request, next)
+        return response
+            
+

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -10,10 +10,10 @@ from contextlib import asynccontextmanager
 from enum import Enum
 
 from starlette._utils import is_async_callable
-from starlette.concurrency import run_in_threadpool
 from starlette.convertors import CONVERTOR_TYPES, Convertor
 from starlette.datastructures import URL, Headers, URLPath
 from starlette.exceptions import HTTPException
+from starlette.handler import RouteHandler
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, RedirectResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -50,24 +50,6 @@ def iscoroutinefunction_or_partial(obj: typing.Any) -> bool:  # pragma: no cover
     while isinstance(obj, functools.partial):
         obj = obj.func
     return inspect.iscoroutinefunction(obj)
-
-
-def request_response(func: typing.Callable) -> ASGIApp:
-    """
-    Takes a function or coroutine `func(request) -> response`,
-    and returns an ASGI application.
-    """
-    is_coroutine = is_async_callable(func)
-
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        request = Request(scope, receive=receive, send=send)
-        if is_coroutine:
-            response = await func(request)
-        else:
-            response = await run_in_threadpool(func, request)
-        await response(scope, receive, send)
-
-    return app
 
 
 def websocket_session(func: typing.Callable) -> ASGIApp:
@@ -202,6 +184,10 @@ class Route(BaseRoute):
         endpoint: typing.Callable,
         *,
         methods: typing.Optional[typing.List[str]] = None,
+        middlewares: typing.Optional[typing.Union[
+            typing.Callable[[Request, typing.Callable[[], typing.Any]], typing.Any],
+            typing.Sequence[typing.Callable[[Request, typing.Callable[[], typing.Any]], typing.Any]]
+        ]] = None,
         name: typing.Optional[str] = None,
         include_in_schema: bool = True,
     ) -> None:
@@ -211,17 +197,22 @@ class Route(BaseRoute):
         self.name = get_name(endpoint) if name is None else name
         self.include_in_schema = include_in_schema
 
+        if callable(middlewares):
+            self.middlewares = [middlewares]
+        else:
+            self.middlewares = middlewares
+
         endpoint_handler = endpoint
         while isinstance(endpoint_handler, functools.partial):
             endpoint_handler = endpoint_handler.func
         if inspect.isfunction(endpoint_handler) or inspect.ismethod(endpoint_handler):
             # Endpoint is function or method. Treat it as `func(request) -> response`.
-            self.app = request_response(endpoint)
+            self.app = RouteHandler(endpoint, self.middlewares, is_coroutine=is_async_callable(endpoint))
             if methods is None:
                 methods = ["GET"]
         else:
             # Endpoint is a class. Treat it as ASGI.
-            self.app = endpoint
+            self.app = RouteHandler(endpoint, self.middlewares, is_class = True)
 
         if methods is None:
             self.methods = None


### PR DESCRIPTION
[Add support for per route middleware](https://github.com/encode/starlette/discussions/1781)

## Route Middlewares
The route middlewares behaves more like an endpoint than a middleware.
These middlewares receive two parameters `request: Request` and `next: async function`

```python
async def check_admin(request: Request, next):
    if request.headers['Authorization'] == 'I am admin':
        request.isAdmin = True
        request.perms = ['a', 'b', 'c']
        return await next()
    else:
        return JSONResponse({'error':'Unauthorized access'})


async def check_perm(request: Request, next):
    if request.isAdmin and 'c' in request.perms:
        response = await next() # you can now do stuff with the response
        if type(response) == str:
            response = Response(response, media_type="text/plain")
        elif type(response) == dict:
            response = JSONResponse(response)

        return response
    else:
        return JSONResponse({'error':'Unauthorized access'})



routes = [
    Route("/admin", endpoint = admin_page, middlewares = check_admin),
    Route(
        "/admin/secret", endpoint = admin_secret,
        middlewares = [check_admin, check_perm] # Middlewares will be ran in the same order
    )
]

```