### PR TITLE
Fix test not passing in 32-bit architectures (fixes #2032)

### DIFF
--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -293,7 +293,7 @@ def test_file_response_with_inline_disposition(tmpdir, test_client_factory):
 
 def test_set_cookie(test_client_factory, monkeypatch):
     # Mock time used as a reference for `Expires` by stdlib `SimpleCookie`.
-    mocked_now = dt.datetime(2100, 1, 22, 12, 0, 0, tzinfo=dt.timezone.utc)
+    mocked_now = dt.datetime(2037, 1, 22, 12, 0, 0, tzinfo=dt.timezone.utc)
     monkeypatch.setattr(time, "time", lambda: mocked_now.timestamp())
 
     async def app(scope, receive, send):
@@ -316,7 +316,7 @@ def test_set_cookie(test_client_factory, monkeypatch):
     assert response.text == "Hello, world!"
     assert (
         response.headers["set-cookie"]
-        == "mycookie=myvalue; Domain=localhost; expires=Fri, 22 Jan 2100 12:00:10 GMT; "
+        == "mycookie=myvalue; Domain=localhost; expires=Thu, 22 Jan 2037 12:00:10 GMT; "
         "HttpOnly; Max-Age=10; Path=/; SameSite=none; Secure"
     )
 
@@ -325,15 +325,15 @@ def test_set_cookie(test_client_factory, monkeypatch):
     "expires",
     [
         pytest.param(
-            dt.datetime(2100, 1, 22, 12, 0, 10, tzinfo=dt.timezone.utc), id="datetime"
+            dt.datetime(2037, 1, 22, 12, 0, 10, tzinfo=dt.timezone.utc), id="datetime"
         ),
-        pytest.param("Fri, 22 Jan 2100 12:00:10 GMT", id="str"),
+        pytest.param("Thu, 22 Jan 2037 12:00:10 GMT", id="str"),
         pytest.param(10, id="int"),
     ],
 )
 def test_expires_on_set_cookie(test_client_factory, monkeypatch, expires):
     # Mock time used as a reference for `Expires` by stdlib `SimpleCookie`.
-    mocked_now = dt.datetime(2100, 1, 22, 12, 0, 0, tzinfo=dt.timezone.utc)
+    mocked_now = dt.datetime(2037, 1, 22, 12, 0, 0, tzinfo=dt.timezone.utc)
     monkeypatch.setattr(time, "time", lambda: mocked_now.timestamp())
 
     async def app(scope, receive, send):
@@ -344,7 +344,7 @@ def test_expires_on_set_cookie(test_client_factory, monkeypatch, expires):
     client = test_client_factory(app)
     response = client.get("/")
     cookie: SimpleCookie = SimpleCookie(response.headers.get("set-cookie"))
-    assert cookie["mycookie"]["expires"] == "Fri, 22 Jan 2100 12:00:10 GMT"
+    assert cookie["mycookie"]["expires"] == "Thu, 22 Jan 2037 12:00:10 GMT"
 
 
 def test_delete_cookie(test_client_factory):


### PR DESCRIPTION
Some architectures cannot hold values after
2038 year.

This commit fixes the following tests, adjusting
the expiring date for the cookies to a maximum
year value of 2037:

* test_set_cookie
* test_expires_on_set_cookie

The starting point for contributions should usually be [a discussion](https://github.com/encode/starlette/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise please ensure you've discussed your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes have been okayed by the maintainers.

- [x] Initially raised as discussion in https://github.com/encode/starlette/issues/2032
