### PR TITLE
Move exception handling logic to endpoints

### DIFF
--- a/starlette/middleware/exceptions.py
+++ b/starlette/middleware/exceptions.py
@@ -55,6 +55,11 @@ class ExceptionMiddleware:
             await self.app(scope, receive, send)
             return
 
+        scope["starlette.exception_handlers"] = (
+            self._exception_handlers,
+            self._status_handlers,
+        )
+
         response_started = False
 
         async def sender(message: Message) -> None:

--- a/starlette/middleware/exceptions.py
+++ b/starlette/middleware/exceptions.py
@@ -110,5 +110,5 @@ class ExceptionMiddleware:
 
     async def websocket_exception(
         self, websocket: WebSocket, exc: WebSocketException
-    ) -> None:
-        await websocket.close(code=exc.code, reason=exc.reason)
+    ) -> None: 
+        await websocket.close(code=exc.code, reason=exc.reason)  # pragma: no cover

--- a/starlette/middleware/exceptions.py
+++ b/starlette/middleware/exceptions.py
@@ -110,5 +110,5 @@ class ExceptionMiddleware:
 
     async def websocket_exception(
         self, websocket: WebSocket, exc: WebSocketException
-    ) -> None: 
+    ) -> None:
         await websocket.close(code=exc.code, reason=exc.reason)  # pragma: no cover

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -17,7 +17,7 @@ from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, RedirectResponse
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketClose
 
 
@@ -84,7 +84,7 @@ def request_response(func: typing.Callable) -> ASGIApp:
 
         response_started = False
 
-        async def sender(message) -> None:
+        async def sender(message: Message) -> None:
             nonlocal response_started
 
             if message["type"] == "http.response.start":
@@ -148,7 +148,7 @@ def websocket_session(func: typing.Callable) -> ASGIApp:
 
         response_started = False
 
-        async def sender(message) -> None:
+        async def sender(message: Message) -> None:
             nonlocal response_started
 
             if message["type"] == "http.response.start":

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -118,13 +118,8 @@ def request_response(func: typing.Callable) -> ASGIApp:
                 response = await handler(request, exc)
             else:
                 response = await run_in_threadpool(handler, request, exc)
-            await response(scope, receive, send)
-        else:
-            try:
-                await response(scope, receive, send)
-            except Exception as exc:
-                msg = "Caught handled exception, but response already started."
-                raise RuntimeError(msg) from exc
+
+        await response(scope, receive, send)
 
     return app
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,7 +4,8 @@ import pytest
 
 from starlette.exceptions import HTTPException, WebSocketException
 from starlette.middleware.exceptions import ExceptionMiddleware
-from starlette.responses import PlainTextResponse
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.routing import Route, Router, WebSocketRoute
 
 
@@ -28,6 +29,20 @@ def with_headers(request):
     raise HTTPException(status_code=200, headers={"x-potato": "always"})
 
 
+class BadBodyException(HTTPException):
+    pass
+
+
+async def read_body_and_raise_exc(request: Request):
+    await request.body()
+    raise BadBodyException(422)
+
+
+async def handler_that_reads_body(request: Request, exc: BadBodyException) -> JSONResponse:
+    body = await request.body()
+    return JSONResponse(status_code=422, content={"body": body.decode()})
+
+
 class HandledExcAfterResponse:
     async def __call__(self, scope, receive, send):
         response = PlainTextResponse("OK", status_code=200)
@@ -44,11 +59,12 @@ router = Router(
         Route("/with_headers", endpoint=with_headers),
         Route("/handled_exc_after_response", endpoint=HandledExcAfterResponse()),
         WebSocketRoute("/runtime_error", endpoint=raise_runtime_error),
+        Route("/consume_body_in_endpoint_and_handler", endpoint=read_body_and_raise_exc, methods=["POST"]),
     ]
 )
 
 
-app = ExceptionMiddleware(router)
+app = ExceptionMiddleware(router, handlers={BadBodyException: handler_that_reads_body})
 
 
 @pytest.fixture
@@ -160,3 +176,9 @@ def test_exception_middleware_deprecation() -> None:
 
     with pytest.warns(DeprecationWarning):
         starlette.exceptions.ExceptionMiddleware
