### PR TITLE
Add edit button on documentation pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,7 @@ theme:
 
 repo_name: encode/starlette
 repo_url: https://github.com/encode/starlette
-edit_uri: ""
+edit_uri: https://github.com/encode/starlette/tree/master/docs
 
 nav:
   - Introduction: 'index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ theme:
 
 repo_name: encode/starlette
 repo_url: https://github.com/encode/starlette
-edit_uri: https://github.com/encode/starlette/tree/master/docs
+edit_uri: edit/master/docs/
 
 nav:
   - Introduction: 'index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ theme:
       toggle:
         icon: 'material/lightbulb-outline'
         name: 'Switch to light mode'
+  icon:
+    repo: fontawesome/brands/github
 
 repo_name: encode/starlette
 repo_url: https://github.com/encode/starlette


### PR DESCRIPTION
This PR fixes #1896 by adding the edit button on documentation page .I have also changed the logo on top of docs page from a `git` logo to a `github` logo as that is a more accurate representation of the github page it leads to.

Edit by @Kludex:
- Closes  #1896