### PR TITLE
Implement __repr__ for route classes

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -283,6 +283,9 @@ class Route(BaseRoute):
             and self.methods == other.methods
         )
 
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: path={self.path}, name={self.name}, methods={sorted(self.methods)}>"
+
 
 class WebSocketRoute(BaseRoute):
     def __init__(

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -348,7 +348,7 @@ class WebSocketRoute(BaseRoute):
         )
 
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}(path="{self.path}", name="{self.name}")'
+        return f"{self.__class__.__name__}(path={self.path!r}, name={self.name!r})"
 
 
 class Mount(BaseRoute):

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -285,8 +285,9 @@ class Route(BaseRoute):
 
     def __repr__(self) -> str:
         return (
-            f"<{self.__class__.__name__}: "
-            f"path={self.path}, name={self.name}, methods={sorted(self.methods or [])}>"
+            f"{self.__class__.__name__}("
+            f'path="{self.path}", name="{self.name}", '
+            f"methods={sorted(self.methods or [])})"
         )
 
 
@@ -348,7 +349,7 @@ class WebSocketRoute(BaseRoute):
         )
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: path={self.path}, name={self.name}>"
+        return f'{self.__class__.__name__}(path="{self.path}", name="{self.name}")'
 
 
 class Mount(BaseRoute):
@@ -451,8 +452,8 @@ class Mount(BaseRoute):
 
     def __repr__(self) -> str:
         return (
-            f"<{self.__class__.__name__}: "
-            f"path={self.path}, name={self.name or ''}, app={self.app}>"
+            f"{self.__class__.__name__}("
+            f'path="{self.path}", name="{self.name or ""}", app="{self.app}")'
         )
 
 
@@ -524,8 +525,8 @@ class Host(BaseRoute):
 
     def __repr__(self) -> str:
         return (
-            f"<{self.__class__.__name__}: "
-            f"host={self.host}, name={self.name or ''}, app={self.app}>"
+            f"{self.__class__.__name__}("
+            f'host="{self.host}", name="{self.name or ""}", app="{self.app}")'
         )
 
 
@@ -872,4 +873,4 @@ class Router:
     def __repr__(self) -> str:
         routes_count = len(self.routes)
         noun = "route" if routes_count == 1 else "routes"
-        return f"<{self.__class__.__name__}: {routes_count} {noun}>"
+        return f"{self.__class__.__name__}({routes_count} {noun})"

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -522,10 +522,9 @@ class Host(BaseRoute):
         )
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}("
-            f'host="{self.host}", name="{self.name or ""}", app="{self.app!r}")'
-        )
+        class_name = self.__class__.__name__
+        name = self.name or ""
+        return f"{class_name}(host={self.host!r}, name={self.name!r}, app={self.app!r})"
 
 
 _T = typing.TypeVar("_T")

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -450,10 +450,9 @@ class Mount(BaseRoute):
         )
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}("
-            f'path="{self.path}", name="{self.name or ""}", app="{self.app!r}")'
-        )
+        class_name = self.__class__.__name__
+        name = self.name or ""
+        return f"{class_name}(path={self.path!r}, name={name!r}, app={self.app!r})"
 
 
 class Host(BaseRoute):

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -284,7 +284,10 @@ class Route(BaseRoute):
         )
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: path={self.path}, name={self.name}, methods={sorted(self.methods)}>"
+        return (
+            f"<{self.__class__.__name__}: "
+            f"path={self.path}, name={self.name}, methods={sorted(self.methods or [])}>"
+        )
 
 
 class WebSocketRoute(BaseRoute):
@@ -447,7 +450,10 @@ class Mount(BaseRoute):
         )
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: path={self.path}, name={self.name or ''}, app={self.app}>"
+        return (
+            f"<{self.__class__.__name__}: "
+            f"path={self.path}, name={self.name or ''}, app={self.app}>"
+        )
 
 
 class Host(BaseRoute):
@@ -517,7 +523,10 @@ class Host(BaseRoute):
         )
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: host={self.host}, name={self.name or ''}, app={self.app}>"
+        return (
+            f"<{self.__class__.__name__}: "
+            f"host={self.host}, name={self.name or ''}, app={self.app}>"
+        )
 
 
 _T = typing.TypeVar("_T")

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -453,7 +453,7 @@ class Mount(BaseRoute):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}("
-            f'path="{self.path}", name="{self.name or ""}", app="{self.app}")'
+            f'path="{self.path}", name="{self.name or ""}", app="{self.app!r}")'
         )
 
 
@@ -526,7 +526,7 @@ class Host(BaseRoute):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}("
-            f'host="{self.host}", name="{self.name or ""}", app="{self.app}")'
+            f'host="{self.host}", name="{self.name or ""}", app="{self.app!r}")'
         )
 
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -524,7 +524,7 @@ class Host(BaseRoute):
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
         name = self.name or ""