+
+
+def test_request_in_app_and_handler_is_the_same_object(client) -> None:
+    response = client.post("/consume_body_in_endpoint_and_handler", content=b"Hello!")
+    assert response.status_code == 422
+    assert response.json() == {"body": "Hello!"}

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -70,7 +70,10 @@ router = Router(
 )
 
 
-app = ExceptionMiddleware(router, handlers={BadBodyException: handler_that_reads_body})
+app = ExceptionMiddleware(
+    router,
+    handlers={BadBodyException: handler_that_reads_body},  # type: ignore[dict-item]
+)
 
 
 @pytest.fixture

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,7 +5,7 @@ import pytest
 from starlette.exceptions import HTTPException, WebSocketException
 from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, PlainTextResponse, Response
+from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.routing import Route, Router, WebSocketRoute
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -38,7 +38,9 @@ async def read_body_and_raise_exc(request: Request):
     raise BadBodyException(422)
 
 
-async def handler_that_reads_body(request: Request, exc: BadBodyException) -> JSONResponse:
+async def handler_that_reads_body(
+    request: Request, exc: BadBodyException
+) -> JSONResponse:
     body = await request.body()
     return JSONResponse(status_code=422, content={"body": body.decode()})
 
@@ -59,7 +61,11 @@ router = Router(
         Route("/with_headers", endpoint=with_headers),
         Route("/handled_exc_after_response", endpoint=HandledExcAfterResponse()),
         WebSocketRoute("/runtime_error", endpoint=raise_runtime_error),
-        Route("/consume_body_in_endpoint_and_handler", endpoint=read_body_and_raise_exc, methods=["POST"]),
+        Route(
+            "/consume_body_in_endpoint_and_handler",
+            endpoint=read_body_and_raise_exc,
+            methods=["POST"],
+        ),
     ]
 )
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -945,13 +945,9 @@ def test_mounted_middleware_does_not_catch_exception(
     assert resp.status_code == 200, resp.content
     assert "X-Mounted" in resp.headers
 
-    # this is the "surprising" behavior bit
-    # the middleware on the mount never runs because there
-    # is nothing to catch the HTTPException
-    # since Mount middlweare is not wrapped by ExceptionMiddleware
     resp = client.get("/mount/err")
     assert resp.status_code == 403, resp.content
-    assert "X-Mounted" not in resp.headers
+    assert "X-Mounted" in resp.headers
 
 
 def test_route_repr() -> None:


### PR DESCRIPTION
Fixes #493, partially resolves https://github.com/encode/starlette/pull/1692#issuecomment-1266401636, resolves https://github.com/encode/starlette/pull/1649#issuecomment-1404473365

By moving handling of exceptions to the `Route` level we can use the same `Request`/`WebSocket` object for the endpoint and exception handlers.

I wrote this PR so that it is backwards compatible (and it also needs a lot of polish). There's a lot of duplicate logic between `ExceptionMiddleware` and `routing.py`. I see two options:

- Clean up the implementation to minimize duplicate code but keep `ExceptionMiddleware` around. This is less likely to break things like FastAPI that poke around into the internals of Starlette. It also means that ASIG middleware e.g. in an ASGI app mounted via `Mount` can continue to raise `HTTPException`s which will get caught by `ExceptionMiddleware` (I'd argue that anyone that is doing this should not be doing this but it's technically possible to do). (see note 1)
- Remove `ExceptionMiddleware`. We'd just need to move a bit of logic (separating the exception and status handlers and putting them into the scope for every request) into `Starlette`. This would eliminate all of the duplicate code.

Implementation aside, to me this makes sense conceptually: exception handlers operate on requests/webscokets not at the ASGI level. So they should live within the sphere of Request/WebSocket, not alongside generic ASGI middleware. I think this is the same principle that applies to FastAPI's dependencies and why they don't have the problems that BaseHTTPMiddleware has.

Notes:
1. Note that this does not apply to normal middleware installed via `Starlette(..., middleware=...)` since those middleware have never had any guarantee of `HTTPException`s they raise being caught.