### PR TITLE
Remove unneeded installation on `install` script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -16,4 +16,3 @@ else
 fi
 
 "$PIP" install -r "$REQUIREMENTS"
-"$PIP" install -e .


### PR DESCRIPTION
This is not needed because our `requirements.txt` already install with `-e .`.

This also follows the `uvicorn` install script: https://github.com/encode/uvicorn/blob/master/scripts/install