### PR TITLE
Bypass GZipMiddleware when response includes `Content-Encoding`

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -180,6 +180,8 @@ The following arguments are supported:
 
 * `minimum_size` - Do not GZip responses that are smaller than this minimum size in bytes. Defaults to `500`.
 
+The middleware won't GZip responses that already have a `Content-Encoding` set, to prevent them from being encoded twice.
+
 ## BaseHTTPMiddleware
 
 An abstract class that allows you to write ASGI middleware against a request/response

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -86,7 +86,7 @@ def test_gzip_ignored_for_responses_with_encoding_set(test_client_factory):
 
         streaming = generator(bytes=b"x" * 400, count=10)
         return StreamingResponse(
-            streaming, status_code=200, headers={"Content-Encoding": "brotli"}
+            streaming, status_code=200, headers={"Content-Encoding": "br"}
         )
 
     app = Starlette(
@@ -95,8 +95,8 @@ def test_gzip_ignored_for_responses_with_encoding_set(test_client_factory):
     )
 
     client = test_client_factory(app)
-    response = client.get("/", headers={"accept-encoding": "gzip"})
+    response = client.get("/", headers={"accept-encoding": "gzip, br"})
     assert response.status_code == 200
     assert response.text == "x" * 4000
-    assert response.headers["Content-Encoding"] == "brotli"
+    assert response.headers["Content-Encoding"] == "br"
     assert "Content-Length" not in response.headers

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -76,3 +76,27 @@ def test_gzip_streaming_response(test_client_factory):
     assert response.text == "x" * 4000
     assert response.headers["Content-Encoding"] == "gzip"
     assert "Content-Length" not in response.headers
+
+
+def test_gzip_ignored_for_responses_with_encoding_set(test_client_factory):
+    def homepage(request):
+        async def generator(bytes, count):
+            for index in range(count):
+                yield bytes
+
+        streaming = generator(bytes=b"x" * 400, count=10)
+        return StreamingResponse(
+            streaming, status_code=200, headers={"Content-Encoding": "brotli"}
+        )
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(GZipMiddleware)],
+    )
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.text == "x" * 4000
+    assert response.headers["Content-Encoding"] == "brotli"
+    assert "Content-Length" not in response.headers


### PR DESCRIPTION
This is a suggestion for `GZipMiddleware` to not encode responses that already include the `Content-Encoding` header. It is a minor issue for me when using the middleware in an application that includes regular routes and _proxies_ based on this:

<https://gist.github.com/tomchristie/5765e10a90a41c7e57470e2dc700f9db>

If the proxied response already has an encoding set, starlette's middleware double-encodes the response.

I can get around it by writing the middleware on my own, such as shown in this PR, but I thought you might want to consider it also. I'm basically imitating [Django's GZipMiddleware](https://docs.djangoproject.com/en/4.1/ref/middleware/#module-django.middleware.gzip) which claims to have this behaviour.