### PR TITLE
put template in scope to avoid assertion errors in other middleware

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -228,6 +228,16 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
                 assert (
                     not response_started
                 ), 'Received multiple "http.response.start" messages.'
+
+                template_info: "typing.Optional[typing.Dict[str, typing.Any]]" = (
+                    scope.get("extensions", {})
+                    .get("http.test_info", {})
+                    .get("template", None)
+                )
+                if template_info is not None:
+                    template = template_info["template"]
+                    context = template_info["context"]
+
                 raw_kwargs["version"] = 11
                 raw_kwargs["status"] = message["status"]
                 raw_kwargs["reason"] = _get_reason_phrase(message["status"])
@@ -254,9 +264,6 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
                 if not more_body:
                     raw_kwargs["body"].seek(0)
                     response_complete.set()
-            elif message["type"] == "http.response.template":
-                template = message["template"]
-                context = message["context"]
 
         try:
             with self.portal_factory() as portal:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,10 +1,17 @@
 import os
+from typing import Callable
 
 import pytest
 
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, Response
 from starlette.routing import Route
 from starlette.templating import Jinja2Templates
+from starlette.testclient import TestClient
+from starlette.types import ASGIApp
 
 
 def test_templates(tmpdir, test_client_factory):
@@ -32,3 +39,35 @@ def test_template_response_requires_request(tmpdir):
     templates = Jinja2Templates(str(tmpdir))
     with pytest.raises(ValueError):
         templates.TemplateResponse("", {})
+
+
+def test_templates_extension_response_replaced(
+    tmpdir: str, test_client_factory: Callable[[ASGIApp], TestClient]
+) -> None:
+    # if a middleware replaces the response
+    # we do not send the template debug/test info
+
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("<html>Hello, <a href='{{ url_for('homepage') }}'>world</a></html>")
+
+    templates = Jinja2Templates(directory=str(tmpdir))
+
+    async def homepage(request: Request) -> Response:
+        return templates.TemplateResponse("index.html", {"request": request})
+
+    class MiddlewareReplacesResponse(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            return HTMLResponse("<html>Bye!</html>")
+
+    app = Starlette(
+        debug=True,
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(MiddlewareReplacesResponse)],
+    )
+
+    client = test_client_factory(app)
+    response = client.get("/")
+    assert response.text == "<html>Bye!</html>"
+    assert not hasattr(response, "template")
+    assert not hasattr(response, "request")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -70,4 +70,4 @@ def test_templates_extension_response_replaced(
     response = client.get("/")
     assert response.text == "<html>Bye!</html>"
     assert not hasattr(response, "template")
-    assert not hasattr(response, "request")
+    assert not hasattr(response, "context")


### PR DESCRIPTION
I think fixes #472 

The [original concern](https://github.com/encode/starlette/issues/472#issuecomment-484144812) with this change was:

> We don't really want to pack it into the state because it's possible that some middleware might return a different response instead, in which case we'd erronously be reporting that we got a template response.

This resolves the concern by putting this info into `scope` _only if TemplateResponse is the one sending the response`.