### PR TITLE
Deprecate `BaseHTTPMiddleware`

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -182,6 +182,11 @@ The following arguments are supported:
 
 ## BaseHTTPMiddleware
 
+!!! warning
+    The `BaseHTTPMiddleware` is deprecated since version `0.22.0`.
+
+    Please refer to [Pure ASGI Middleware](#pure-asgi-middleware) for the recommended way to implement middleware.
+
 An abstract class that allows you to write ASGI middleware against a request/response
 interface.
 
@@ -569,7 +574,7 @@ import time
 class MonitoringMiddleware:
     def __init__(self, app):
         self.app = app
-    
+
     async def __call__(self, scope, receive, send):
         start = time.time()
         try:

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -1,4 +1,5 @@
 import typing
+import warnings
 
 import anyio
 
@@ -11,6 +12,13 @@ DispatchFunction = typing.Callable[
     [Request, RequestResponseEndpoint], typing.Awaitable[Response]
 ]
 T = typing.TypeVar("T")
+
+warnings.warn(
+    "The 'BaseHTTPMiddleware' is deprecated, and will be removed in version 1.0.0. "
+    "Refer to https://www.starlette.io/middleware/#pure-asgi-middleware to learn how to create middlewares.\n"  # noqa: E501
+    "If you need help, please create a discussion on: https://github.com/encode/starlette/discussions.",  # noqa: E501
+    DeprecationWarning,
+)
 
 
 class BaseHTTPMiddleware:


### PR DESCRIPTION
- Closes https://github.com/encode/starlette/issues/1678

## Description

To be continued... Here you'll see an explanation about this decision.

## Documentation

![image](https://user-images.githubusercontent.com/7353520/194150988-3e9289c7-971e-4316-8cd6-32898a980549.png)