### PR TITLE
Add missing import on `HTTPSRedirectMiddleware` docs section

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -114,6 +114,7 @@ requests to `http` or `ws` will be redirected to the secure scheme instead.
 
 ```python
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 
 routes = ...


### PR DESCRIPTION
The docs for HTTPSRedirectMiddleware [(here)](https://www.starlette.io/middleware/#:~:text=to%20False.-,HTTPSRedirectMiddleware,-Enforces%20that%20all) reference a Middleware class in the code snippet
```py
from starlette.applications import Starlette
from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware

routes = ...

middleware = [
    Middleware(HTTPSRedirectMiddleware)
]

app = Starlette(routes=routes, middleware=middleware)
```

Middleware isn't defined in that context, the required code
```py
from starlette.middleware import Middleware
```
Is present in all other examples, leading me to believe that this wasn't intentional.

----

This pull request adds an import for a class that's referenced in the code, but not imported.