-        return f"{class_name}(host={self.host!r}, name={self.name!r}, app={self.app!r})"
+        return f"{class_name}(host={self.host!r}, name={name!r}, app={self.app!r})"
 
 
 _T = typing.TypeVar("_T")

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -866,8 +866,3 @@ class Router:
             return func
 
         return decorator
-
-    def __repr__(self) -> str:
-        routes_count = len(self.routes)
-        noun = "route" if routes_count == 1 else "routes"
-        return f"{self.__class__.__name__}({routes_count} {noun})"

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -284,11 +284,10 @@ class Route(BaseRoute):
         )
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}("
-            f'path="{self.path}", name="{self.name}", '
-            f"methods={sorted(self.methods or [])})"
-        )
+        class_name = self.__class__.__name__
+        methods = sorted(self.methods or [])
+        path, name = self.path, self.name
+        return f"{class_name}(path={path!r}, name={name!r}, methods={methods!r})"
 
 
 class WebSocketRoute(BaseRoute):

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -344,6 +344,9 @@ class WebSocketRoute(BaseRoute):
             and self.endpoint == other.endpoint
         )
 
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: path={self.path}, name={self.name}>"
+
 
 class Mount(BaseRoute):
     def __init__(
@@ -443,6 +446,9 @@ class Mount(BaseRoute):
             and self.app == other.app
         )
 
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: path={self.path}, name={self.name or ''}, app={self.app}>"
+
 
 class Host(BaseRoute):
     def __init__(
@@ -509,6 +515,9 @@ class Host(BaseRoute):
             and self.host == other.host
             and self.app == other.app
         )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: host={self.host}, name={self.name or ''}, app={self.app}>"
 
 
 _T = typing.TypeVar("_T")
@@ -850,3 +859,8 @@ class Router:
             return func
 
         return decorator
+
+    def __repr__(self) -> str:
+        routes_count = len(self.routes)
+        noun = "route" if routes_count == 1 else "routes"
+        return f"<{self.__class__.__name__}: {routes_count} {noun}>"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -969,7 +969,7 @@ def test_route_repr_without_methods() -> None:
 
 def test_websocket_route_repr() -> None:
     route = WebSocketRoute("/ws", endpoint=websocket_endpoint)
-    assert repr(route) == 'WebSocketRoute(path="/ws", name="websocket_endpoint")'
+    assert repr(route) == "WebSocketRoute(path='/ws', name='websocket_endpoint')"
 
 
 def test_mount_repr() -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -979,7 +979,8 @@ def test_mount_repr() -> None:
             Route("/", endpoint=homepage),
         ],
     )
-    assert repr(route) == "Mount(path='/app', name='', app=Router(1 route))"
+    # test for substring because repr(Router) returns unique object ID
+    assert repr(route).startswith("Mount(path='/app', name='', app=")
 
 
 def test_mount_named_repr() -> None:
@@ -990,7 +991,8 @@ def test_mount_named_repr() -> None:
             Route("/", endpoint=homepage),
         ],
     )
-    assert repr(route) == "Mount(path='/app', name='app', app=Router(1 route))"
+    # test for substring because repr(Router) returns unique object ID
+    assert repr(route).startswith("Mount(path='/app', name='app', app=")
 
 
 def test_host_repr() -> None:
@@ -1002,7 +1004,8 @@ def test_host_repr() -> None:
             ]
         ),
     )
-    assert repr(route) == "Host(host='example.com', name='', app=Router(1 route))"
+    # test for substring because repr(Router) returns unique object ID
+    assert repr(route).startswith("Host(host='example.com', name='', app=")
 
 
 def test_host_named_repr() -> None:
@@ -1015,23 +1018,5 @@ def test_host_named_repr() -> None:
             ]
         ),
     )
-    assert repr(route) == "Host(host='example.com', name='app', app=Router(1 route))"
-
-
-def test_router_repr() -> None:
-    route = Router(
-        routes=[
-            Route("/", endpoint=homepage),
-        ]
-    )
-    assert repr(route) == "Router(1 route)"
-
-
-def test_router_repr_plural() -> None:
-    route = Router(
-        routes=[
-            Route("/", endpoint=homepage),
-            Route("/app", endpoint=homepage),
-        ]
-    )
-    assert repr(route) == "Router(2 routes)"
+    # test for substring because repr(Router) returns unique object ID
+    assert repr(route).startswith("Host(host='example.com', name='app', app=")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -957,18 +957,19 @@ def test_mounted_middleware_does_not_catch_exception(
 def test_route_repr() -> None:
     route = Route("/welcome", endpoint=homepage)
     assert (
-        repr(route) == "<Route: path=/welcome, name=homepage, methods=['GET', 'HEAD']>"
+        repr(route)
+        == "Route(path=\"/welcome\", name=\"homepage\", methods=['GET', 'HEAD'])"
     )
 
 
 def test_route_repr_without_methods() -> None:
     route = Route("/welcome", endpoint=Endpoint, methods=None)
-    assert repr(route) == "<Route: path=/welcome, name=Endpoint, methods=[]>"
+    assert repr(route) == 'Route(path="/welcome", name="Endpoint", methods=[])'
 
 
 def test_websocket_route_repr() -> None:
     route = WebSocketRoute("/ws", endpoint=websocket_endpoint)
-    assert repr(route) == "<WebSocketRoute: path=/ws, name=websocket_endpoint>"
+    assert repr(route) == 'WebSocketRoute(path="/ws", name="websocket_endpoint")'
 
 
 def test_mount_repr() -> None:
@@ -978,7 +979,7 @@ def test_mount_repr() -> None:
             Route("/", endpoint=homepage),
         ],
     )
