### PR TITLE
Remove reference to `DatabaseMiddleware` in the documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -224,9 +224,6 @@ def client():
     """
     # Our fixture is created within a context manager. This ensures that
     # application startup and shutdown run for every test case.
-    #
-    # Because we've configured the DatabaseMiddleware with `rollback_on_shutdown`
-    # we'll get a complete rollback to the initial state after each test case runs.
     with TestClient(app) as test_client:
         yield test_client
 ```

--- a/docs/database.md
+++ b/docs/database.md
@@ -6,10 +6,6 @@ or use regular non-async endpoints, and integrate with [SQLAlchemy](https://www.
 In this documentation we'll demonstrate how to integrate against [the `databases` package](https://github.com/encode/databases),
 which provides SQLAlchemy core support against a range of different database drivers.
 
-**Note**: Previous versions of Starlette included a built-in `DatabaseMiddleware`.
-This option is currently still available but should be considered as pending deprecation.
-It will be removed in a future release. The legacy documentation [is available here](https://github.com/encode/starlette/blob/0.10.2/docs/database.md).
-
 Here's a complete example, that includes table definitions, configuring a `database.Database`
 instance, and a couple of endpoints that interact with the database.
 


### PR DESCRIPTION
`DatabaseMiddleware` was removed 4 years ago. :sweat_smile: 