### PR TITLE
♻️ Add compatibility with the next version of AnyIO

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -12,6 +12,7 @@ from types import GeneratorType
 from urllib.parse import unquote, urljoin
 
 import anyio
+import anyio.from_thread
 import httpx
 from anyio.streams.stapled import StapledObjectStream
 
@@ -398,7 +399,9 @@ class TestClient(httpx.Client):
         if self.portal is not None:
             yield self.portal
         else:
-            with anyio.start_blocking_portal(**self.async_backend) as portal:
+            with anyio.from_thread.start_blocking_portal(
+                **self.async_backend
+            ) as portal:
                 yield portal
 
     def _choose_redirect_arg(
@@ -714,7 +717,7 @@ class TestClient(httpx.Client):
     def __enter__(self) -> "TestClient":
         with contextlib.ExitStack() as stack:
             self.portal = portal = stack.enter_context(
-                anyio.start_blocking_portal(**self.async_backend)
+                anyio.from_thread.start_blocking_portal(**self.async_backend)
             )
 
             @stack.callback


### PR DESCRIPTION
♻️ Add compatibility with the next version of AnyIO

The next version of AnyIO (https://github.com/agronholm/anyio/commit/9f97cd7bb5f59f79f1bcda64230ab2127e79935a), not released yet, doesn't export `start_blocking_portal` from the top level of the package, it has to be imported from directly where it is declared, in `from_thread`.

This keeps compatibility with the current version but adds compatibility with the next (current main branch in AnyIO's repo).