### PR TITLE
Use `MiddlewareType` as a type hint for middlewares

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -134,7 +134,9 @@ class Starlette:
     ) -> None:  # pragma: no cover
         self.router.host(host, app=app, name=name)
 
-    def add_middleware(self, middleware_class: MiddlewareType, **options: typing.Any) -> None:
+    def add_middleware(
+        self, middleware_class: MiddlewareType, **options: typing.Any
+    ) -> None:
         if self.middleware_stack is not None:  # pragma: no cover
             raise RuntimeError("Cannot add middleware after an application has started")
         self.user_middleware.insert(0, Middleware(middleware_class, **options))

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -134,9 +134,9 @@ class Starlette:
     ) -> None:  # pragma: no cover
         self.router.host(host, app=app, name=name)
 
-    def add_middleware(
-        self, middleware_class: MiddlewareType, **options: typing.Any
-    ) -> None:  # pragma: no cover
+    def add_middleware(self, middleware_class: type, **options: typing.Any) -> None:
+        if self.middleware_stack is not None:  # pragma: no cover
+            raise RuntimeError("Cannot add middleware after an application has started")
         self.user_middleware.insert(0, Middleware(middleware_class, **options))
 
     def add_exception_handler(

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -9,7 +9,7 @@ from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import BaseRoute, Router
-from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send
+from starlette.types import ASGIApp, Lifespan, MiddlewareType, Receive, Scope, Send
 
 AppType = typing.TypeVar("AppType", bound="Starlette")
 
@@ -135,7 +135,7 @@ class Starlette:
         self.router.host(host, app=app, name=name)
 
     def add_middleware(
-        self, middleware_class: typing.Type[ASGIApp], **options: typing.Any
+        self, middleware_class: MiddlewareType, **options: typing.Any
     ) -> None:  # pragma: no cover
         self.user_middleware.insert(0, Middleware(middleware_class, **options))
 

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -134,9 +134,9 @@ class Starlette:
     ) -> None:  # pragma: no cover
         self.router.host(host, app=app, name=name)
 
-    def add_middleware(self, middleware_class: type, **options: typing.Any) -> None:
-        if self.middleware_stack is not None:  # pragma: no cover
-            raise RuntimeError("Cannot add middleware after an application has started")
+    def add_middleware(
+        self, middleware_class: typing.Type[ASGIApp], **options: typing.Any
+    ) -> None:  # pragma: no cover
         self.user_middleware.insert(0, Middleware(middleware_class, **options))
 
     def add_exception_handler(

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -134,7 +134,7 @@ class Starlette:
     ) -> None:  # pragma: no cover
         self.router.host(host, app=app, name=name)
 
-    def add_middleware(self, middleware_class: type, **options: typing.Any) -> None:
+    def add_middleware(self, middleware_class: MiddlewareType, **options: typing.Any) -> None:
         if self.middleware_stack is not None:  # pragma: no cover
             raise RuntimeError("Cannot add middleware after an application has started")
         self.user_middleware.insert(0, Middleware(middleware_class, **options))

--- a/starlette/middleware/__init__.py
+++ b/starlette/middleware/__init__.py
@@ -1,8 +1,10 @@
 import typing
 
+from starlette.types import ASGIApp
+
 
 class Middleware:
-    def __init__(self, cls: type, **options: typing.Any) -> None:
+    def __init__(self, cls: typing.Type[ASGIApp], **options: typing.Any) -> None:
         self.cls = cls
         self.options = options
 

--- a/starlette/middleware/__init__.py
+++ b/starlette/middleware/__init__.py
@@ -1,10 +1,10 @@
 import typing
 
-from starlette.types import ASGIApp
+from starlette.types import MiddlewareType
 
 
 class Middleware:
-    def __init__(self, cls: typing.Type[ASGIApp], **options: typing.Any) -> None:
+    def __init__(self, cls: MiddlewareType, **options: typing.Any) -> None:
         self.cls = cls
         self.options = options
 

--- a/starlette/types.py
+++ b/starlette/types.py
@@ -1,4 +1,10 @@
+import sys
 import typing
+
+if sys.version_info < (3, 8):  # pragma: no cover
+    from typing_extensions import Protocol
+else:  # pragma: no cover
+    from typing import Protocol
 
 AppType = typing.TypeVar("AppType")
 
@@ -15,3 +21,15 @@ StatefulLifespan = typing.Callable[
     [AppType], typing.AsyncContextManager[typing.Mapping[str, typing.Any]]
 ]
 Lifespan = typing.Union[StatelessLifespan[AppType], StatefulLifespan[AppType]]
+
+
+# This callable protocol can both be used to represent a function returning
+# an ASGIApp, or a class with an __init__ method matching this __call__ signature
+# and a __call__ method matching the ASGIApp signature.
+class MiddlewareType(Protocol):
+    __name__: str
+
+    def __call__(
+        self, *args: typing.Any, **kwargs: typing.Any
+    ) -> ASGIApp:  # pragma: no cover
+        ...

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1,4 +1,5 @@
 import contextvars
+import typing
 from contextlib import AsyncExitStack
 
 import anyio
@@ -193,7 +194,7 @@ class CustomMiddlewareUsingBaseHTTPMiddleware(BaseHTTPMiddleware):
         ),
     ],
 )
-def test_contextvars(test_client_factory, middleware_cls: type):
+def test_contextvars(test_client_factory, middleware_cls: typing.Type[ASGIApp]):
     # this has to be an async endpoint because Starlette calls run_in_threadpool
     # on sync endpoints which has it's own set of peculiarities w.r.t propagating
     # contextvars (it propagates them forwards but not backwards)

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1,5 +1,4 @@
 import contextvars
-import typing
 from contextlib import AsyncExitStack
 
 import anyio
@@ -11,7 +10,7 @@ from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import PlainTextResponse, StreamingResponse
 from starlette.routing import Route, WebSocketRoute
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, MiddlewareType, Receive, Scope, Send
 
 
 class CustomMiddleware(BaseHTTPMiddleware):
@@ -194,7 +193,7 @@ class CustomMiddlewareUsingBaseHTTPMiddleware(BaseHTTPMiddleware):
         ),
     ],
 )
-def test_contextvars(test_client_factory, middleware_cls: typing.Type[ASGIApp]):
+def test_contextvars(test_client_factory, middleware_cls: MiddlewareType):
     # this has to be an async endpoint because Starlette calls run_in_threadpool
     # on sync endpoints which has it's own set of peculiarities w.r.t propagating
     # contextvars (it propagates them forwards but not backwards)

--- a/tests/middleware/test_middleware.py
+++ b/tests/middleware/test_middleware.py
@@ -1,8 +1,10 @@
 from starlette.middleware import Middleware
+from starlette.types import Receive, Scope, Send
 
 
 class CustomMiddleware:
-    pass
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        return None  # pragma: no cover
 
 
 def test_middleware_repr():


### PR DESCRIPTION
This might brake things in other repositories (fastapi for instance), but this improves type safety in my opinion.