### PR TITLE
Lazily build middleware stack

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -74,7 +74,7 @@ class Starlette:
             {} if exception_handlers is None else dict(exception_handlers)
         )
         self.user_middleware = [] if middleware is None else list(middleware)
-        self.middleware_stack = self.build_middleware_stack()
+        self.middleware_stack = None
 
     def build_middleware_stack(self) -> ASGIApp:
         debug = self.debug
@@ -115,13 +115,14 @@ class Starlette:
     @debug.setter
     def debug(self, value: bool) -> None:
         self._debug = value
-        self.middleware_stack = self.build_middleware_stack()
 
     def url_path_for(self, name: str, **path_params: typing.Any) -> URLPath:
         return self.router.url_path_for(name, **path_params)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope["app"] = self
+        if self.middleware_stack is None:
+            self.middleware_stack = self.build_middleware_stack()
         await self.middleware_stack(scope, receive, send)
 
     def on_event(self, event_type: str) -> typing.Callable:  # pragma: nocover
@@ -140,8 +141,11 @@ class Starlette:
     def add_middleware(
         self, middleware_class: type, **options: typing.Any
     ) -> None:  # pragma: no cover
+        if self.middleware_stack is not None:
+            raise RuntimeError(
+                "Cannot add middlewares after an application has started"
+            )
         self.user_middleware.insert(0, Middleware(middleware_class, **options))
-        self.middleware_stack = self.build_middleware_stack()
 
     def add_exception_handler(
         self,
@@ -149,7 +153,6 @@ class Starlette:
         handler: typing.Callable,
     ) -> None:  # pragma: no cover
         self.exception_handlers[exc_class_or_status_code] = handler
-        self.middleware_stack = self.build_middleware_stack()
 
     def add_event_handler(
         self, event_type: str, func: typing.Callable

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -65,7 +65,7 @@ class Starlette:
             on_startup is None and on_shutdown is None
         ), "Use either 'lifespan' or 'on_startup'/'on_shutdown', not both."
 
-        self._debug = debug
+        self.debug = debug
         self.state = State()
         self.router = Router(
             routes, on_startup=on_startup, on_shutdown=on_shutdown, lifespan=lifespan
@@ -108,14 +108,6 @@ class Starlette:
     def routes(self) -> typing.List[BaseRoute]:
         return self.router.routes
 
-    @property
-    def debug(self) -> bool:
-        return self._debug
-
-    @debug.setter
-    def debug(self, value: bool) -> None:
-        self._debug = value
-
     def url_path_for(self, name: str, **path_params: typing.Any) -> URLPath:
         return self.router.url_path_for(name, **path_params)
 
@@ -140,9 +132,7 @@ class Starlette:
 
     def add_middleware(self, middleware_class: type, **options: typing.Any) -> None:
         if self.middleware_stack is not None:  # pragma: no cover
-            raise RuntimeError(
-                "Cannot add middleware after an application has started"
-            )
+            raise RuntimeError("Cannot add middleware after an application has started")
         self.user_middleware.insert(0, Middleware(middleware_class, **options))
 
     def add_exception_handler(

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -140,7 +140,7 @@ class Starlette:
 
     def add_middleware(
         self, middleware_class: type, **options: typing.Any
-    ) -> None:  # pragma: no cover
+    ) -> None:
         if self.middleware_stack is not None:
             raise RuntimeError(
                 "Cannot add middlewares after an application has started"

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -139,9 +139,9 @@ class Starlette:
         self.router.host(host, app=app, name=name)
 
     def add_middleware(self, middleware_class: type, **options: typing.Any) -> None:
-        if self.middleware_stack is not None:
+        if self.middleware_stack is not None:  # pragma: no cover
             raise RuntimeError(
-                "Cannot add middlewares after an application has started"
+                "Cannot add middleware after an application has started"
             )
         self.user_middleware.insert(0, Middleware(middleware_class, **options))
 

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -138,9 +138,7 @@ class Starlette:
     ) -> None:  # pragma: no cover
         self.router.host(host, app=app, name=name)
 
-    def add_middleware(
-        self, middleware_class: type, **options: typing.Any
-    ) -> None:
+    def add_middleware(self, middleware_class: type, **options: typing.Any) -> None:
         if self.middleware_stack is not None:
             raise RuntimeError(
                 "Cannot add middlewares after an application has started"

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -74,7 +74,7 @@ class Starlette:
             {} if exception_handlers is None else dict(exception_handlers)
         )
         self.user_middleware = [] if middleware is None else list(middleware)
-        self.middleware_stack = None
+        self.middleware_stack: typing.Optional[ASGIApp] = None
 
     def build_middleware_stack(self) -> ASGIApp:
         debug = self.debug

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -515,11 +515,19 @@ def test_middleware_stack_init(test_client_factory: Callable[[ASGIApp], httpx.Cl
         app.add_middleware(NoOpMiddleware)
         return app
 
-    with test_client_factory(get_app()):
+    app = get_app()
+
+    with test_client_factory(app):
         pass
 
     assert SimpleInitializableMiddleware.counter == 1
 
-    test_client_factory(get_app()).get("/foo")
+    test_client_factory(app).get("/foo")
+
+    assert SimpleInitializableMiddleware.counter == 1
+
+    app = get_app()
+
+    test_client_factory(app).get("/foo")
 
     assert SimpleInitializableMiddleware.counter == 2


### PR DESCRIPTION
- Closes https://github.com/encode/starlette/issues/2002

Edit by @Kludex:

This is an alternative solution for deprecation + removal of the `add_middlware`. The solution here is to build the application with its middlewares only when we receive the first ASGI event - lifespan, websocket or http, doesn't matter.