### PR TITLE
Add `RuntimeError` when WebSocket endpoint function is not async

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -75,7 +75,8 @@ def websocket_session(func: typing.Callable) -> ASGIApp:
     """
     Takes a coroutine `func(session)`, and returns an ASGI application.
     """
-    # assert asyncio.iscoroutinefunction(func), "WebSocket endpoints must be async"
+    if not is_async_callable(func):
+        raise RuntimeError("WebSocket endpoints must be async.")
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         session = WebSocket(scope, receive=receive, send=send)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1020,3 +1020,11 @@ def test_host_named_repr() -> None:
     )
     # test for substring because repr(Router) returns unique object ID
     assert repr(route).startswith("Host(host='example.com', name='app', app=")
+
+
+def test_websocket_endpoint_must_be_async() -> None:
+    def websocket_endpoint(websocket: WebSocket) -> None:
+        ...
+
+    with pytest.raises(RuntimeError):
+        WebSocketRoute("/ws", endpoint=websocket_endpoint)


### PR DESCRIPTION
## Current behavior

When the WebSocket endpoint is reached, this exception is raised:

```python
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/protocols/websockets/websockets_impl.py", line 230, in run_asgi
    result = await self.app(self.scope, self.asgi_receive, self.asgi_send)
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/home/marcelo/Development/encode/starlette/./starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/marcelo/Development/encode/starlette/./starlette/middleware/errors.py", line 149, in __call__
    await self.app(scope, receive, send)
  File "/home/marcelo/Development/encode/starlette/./starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/home/marcelo/Development/encode/starlette/./starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/home/marcelo/Development/encode/starlette/./starlette/routing.py", line 706, in __call__
    await route.handle(scope, receive, send)
  File "/home/marcelo/Development/encode/starlette/./starlette/routing.py", line 341, in handle
    await self.app(scope, receive, send)
  File "/home/marcelo/Development/encode/starlette/./starlette/routing.py", line 82, in app
    await func(session)
TypeError: object NoneType can't be used in 'await' expression
```

## Alternative

- Remove the comment.