### PR TITLE
Bugfix of regex at FloatConvertor

### DIFF
--- a/starlette/convertors.py
+++ b/starlette/convertors.py
@@ -51,7 +51,7 @@ class IntegerConvertor(Convertor):
 
 
 class FloatConvertor(Convertor):
-    regex = "[0-9]+(.[0-9]+)?"
+    regex = "[0-9]+(\.[0-9]+)?"
 
     def convert(self, value: str) -> float:
         return float(value)


### PR DESCRIPTION
1. ValueError: could not convert string to float if path parameters '/path/{number:float}' like /path/1-1, /path/2+2, /path/3^3

2. Bug: A dot in regex of class FloatConvetor is also a metacharacter, it is used to match any character.

3. Fix: I need to add a backslash escape the dot, so regex = "[0-9]+(\\.[0-9]+)?"

The starting point for contributions should usually be [a discussion](https://github.com/encode/starlette/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise please ensure you've discussed your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes have been okayed by the maintainers.

- [ ] Initially raised as discussion #...
