### PR TITLE
Docs: Remove SentryMiddleware from third-party list

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -773,10 +773,6 @@ A middleware class for reading/generating request IDs and attaching them to appl
 
 A middleware class for logging exceptions, errors, and log messages to [Rollbar](https://www.rollbar.com).
 
-#### [SentryMiddleware](https://github.com/encode/sentry-asgi)
-
-A middleware class for logging exceptions to [Sentry](https://sentry.io/).
-
 #### [StarletteOpentracing](https://github.com/acidjunk/starlette-opentracing)
 
 A middleware class that emits tracing info to [OpenTracing.io](https://opentracing.io/) compatible tracers and


### PR DESCRIPTION
I was going through the [third-party middlewares list](https://www.starlette.io/middleware/#sentrymiddleware) in the docs and came across [`SentryMiddleware`](https://github.com/encode/sentry-asgi). As stated in the project:

> Update Sentry now includes built-in support for ASGI. (Based on this implementation.)

So I thought it may not be useful to mention it in the docs anymore.

What we could do however (not done, but I would happily do it) is to add `SentryASGIMiddleware` and link to Sentry docs: https://docs.sentry.io/platforms/python/guides/quart/configuration/integrations/asgi/ What do you think?