### PR TITLE
Update link to jinja2

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ in isolation.
 
 [asgi]: https://asgi.readthedocs.io/en/latest/
 [httpx]: https://www.python-httpx.org/
-[jinja2]: http://jinja.pocoo.org/
+[jinja2]: https://jinja.palletsprojects.com/
 [python-multipart]: https://andrew-d.github.io/python-multipart/
 [itsdangerous]: https://pythonhosted.org/itsdangerous/
 [sqlalchemy]: https://www.sqlalchemy.org

--- a/docs/index.md
+++ b/docs/index.md
@@ -131,7 +131,7 @@ in isolation.
 
 [asgi]: https://asgi.readthedocs.io/en/latest/
 [httpx]: https://www.python-httpx.org/
-[jinja2]: http://jinja.pocoo.org/
+[jinja2]: https://jinja.palletsprojects.com/
 [python-multipart]: https://andrew-d.github.io/python-multipart/
 [itsdangerous]: https://pythonhosted.org/itsdangerous/
 [sqlalchemy]: https://www.sqlalchemy.org


### PR DESCRIPTION
The old link doesn't support https, which makes it not work for https-only users, and it only redirects to this one anyway.