-    assert repr(route) == "<Mount: path=/app, name=, app=<Router: 1 route>>"
+    assert repr(route) == 'Mount(path="/app", name="", app="Router(1 route)")'
 
 
 def test_mount_named_repr() -> None:
@@ -989,7 +990,7 @@ def test_mount_named_repr() -> None:
             Route("/", endpoint=homepage),
         ],
     )
-    assert repr(route) == "<Mount: path=/app, name=app, app=<Router: 1 route>>"
+    assert repr(route) == 'Mount(path="/app", name="app", app="Router(1 route)")'
 
 
 def test_host_repr() -> None:
@@ -1001,7 +1002,7 @@ def test_host_repr() -> None:
             ]
         ),
     )
-    assert repr(route) == "<Host: host=example.com, name=, app=<Router: 1 route>>"
+    assert repr(route) == 'Host(host="example.com", name="", app="Router(1 route)")'
 
 
 def test_host_named_repr() -> None:
@@ -1014,7 +1015,7 @@ def test_host_named_repr() -> None:
             ]
         ),
     )
-    assert repr(route) == "<Host: host=example.com, name=app, app=<Router: 1 route>>"
+    assert repr(route) == 'Host(host="example.com", name="app", app="Router(1 route)")'
 
 
 def test_router_repr() -> None:
@@ -1023,7 +1024,7 @@ def test_router_repr() -> None:
             Route("/", endpoint=homepage),
         ]
     )
-    assert repr(route) == "<Router: 1 route>"
+    assert repr(route) == "Router(1 route)"
 
 
 def test_router_repr_plural() -> None:
@@ -1033,4 +1034,4 @@ def test_router_repr_plural() -> None:
             Route("/app", endpoint=homepage),
         ]
     )
-    assert repr(route) == "<Router: 2 routes>"
+    assert repr(route) == "Router(2 routes)"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1015,7 +1015,7 @@ def test_host_named_repr() -> None:
             ]
         ),
     )
-    assert repr(route) == 'Host(host="example.com", name="app", app="Router(1 route)")'
+    assert repr(route) == "Host(host='example.com', name='app', app=\"Router(1 route)\")"
 
 
 def test_router_repr() -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -990,7 +990,7 @@ def test_mount_named_repr() -> None:
             Route("/", endpoint=homepage),
         ],
     )
-    assert repr(route) == 'Mount(path="/app", name="app", app="Router(1 route)")'
+    assert repr(route) == "Mount(path='/app', name='app', app=\"Router(1 route)\")"
 
 
 def test_host_repr() -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1002,7 +1002,7 @@ def test_host_repr() -> None:
             ]
         ),
     )
-    assert repr(route) == 'Host(host="example.com", name="", app="Router(1 route)")'
+    assert repr(route) == "Host(host='example.com', name='', app=\"Router(1 route)\")"
 
 
 def test_host_named_repr() -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -959,3 +959,73 @@ def test_route_repr() -> None:
     assert (
         repr(route) == "<Route: path=/welcome, name=homepage, methods=['GET', 'HEAD']>"
     )
