### PR TITLE
Validating host header

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -21,8 +21,8 @@ _CovariantValueType = typing.TypeVar("_CovariantValueType", covariant=True)
 
 
 class TrustedHost(bytes):
-    def __repr__(self):
-        return f"{self.__class__.__name__}({self})"
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self!r})"
 
 
 class URL:

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -20,6 +20,11 @@ _KeyType = typing.TypeVar("_KeyType")
 _CovariantValueType = typing.TypeVar("_CovariantValueType", covariant=True)
 
 
+class TrustedHost(bytes):
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self})"
+
+
 class URL:
     def __init__(
         self,

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -22,7 +22,7 @@ _CovariantValueType = typing.TypeVar("_CovariantValueType", covariant=True)
 
 class TrustedHost(bytes):
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self!r})"
+        return f"{self.__class__.__name__}({super().__repr__()})"
 
 
 class URL:

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -33,6 +33,10 @@ class WebSocketException(Exception):
         return f"{class_name}(code={self.code!r}, reason={self.reason!r})"
 
 
+class ImproperlyConfigured(Exception):
+    pass
+
+
 __deprecated__ = "ExceptionMiddleware"
 
 

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -31,7 +31,7 @@ class TrustedHostMiddleware:
             "http",
             "websocket",
         ):  # pragma: no cover
-            self._mark_host_header_as_trusted(scope)
+            scope = self._mark_host_header_as_trusted(scope)
             await self.app(scope, receive, send)
             return
 
@@ -49,7 +49,7 @@ class TrustedHostMiddleware:
                 found_www_redirect = True
 
         if is_valid_host:
-            self._mark_host_header_as_trusted(scope)
+            scope = self._mark_host_header_as_trusted(scope)
             await self.app(scope, receive, send)
         else:
             response: Response
@@ -63,8 +63,10 @@ class TrustedHostMiddleware:
 
     def _mark_host_header_as_trusted(self, scope):
         if "headers" not in scope:
-            return
-        scope["headers"] = [
+            return scope
+        new_scope = scope.copy()
+        new_scope["headers"] = [
             (key, value if key != b"host" else TrustedHost(value))
-            for key, value in scope["headers"]
+            for key, value in new_scope["headers"]
         ]
+        return new_scope

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -1,3 +1,4 @@
+import copy
 import typing
 
 from starlette.datastructures import URL, Headers, TrustedHost
@@ -61,10 +62,10 @@ class TrustedHostMiddleware:
                 response = PlainTextResponse("Invalid host header", status_code=400)
             await response(scope, receive, send)
 
-    def _mark_host_header_as_trusted(self, scope):
+    def _mark_host_header_as_trusted(self, scope: Scope) -> Scope:
         if "headers" not in scope:
             return scope
-        new_scope = scope.copy()
+        new_scope = copy.copy(scope)
         new_scope["headers"] = [
             (key, value if key != b"host" else TrustedHost(value))
             for key, value in new_scope["headers"]

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -4,7 +4,15 @@ from http import cookies as http_cookies
 
 import anyio
 
-from starlette.datastructures import URL, Address, FormData, Headers, QueryParams, State, TrustedHost
+from starlette.datastructures import (
+    URL,
+    Address,
+    FormData,
+    Headers,
+    QueryParams,
+    State,
+    TrustedHost,
+)
 from starlette.exceptions import HTTPException, ImproperlyConfigured
 from starlette.formparsers import FormParser, MultiPartException, MultiPartParser
 from starlette.types import Message, Receive, Scope, Send

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -4,8 +4,8 @@ from http import cookies as http_cookies
 
 import anyio
 
-from starlette.datastructures import URL, Address, FormData, Headers, QueryParams, State
-from starlette.exceptions import HTTPException
+from starlette.datastructures import URL, Address, FormData, Headers, QueryParams, State, TrustedHost
+from starlette.exceptions import HTTPException, ImproperlyConfigured
 from starlette.formparsers import FormParser, MultiPartException, MultiPartParser
 from starlette.types import Message, Receive, Scope, Send
 
@@ -103,6 +103,13 @@ class HTTPConnection(typing.Mapping[str, typing.Any]):
             base_url_scope["root_path"] = base_url_scope.get(
                 "app_root_path", base_url_scope.get("root_path", "")
             )
+            for key, value in base_url_scope["headers"]:
+                if key == b"host" and not isinstance(value, TrustedHost):
+                    raise ImproperlyConfigured(
+                        "No trusted host header configuration found, you need "
+                        "to use TrustedHostMiddleware(allowed_hosts=[...]) "
+                        "if you want to generate absolute URL."
+                    )
             self._base_url = URL(scope=base_url_scope)
         return self._base_url
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -16,6 +16,7 @@ import httpx
 from anyio.streams.stapled import StapledObjectStream
 
 from starlette._utils import is_async_callable
+from starlette.datastructures import TrustedHost
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocketDisconnect
 
@@ -210,14 +211,18 @@ class _TestClientTransport(httpx.BaseTransport):
         if "host" in request.headers:
             headers: typing.List[typing.Tuple[bytes, bytes]] = []
         elif port == default_port:  # pragma: no cover
-            headers = [(b"host", host.encode())]
+            headers = [(b"host", TrustedHost(host.encode()))]
         else:  # pragma: no cover
-            headers = [(b"host", (f"{host}:{port}").encode())]
+            headers = [(b"host", TrustedHost((f"{host}:{port}").encode()))]
 
         # Include other request headers.
         headers += [
             (key.lower().encode(), value.encode())
             for key, value in request.headers.items()
+        ]
+        headers = [
+            (key, (value if key != b"host" else TrustedHost(value)))
+            for key, value in headers
         ]
 
         scope: typing.Dict[str, typing.Any]

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -451,8 +451,8 @@ async def test_trusted_host_not_configured():
         "path": "/func",
     }
 
-    async def receive() -> Message:
-        pass
+    async def receive() -> Message:  # pragma: no cover
+        assert False
 
     async def send(message):
         if message["type"] == "http.response.start":
@@ -484,8 +484,8 @@ async def test_trusted_host_wildcard():
         "path": "/func",
     }
 
