### PR TITLE
Document that UploadFile's `filename` and `content_type` can be `None`

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -119,8 +119,8 @@ multidict, containing both file uploads and text input. File upload items are re
 
 `UploadFile` has the following attributes:
 
-* `filename`: A `str` with the original file name that was uploaded (e.g. `myimage.jpg`).
-* `content_type`: A `str` with the content type (MIME type / media type) (e.g. `image/jpeg`).
+* `filename`: An `str` with the original file name that was uploaded or `None` if its not available (e.g. `myimage.jpg`).
+* `content_type`: An `str` with the content type (MIME type / media type) or `None` if it's not available (e.g. `image/jpeg`).
 * `file`: A <a href="https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile" target="_blank">`SpooledTemporaryFile`</a> (a <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> object). This is the actual Python file that you can pass directly to other functions or libraries that expect a "file-like" object.
 * `headers`: A `Headers` object. Often this will only be the `Content-Type` header, but if additional headers were included in the multipart field they will be included here. Note that these headers have no relationship with the headers in `Request.headers`.
 * `size`: An `int` with uploaded file's size in bytes. This value is calculated from request's contents, making it better choice to find uploaded file's size than `Content-Length` header. `None` if not set.


### PR DESCRIPTION
Our docs for `UploadFile` don't mention that `filename` and `content_type` attributes are nullable, which just got me burned. This PR addresses that.