+
+
+def test_websocket_route_repr() -> None:
+    route = WebSocketRoute("/ws", endpoint=websocket_endpoint)
+    assert repr(route) == "<WebSocketRoute: path=/ws, name=websocket_endpoint>"
+
+
+def test_mount_repr() -> None:
+    route = Mount(
+        "/app",
+        routes=[
+            Route("/", endpoint=homepage),
+        ],
+    )
+    assert repr(route) == "<Mount: path=/app, name=, app=<Router: 1 route>>"
+
+
+def test_mount_named_repr() -> None:
+    route = Mount(
+        "/app",
+        name="app",
+        routes=[
+            Route("/", endpoint=homepage),
+        ],
+    )
+    assert repr(route) == "<Mount: path=/app, name=app, app=<Router: 1 route>>"
+
+
+def test_host_repr() -> None:
+    route = Host(
+        "example.com",
+        app=Router(
+            [
+                Route("/", endpoint=homepage),
+            ]
+        ),
+    )
+    assert repr(route) == "<Host: host=example.com, name=, app=<Router: 1 route>>"
+
+
+def test_host_named_repr() -> None:
+    route = Host(
+        "example.com",
+        name="app",
+        app=Router(
+            [
+                Route("/", endpoint=homepage),
+            ]
+        ),
+    )
+    assert repr(route) == "<Host: host=example.com, name=app, app=<Router: 1 route>>"
+
+
+def test_router_repr() -> None:
+    route = Router(
+        routes=[
+            Route("/", endpoint=homepage),
+        ]
+    )
+    assert repr(route) == "<Router: 1 route>"
+
+
+def test_router_repr_plural() -> None:
+    route = Router(
+        routes=[
+            Route("/", endpoint=homepage),
+            Route("/app", endpoint=homepage),
+        ]
+    )
+    assert repr(route) == "<Router: 2 routes>"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -961,6 +961,11 @@ def test_route_repr() -> None:
     )
 
 
+def test_route_repr_without_methods() -> None:
+    route = Route("/welcome", endpoint=Endpoint, methods=None)
+    assert repr(route) == "<Route: path=/welcome, name=Endpoint, methods=[]>"
+
+
 def test_websocket_route_repr() -> None:
     route = WebSocketRoute("/ws", endpoint=websocket_endpoint)
     assert repr(route) == "<WebSocketRoute: path=/ws, name=websocket_endpoint>"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -958,13 +958,13 @@ def test_route_repr() -> None:
     route = Route("/welcome", endpoint=homepage)
     assert (
         repr(route)
-        == "Route(path=\"/welcome\", name=\"homepage\", methods=['GET', 'HEAD'])"
+        == "Route(path='/welcome', name='homepage', methods=['GET', 'HEAD'])"
     )
 
 
 def test_route_repr_without_methods() -> None:
     route = Route("/welcome", endpoint=Endpoint, methods=None)
-    assert repr(route) == 'Route(path="/welcome", name="Endpoint", methods=[])'
+    assert repr(route) == "Route(path='/welcome', name='Endpoint', methods=[])"
 
 
 def test_websocket_route_repr() -> None:
@@ -979,7 +979,7 @@ def test_mount_repr() -> None:
             Route("/", endpoint=homepage),
         ],
     )
-    assert repr(route) == "Mount(path='/app', name='', app=\"Router(1 route)\")"
+    assert repr(route) == "Mount(path='/app', name='', app=Router(1 route))"
 
 
 def test_mount_named_repr() -> None:
@@ -990,7 +990,7 @@ def test_mount_named_repr() -> None:
             Route("/", endpoint=homepage),
         ],
     )
-    assert repr(route) == "Mount(path='/app', name='app', app=\"Router(1 route)\")"
+    assert repr(route) == "Mount(path='/app', name='app', app=Router(1 route))"
 
 
 def test_host_repr() -> None:
@@ -1002,7 +1002,7 @@ def test_host_repr() -> None:
             ]
         ),
     )
-    assert repr(route) == "Host(host='example.com', name='', app=\"Router(1 route)\")"
+    assert repr(route) == "Host(host='example.com', name='', app=Router(1 route))"
 
 
 def test_host_named_repr() -> None:
@@ -1015,7 +1015,7 @@ def test_host_named_repr() -> None:
             ]
         ),
     )
-    assert repr(route) == "Host(host='example.com', name='app', app=\"Router(1 route)\")"
+    assert repr(route) == "Host(host='example.com', name='app', app=Router(1 route))"
 
 
 def test_router_repr() -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -952,3 +952,10 @@ def test_mounted_middleware_does_not_catch_exception(
     resp = client.get("/mount/err")
     assert resp.status_code == 403, resp.content
     assert "X-Mounted" not in resp.headers
+
+
+def test_route_repr() -> None:
+    route = Route("/welcome", endpoint=homepage)
+    assert (
+        repr(route) == "<Route: path=/welcome, name=homepage, methods=['GET', 'HEAD']>"
+    )

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -979,7 +979,7 @@ def test_mount_repr() -> None:
             Route("/", endpoint=homepage),
         ],
     )
-    assert repr(route) == 'Mount(path="/app", name="", app="Router(1 route)")'
+    assert repr(route) == "Mount(path='/app', name='', app=\"Router(1 route)\")"
 
 
 def test_mount_named_repr() -> None:


### PR DESCRIPTION
This little quality of life improvement makes debugging a bit easier by providing route information in the debugger:

![image](https://user-images.githubusercontent.com/635848/191740765-cc96ba10-eddb-471d-a644-26c6dee0d588.png)
