### PR TITLE
Fix TestClient for extra unquote in query parameters (#1952)

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -196,10 +196,10 @@ class _TestClientTransport(httpx.BaseTransport):
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         scheme = request.url.scheme
-        netloc = unquote(request.url.netloc.decode(encoding="ascii"))
+        netloc = request.url.netloc.decode(encoding="ascii")
         path = request.url.path
         raw_path = request.url.raw_path
-        query = unquote(request.url.query.decode(encoding="ascii"))
+        query = request.url.query.decode(encoding="ascii")
 
         default_port = {"http": 80, "ws": 80, "https": 443, "wss": 443}[scheme]
 

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -242,12 +242,12 @@ def test_client(test_client_factory):
     assert response.json() == {"host": "testclient", "port": 50000}
 
 
-def test_query_params(test_client_factory):
+@pytest.mark.parametrize("param", ("2020-07-14T00:00:00+00:00", "España", "voilà"))
+def test_query_params(test_client_factory, param: str):
     def homepage(request):
         return Response(request.query_params["param"])
 
     app = Starlette(routes=[Route("/", endpoint=homepage)])
     client = test_client_factory(app)
-    for param in ("2020-07-14T00:00:00+00:00", "España", "voilà"):
-        response = client.get("/", params={"param": param})
-        assert response.text == param
+    response = client.get("/", params={"param": param})
+    assert response.text == param

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -9,7 +9,7 @@ import trio.lowlevel
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
@@ -240,3 +240,14 @@ def test_client(test_client_factory):
     client = test_client_factory(app)
     response = client.get("/")
     assert response.json() == {"host": "testclient", "port": 50000}
+
+
+def test_query_params(test_client_factory):
+    def homepage(request):
+        return Response(request.query_params["param"])
+
+    app = Starlette(routes=[Route("/", endpoint=homepage)])
+    client = test_client_factory(app)
+    for param in ("2020-07-14T00:00:00+00:00", "España", "voilà"):
+        response = client.get("/", params={"param": param})
+        assert response.text == param


### PR DESCRIPTION
The starting point for contributions should usually be [a discussion](https://github.com/encode/starlette/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise please ensure you've discussed your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes have been okayed by the maintainers.

- [x] Initially raised as discussion #1946 
- [x] Evolved to issue #1952  