-    async def receive() -> Message:
-        pass
+    async def receive() -> Message:  # pragma: no cover
+        assert False
 
     async def send(message):
         if message["type"] == "http.response.start":
@@ -515,8 +515,8 @@ async def test_trusted_host_in_allowed_hosts():
         "path": "/func",
     }
 
-    async def receive() -> Message:
-        pass
+    async def receive() -> Message:  # pragma: no cover
+        assert False
 
     async def send(message):
         if message["type"] == "http.response.start":
@@ -529,8 +529,8 @@ async def test_trusted_host_in_allowed_hosts():
 
 @pytest.mark.anyio
 async def test_trusted_host_not_in_allowed_hosts():
-    async def async_url_for(request):
-        return PlainTextResponse(request.url_for("async_url_for"))
+    async def async_url_for(request): # pragma: no cover
+        assert False
 
     app = Starlette(
         routes=[
@@ -546,8 +546,8 @@ async def test_trusted_host_not_in_allowed_hosts():
         "path": "/func",
     }
 
-    async def receive() -> Message:
-        pass
+    async def receive() -> Message:  # pragma: no cover
+        assert False
 
     async def send(message):
         if message["type"] == "http.response.start":

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -529,7 +529,7 @@ async def test_trusted_host_in_allowed_hosts():
 
 @pytest.mark.anyio
 async def test_trusted_host_not_in_allowed_hosts():
-    async def async_url_for(request): # pragma: no cover
+    async def async_url_for(request):  # pragma: no cover
         assert False
 
     app = Starlette(

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -7,7 +7,7 @@ import pytest
 from starlette import status
 from starlette.applications import Starlette
 from starlette.endpoints import HTTPEndpoint
-from starlette.exceptions import HTTPException, WebSocketException
+from starlette.exceptions import HTTPException, WebSocketException, ImproperlyConfigured
 from starlette.middleware import Middleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import JSONResponse, PlainTextResponse
@@ -429,3 +429,123 @@ def test_app_sync_gen_lifespan(test_client_factory):
         assert not cleanup_complete
     assert startup_complete
     assert cleanup_complete
+
+
+@pytest.mark.anyio
+async def test_trusted_host_not_configured():
+    async def async_url_for(request):
+        return PlainTextResponse(request.url_for("async_url_for"))
+
+    app = Starlette(
+        routes=[
+            Route("/func", endpoint=async_url_for),
+        ],
+    )
+    scope = {
+        "type": "http",
+        "headers": {
+            (b"host", b"testserver"),
+        },
+        "method": "GET",
+        "path": "/func",
+    }
+    async def receive(arg):
+        pass
+    async def send(arg):
+        if arg["type"] == "http.response.start":
+            assert arg["status"] == 500
+        elif arg["type"] == "http.response.body":
+            assert arg["body"] == b"Internal Server Error"
+
+    request = app(scope, receive, send)
+    with pytest.raises(ImproperlyConfigured):
+        await request
+
+
+@pytest.mark.anyio
+async def test_trusted_host_wildcard():
+    async def async_url_for(request):
+        return PlainTextResponse(request.url_for("async_url_for"))
+
+    app = Starlette(
+        routes=[
+            Route("/func", endpoint=async_url_for),
+        ],
+    )
+    scope = {
+        "type": "http",
+        "headers": {
+            (b"host", b"testserver"),
+        },
+        "method": "GET",
+        "path": "/func",
+    }
+    async def receive(arg):
+        pass
+    async def send(arg):
+        if arg["type"] == "http.response.start":
+            assert arg["status"] == 200
+
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=["*"])
+    request = app(scope, receive, send)
+    await request
+
+
+@pytest.mark.anyio
+async def test_trusted_host_in_allowed_hosts():
+    async def async_url_for(request):
+        return PlainTextResponse(request.url_for("async_url_for"))
+
+    app = Starlette(
+        routes=[
+            Route("/func", endpoint=async_url_for),
+        ],
+    )
+    scope = {
+        "type": "http",
+        "headers": {
+            (b"host", b"testserver"),
+        },
+        "method": "GET",
+        "path": "/func",
+    }
+    async def receive(arg):
+        pass
+    async def send(arg):
+        if arg["type"] == "http.response.start":
+            assert arg["status"] == 200
+
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=["testserver"])
+    request = app(scope, receive, send)
+    await request
+
+
+@pytest.mark.anyio
+async def test_trusted_host_not_in_allowed_hosts():
+    async def async_url_for(request):
+        return PlainTextResponse(request.url_for("async_url_for"))
+
+    app = Starlette(
+        routes=[
+            Route("/func", endpoint=async_url_for),
+        ],
+    )
+    scope = {
+        "type": "http",
+        "headers": {
+            (b"host", b"testserver"),
+        },
+        "method": "GET",
+        "path": "/func",
+    }
+    async def receive(arg):
+        pass
+    async def send(arg):
+        if arg["type"] == "http.response.start":
+            assert arg["status"] == 400
+        elif arg["type"] == "http.response.body":
+            assert arg["body"] == b"Invalid host header"
+
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=["anotherserver"])
+    request = app(scope, receive, send)
+    resp = await request

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -449,8 +449,10 @@ async def test_trusted_host_not_configured():
         "method": "GET",
         "path": "/func",
     }
