### PR TITLE
Disable TestClient follow_redirects by default

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -386,7 +386,6 @@ class TestClient(httpx.Client):
             base_url=base_url,
             headers={"user-agent": "testclient"},
             transport=transport,
-            follow_redirects=True,
             cookies=cookies,
         )
 


### PR DESCRIPTION
As discussed in https://github.com/encode/starlette/discussions/1871

In the migration of `TestClient` from `requests` to `httpx` in https://github.com/encode/starlette/pull/1376 we enabled `follow_redirects` in httpx by default. I think this was a side effect of that PR and was not on purpose.

There are two points to disable it by default:
- This was not enabled by default before, even though it's not a major breaking change, it can still break some code and it was not planned for.
- In httpx this is also disabled by default so if you have both async and sync tests, you have to also enable it for AsyncClient to get the same behaviour of TestClient.

There's a sample code in https://github.com/encode/starlette/discussions/1871 if needed.