### PR TITLE
Ignore Trio excepthook warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ typing_extensions==4.4.0
 types-contextvars==2.4.7
 types-PyYAML==6.0.12
 types-dataclasses==0.6.6
-pytest==7.1.3
+pytest==7.2.0
 trio==0.21.0
 
 # Documentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ filterwarnings=
     ignore: Use 'content=<...>' to upload raw bytes/text content.:DeprecationWarning
     ignore: The `allow_redirects` argument is deprecated. Use `follow_redirects` instead.:DeprecationWarning
     ignore: 'cgi' is deprecated and slated for removal in Python 3\.13:DeprecationWarning
+    ignore: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.:RuntimeWarning
 
 [coverage:run]
 source_pkgs = starlette, tests


### PR DESCRIPTION
pytest 7.2.0 introduced the exceptiongroup backport as a dependency for Python < 3.11, which uses sys.excepthook to format ExceptionGroup exceptions.

But Trio 0.21.0 also uses sys.excepthook to format MultiError exceptions (the ancestor of ExceptionGroup). However, since there can only be one exception hook, Trio aborts when it finds the one set by the exceptiongroup backport and raises a warning.

There are three ways to fix this.

 1. Upgrade to Trio 0.22.0 which also uses the exceptiongroup backport. But AnyIO does not support Trio 0.22.0 just yet.
 2. Import `trio` before `pytest` in test_testclient.py, since exceptiongroup does not warn when an exceptiongroup exists. However, messing with isort `--top` option sounds confusing.
 3. Ignore this warning. Starlette does not use MultiError so it's harmless. This is what this commit does.

This was discussed here: https://gitter.im/python-trio/general?at=63617d79bad3c737520305af

Closes #1926 