+
     async def receive(message):
         pass
+
     async def send(message):
         if message["type"] == "http.response.start":
             assert message["status"] == 500
@@ -480,8 +482,10 @@ async def test_trusted_host_wildcard():
         "method": "GET",
         "path": "/func",
     }
+
     async def receive(message):
         pass
+
     async def send(message):
         if message["type"] == "http.response.start":
             assert message["status"] == 200
@@ -509,8 +513,10 @@ async def test_trusted_host_in_allowed_hosts():
         "method": "GET",
         "path": "/func",
     }
+
     async def receive(message):
         pass
+
     async def send(message):
         if message["type"] == "http.response.start":
             assert message["status"] == 200
@@ -538,8 +544,10 @@ async def test_trusted_host_not_in_allowed_hosts():
         "method": "GET",
         "path": "/func",
     }
+
     async def receive(message):
         pass
+
     async def send(message):
         if message["type"] == "http.response.start":
             assert message["status"] == 400

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -13,6 +13,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.routing import Host, Mount, Route, Router, WebSocketRoute
 from starlette.staticfiles import StaticFiles
+from starlette.types import Message
 from starlette.websockets import WebSocket
 
 
@@ -450,7 +451,7 @@ async def test_trusted_host_not_configured():
         "path": "/func",
     }
 
-    async def receive(message):
+    async def receive() -> Message:
         pass
 
     async def send(message):
@@ -483,7 +484,7 @@ async def test_trusted_host_wildcard():
         "path": "/func",
     }
 
