### PR TITLE
middleware/wsgi: remove unnecessary threads

### DIFF
--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -95,7 +95,7 @@ class WSGIResponder:
         async with anyio.create_task_group() as task_group:
             task_group.start_soon(self.sender, send)
             async with self.stream_send:
-                await anyio.to_thread.run_sync(self.wsgi, environ, self.start_response)
+                self.wsgi(environ, self.start_response)
         if self.exc_info is not None:
             raise self.exc_info[0].with_traceback(self.exc_info[1], self.exc_info[2])
 
@@ -119,22 +119,18 @@ class WSGIResponder:
                 (name.strip().encode("ascii").lower(), value.strip().encode("ascii"))
                 for name, value in response_headers
             ]
-            anyio.from_thread.run(
-                self.stream_send.send,
+            self.stream_send.send_nowait(
                 {
                     "type": "http.response.start",
                     "status": status_code,
                     "headers": headers,
-                },
+                }
             )
 
     def wsgi(self, environ: dict, start_response: typing.Callable) -> None:
         for chunk in self.app(environ, start_response):
-            anyio.from_thread.run(
-                self.stream_send.send,
-                {"type": "http.response.body", "body": chunk, "more_body": True},
+            self.stream_send.send_nowait(
+                {"type": "http.response.body", "body": chunk, "more_body": True}
             )
 
-        anyio.from_thread.run(
-            self.stream_send.send, {"type": "http.response.body", "body": b""}
-        )
+        self.stream_send.send_nowait({"type": "http.response.body", "body": b""})


### PR DESCRIPTION
With the addition of `send_nowait()` to memory object streams in anyio 3.0, there are some extraneous threads that can be removed as the underlying stream is configured to buffer to infinity and this will never block.

I didn't start a discussion, just noticed that this can be simplified a bit.  I bet it'd improve performance a bit.

---

The starting point for contributions should usually be [a discussion](https://github.com/encode/starlette/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise please ensure you've discussed your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes have been okayed by the maintainers.

- [ ] Initially raised as discussion #...
