### PR TITLE
Add Config.env_prefix option

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -40,9 +40,9 @@ ALLOWED_HOSTS=127.0.0.1, localhost
 
 The order in which configuration values are read is:
 
--   From an environment variable.
--   From the ".env" file.
--   The default value given in `config`.
+* From an environment variable.
+* From the ".env" file.
+* The default value given in `config`.
 
 If none of those match, then `config(...)` will raise an error.
 
@@ -100,7 +100,7 @@ keys in the environment.
 Rather than reading or writing from `os.environ`, you should use Starlette's
 `environ` instance. This instance is a mapping onto the standard `os.environ`
 that additionally protects you by raising an error if any environment variable
-is set _after_ the point that it has already been read by the configuration.
+is set *after* the point that it has already been read by the configuration.
 
 If you're using `pytest`, then you can setup any initial environment in
 `tests/conftest.py`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -40,9 +40,9 @@ ALLOWED_HOSTS=127.0.0.1, localhost
 
 The order in which configuration values are read is:
 
-* From an environment variable.
-* From the ".env" file.
-* The default value given in `config`.
+-   From an environment variable.
+-   From the ".env" file.
+-   The default value given in `config`.
 
 If none of those match, then `config(...)` will raise an error.
 
@@ -100,7 +100,7 @@ keys in the environment.
 Rather than reading or writing from `os.environ`, you should use Starlette's
 `environ` instance. This instance is a mapping onto the standard `os.environ`
 that additionally protects you by raising an error if any environment variable
-is set *after* the point that it has already been read by the configuration.
+is set _after_ the point that it has already been read by the configuration.
 
 If you're using `pytest`, then you can setup any initial environment in
 `tests/conftest.py`.
@@ -111,6 +111,25 @@ If you're using `pytest`, then you can setup any initial environment in
 from starlette.config import environ
 
 environ['TESTING'] = 'TRUE'
+```
+
+## Reading prefixed environment variables
+
+You can namespace the environment variables by setting `env_prefix` argument.
+
+**myproject/settings.py**:
+
+```python
+import os
+from starlette.config import Config
+
+os.environ['APP_DEBUG'] = 'yes'
+os.environ['ENVIRONMENT'] = 'dev'
+
+config = Config(env_prefix='APP_')
+
+DEBUG = config('DEBUG') # lookups APP_DEBUG, returns "yes"
+DEBUG = config('ENVIRONMENT') # lookups APP_ENVIRONMENT, raises KeyError as variable is not defined
 ```
 
 ## A full example

--- a/docs/config.md
+++ b/docs/config.md
@@ -129,7 +129,7 @@ os.environ['ENVIRONMENT'] = 'dev'
 config = Config(env_prefix='APP_')
 
 DEBUG = config('DEBUG') # lookups APP_DEBUG, returns "yes"
-DEBUG = config('ENVIRONMENT') # lookups APP_ENVIRONMENT, raises KeyError as variable is not defined
+ENVIRONMENT = config('ENVIRONMENT') # lookups APP_ENVIRONMENT, raises KeyError as variable is not defined
 ```
 
 ## A full example

--- a/docs/config.md
+++ b/docs/config.md
@@ -117,9 +117,7 @@ environ['TESTING'] = 'TRUE'
 
 You can namespace the environment variables by setting `env_prefix` argument.
 
-**myproject/settings.py**:
-
-```python
+```python title="myproject/settings.py"
 import os
 from starlette.config import Config
 

--- a/starlette/config.py
+++ b/starlette/config.py
@@ -54,8 +54,10 @@ class Config:
         self,
         env_file: typing.Optional[typing.Union[str, Path]] = None,
         environ: typing.Mapping[str, str] = environ,
+        env_prefix: str = "",
     ) -> None:
         self.environ = environ
+        self.env_prefix = env_prefix
         self.file_values: typing.Dict[str, str] = {}
         if env_file is not None and os.path.isfile(env_file):
             self.file_values = self._read_file(env_file)
@@ -103,6 +105,7 @@ class Config:
         cast: typing.Optional[typing.Callable] = None,
         default: typing.Any = undefined,
     ) -> typing.Any:
+        key = self.env_prefix + key
         if key in self.environ:
             value = self.environ[key]
             return self._perform_cast(key, value, cast)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -127,3 +127,13 @@ def test_environ():
     environ = Environ()
     assert list(iter(environ)) == list(iter(os.environ))
     assert len(environ) == len(os.environ)
+
+
+def test_config_with_env_prefix(tmpdir, monkeypatch):
+    config = Config(
+        environ={"APP_DEBUG": "value", "ENVIRONMENT": "dev"}, env_prefix="APP_"
+    )
+    assert config.get("DEBUG") == "value"
+
+    with pytest.raises(KeyError):
+        assert config.get("ENVIRONMENT") == "value"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,4 +136,4 @@ def test_config_with_env_prefix(tmpdir, monkeypatch):
     assert config.get("DEBUG") == "value"
 
     with pytest.raises(KeyError):
-        assert config.get("ENVIRONMENT") == "value"
+        config.get("ENVIRONMENT")


### PR DESCRIPTION
This PR adds `Config.env_prefix` argument.

```python
import os
from starlette.config import Config

os.environ['APP_DEBUG'] = 'yes'
os.environ['ENVIRONMENT'] = 'dev'

config = Config(env_prefix='APP_')

DEBUG = config('DEBUG') # lookups APP_DEBUG, returns "yes"
ENVIRONMENT = config('ENVIRONMENT') # lookups APP_ENVIRONMENT, raises KeyError as variable is not defined
```