-    async def receive(message):
+    async def receive() -> Message:
         pass
 
     async def send(message):
@@ -514,7 +515,7 @@ async def test_trusted_host_in_allowed_hosts():
         "path": "/func",
     }
 
-    async def receive(message):
+    async def receive() -> Message:
         pass
 
     async def send(message):
@@ -545,7 +546,7 @@ async def test_trusted_host_not_in_allowed_hosts():
         "path": "/func",
     }
 
-    async def receive(message):
+    async def receive() -> Message:
         pass
 
     async def send(message):

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -556,4 +556,4 @@ async def test_trusted_host_not_in_allowed_hosts():
 
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=["anotherserver"])
     request = app(scope, receive, send)
-    resp = await request
+    await request

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -7,7 +7,7 @@ import pytest
 from starlette import status
 from starlette.applications import Starlette
 from starlette.endpoints import HTTPEndpoint
-from starlette.exceptions import HTTPException, WebSocketException, ImproperlyConfigured
+from starlette.exceptions import HTTPException, ImproperlyConfigured, WebSocketException
 from starlette.middleware import Middleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import JSONResponse, PlainTextResponse
@@ -449,13 +449,13 @@ async def test_trusted_host_not_configured():
         "method": "GET",
         "path": "/func",
     }
-    async def receive(arg):
+    async def receive(message):
         pass
-    async def send(arg):
-        if arg["type"] == "http.response.start":
-            assert arg["status"] == 500
-        elif arg["type"] == "http.response.body":
-            assert arg["body"] == b"Internal Server Error"
+    async def send(message):
+        if message["type"] == "http.response.start":
+            assert message["status"] == 500
+        elif message["type"] == "http.response.body":
+            assert message["body"] == b"Internal Server Error"
 
     request = app(scope, receive, send)
     with pytest.raises(ImproperlyConfigured):
@@ -480,11 +480,11 @@ async def test_trusted_host_wildcard():
         "method": "GET",
         "path": "/func",
     }
-    async def receive(arg):
+    async def receive(message):
         pass
-    async def send(arg):
-        if arg["type"] == "http.response.start":
-            assert arg["status"] == 200
+    async def send(message):
+        if message["type"] == "http.response.start":
+            assert message["status"] == 200
 
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=["*"])
     request = app(scope, receive, send)
@@ -509,11 +509,11 @@ async def test_trusted_host_in_allowed_hosts():
         "method": "GET",
         "path": "/func",
     }
-    async def receive(arg):
+    async def receive(message):
         pass
-    async def send(arg):
-        if arg["type"] == "http.response.start":
-            assert arg["status"] == 200
+    async def send(message):
+        if message["type"] == "http.response.start":
+            assert message["status"] == 200
 
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=["testserver"])
     request = app(scope, receive, send)
@@ -538,13 +538,13 @@ async def test_trusted_host_not_in_allowed_hosts():
         "method": "GET",
         "path": "/func",
     }
-    async def receive(arg):
+    async def receive(message):
         pass
-    async def send(arg):
-        if arg["type"] == "http.response.start":
-            assert arg["status"] == 400
-        elif arg["type"] == "http.response.body":
-            assert arg["body"] == b"Invalid host header"
+    async def send(message):
+        if message["type"] == "http.response.start":
+            assert message["status"] == 400
+        elif message["type"] == "http.response.body":
+            assert message["body"] == b"Invalid host header"
 
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=["anotherserver"])
     request = app(scope, receive, send)


### PR DESCRIPTION
This is one way this issue could be addressed in Starlette. This basically change the type of the `headers` value for `host` to a marker class that inherits from `bytes` (`TrustedHost`) once the header is validated by `TrustedHostMiddleware`. This may cause compatibility issues with middlewares/applications that expects `host` to be exactly `bytes`.

There are other approaches this could have been addressed, such as:

- adding the validation marker into the `scope`, e.g. `scope["host_validated"] = "blah.com"`
- simply validating `host` against a regex pattern (must only contain characters that are allowed for a domain name), you can still be redirected to an unexpected malicious domain, but at least it would prevent most of the funkier attacks
- since raising a hard error here is necessarily backwards incompatible, maybe this should just print a warning instead for a few versions

Let me know if you think that another approach should be taken instead.

- [x] Initially raised as discussion #1854, and ticket #1855 
