### PR TITLE
Ignore `type: ignore` without code error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ disallow_untyped_defs = True
 ignore_missing_imports = True
 no_implicit_optional = True
 show_error_codes = True
+enable_error_code = ignore-without-code
 
 [mypy-starlette.testclient]
 no_implicit_optional = False

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -410,7 +410,7 @@ class QueryParams(ImmutableMultiDict[str, str]):
                 parse_qsl(value.decode("latin-1"), keep_blank_values=True), **kwargs
             )
         else:
-            super().__init__(*args, **kwargs)  # type: ignore
+            super().__init__(*args, **kwargs)  # type: ignore[arg-type]
         self._list = [(str(k), str(v)) for k, v in self._list]
         self._dict = {str(k): str(v) for k, v in self._dict.items()}
 
@@ -443,7 +443,7 @@ class UploadFile:
         self.filename = filename
         self.content_type = content_type
         if file is None:
-            self.file = tempfile.SpooledTemporaryFile(max_size=self.spool_max_size)  # type: ignore  # noqa: E501
+            self.file = tempfile.SpooledTemporaryFile(max_size=self.spool_max_size)  # type: ignore[assignment]  # noqa: E501
         else:
             self.file = file
         self.headers = headers or Headers()
@@ -528,13 +528,13 @@ class Headers(typing.Mapping[str, str]):
     def raw(self) -> typing.List[typing.Tuple[bytes, bytes]]:
         return list(self._list)
 
-    def keys(self) -> typing.List[str]:  # type: ignore
+    def keys(self) -> typing.List[str]:  # type: ignore[override]
         return [key.decode("latin-1") for key, value in self._list]
 
-    def values(self) -> typing.List[str]:  # type: ignore
+    def values(self) -> typing.List[str]:  # type: ignore[override]
         return [value.decode("latin-1") for key, value in self._list]
 
-    def items(self) -> typing.List[typing.Tuple[str, str]]:  # type: ignore
+    def items(self) -> typing.List[typing.Tuple[str, str]]:  # type: ignore[override]
         return [
             (key.decode("latin-1"), value.decode("latin-1"))
             for key, value in self._list

--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -198,7 +198,9 @@ class ServerErrorMiddleware:
 
     def generate_frame_html(self, frame: inspect.FrameInfo, is_collapsed: bool) -> str:
         code_context = "".join(
-            self.format_line(index, line, frame.lineno, frame.index)  # type: ignore
+            self.format_line(
+                index, line, frame.lineno, frame.index  # type: ignore[arg-type]
+            )
             for index, line in enumerate(frame.code_context or [])
         )
 

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -23,7 +23,7 @@ else:  # pragma: no cover
     from typing_extensions import Literal
 
 # Workaround for adding samesite support to pre 3.8 python
-http.cookies.Morsel._reserved["samesite"] = "SameSite"  # type: ignore
+http.cookies.Morsel._reserved["samesite"] = "SameSite"  # type: ignore[attr-defined]
 
 
 # Compatibility wrapper for `mimetypes.guess_type` to support `os.PathLike` on <py3.8

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -9,7 +9,7 @@ from starlette.routing import BaseRoute, Mount, Route
 try:
     import yaml
 except ImportError:  # pragma: nocover
-    yaml = None  # type: ignore
+    yaml = None  # type: ignore[assignment]
 
 
 class OpenAPIResponse(Response):

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -17,7 +17,7 @@ try:
     else:  # pragma: nocover
         pass_context = jinja2.contextfunction  # type: ignore[attr-defined]
 except ImportError:  # pragma: nocover
-    jinja2 = None  # type: ignore
+    jinja2 = None  # type: ignore[assignment]
 
 
 class _TemplateResponse(Response):

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -201,9 +201,9 @@ def test_mutable_headers_update_dict():
 def test_mutable_headers_merge_not_mapping():
     h = MutableHeaders()
     with pytest.raises(TypeError):
-        h |= {"not_mapping"}  # type: ignore
+        h |= {"not_mapping"}  # type: ignore[arg-type]
     with pytest.raises(TypeError):
-        h | {"not_mapping"}  # type: ignore
+        h | {"not_mapping"}  # type: ignore[operator]
 
 
 def test_headers_mutablecopy():


### PR DESCRIPTION
Do we have an agreement that this is an improvement? :thinking: 