### PR TITLE
Bugfix of regex at FloatConvertor (version 2)

### DIFF
--- a/starlette/convertors.py
+++ b/starlette/convertors.py
@@ -51,7 +51,7 @@ class IntegerConvertor(Convertor):
 
 
 class FloatConvertor(Convertor):
-    regex = "[0-9]+(.[0-9]+)?"
+    regex = r"[0-9]+(\.[0-9]+)?"
 
     def convert(self, value: str) -> float:
         return float(value)


### PR DESCRIPTION
For passing your checks of https://github.com/encode/starlette/pull/1942 A correct statement is: regex = r"[0-9]+(\\.[0-9]+)?" Reference: https://www.flake8rules.com/rules/W605.html

I have no problem of correction without 'r' prefix directly at /site-packages/starlette/convertors.py of my computer. Having submitted last pull-request #1942, I realized to add a 'r' prefix to pass your tests.