### PR TITLE
Add ExceptionHandler type

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -5,7 +5,7 @@ from starlette.datastructures import State, URLPath
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.errors import ServerErrorMiddleware
-from starlette.middleware.exceptions import ExceptionMiddleware
+from starlette.middleware.exceptions import ExceptionHandler, ExceptionMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import BaseRoute, Router
@@ -45,7 +45,16 @@ class Starlette:
         routes: typing.Optional[typing.Sequence[BaseRoute]] = None,
         middleware: typing.Optional[typing.Sequence[Middleware]] = None,
         exception_handlers: typing.Optional[
-            typing.Mapping[typing.Any, typing.Any]
+            typing.Mapping[
+                typing.Any,
+                typing.Union[
+                    ExceptionHandler,
+                    typing.Callable[
+                        [Request, Exception],
+                        typing.Union[Response, typing.Awaitable[Response]],
+                    ],
+                ],
+            ]
         ] = None,
         on_startup: typing.Optional[typing.Sequence[typing.Callable]] = None,
         on_shutdown: typing.Optional[typing.Sequence[typing.Callable]] = None,
@@ -74,7 +83,14 @@ class Starlette:
         debug = self.debug
         error_handler = None
         exception_handlers: typing.Dict[
-            typing.Any, typing.Callable[[Request, Exception], Response]
+            typing.Any,
+            typing.Union[
+                ExceptionHandler,
+                typing.Callable[
+                    [Request, Exception],
+                    typing.Union[Response, typing.Awaitable[Response]],
+                ],
+            ],
         ] = {}
 
         for key, value in self.exception_handlers.items():

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -45,13 +45,7 @@ class Starlette:
         routes: typing.Optional[typing.Sequence[BaseRoute]] = None,
         middleware: typing.Optional[typing.Sequence[Middleware]] = None,
         exception_handlers: typing.Optional[
-            typing.Mapping[
-                typing.Any,
-                typing.Callable[
-                    [Request, Exception],
-                    typing.Union[Response, typing.Awaitable[Response]],
-                ],
-            ]
+            typing.Mapping[typing.Any, typing.Any]
         ] = None,
         on_startup: typing.Optional[typing.Sequence[typing.Callable]] = None,
         on_shutdown: typing.Optional[typing.Sequence[typing.Callable]] = None,

--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -5,6 +5,7 @@ import typing
 
 from starlette._utils import is_async_callable
 from starlette.concurrency import run_in_threadpool
+from starlette.middleware.exceptions import ExceptionHandler
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, PlainTextResponse, Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -137,11 +138,17 @@ class ServerErrorMiddleware:
     def __init__(
         self,
         app: ASGIApp,
-        handler: typing.Optional[typing.Callable] = None,
+        handler: typing.Optional[
+            typing.Union[
+                ExceptionHandler, typing.Callable[[typing.Any, typing.Any], typing.Any]
+            ]
+        ] = None,
         debug: bool = False,
     ) -> None:
         self.app = app
-        self.handler = handler
+        self.handler = (
+            handler.handler if isinstance(handler, ExceptionHandler) else handler
+        )
         self.debug = debug
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 
 from starlette import status
-from starlette.applications import Starlette
+from starlette.applications import ExceptionHandler, Starlette
 from starlette.endpoints import HTTPEndpoint
 from starlette.exceptions import HTTPException, WebSocketException
 from starlette.middleware import Middleware
@@ -100,10 +100,10 @@ subdomain = Router(
 )
 
 exception_handlers = {
-    500: error_500,
-    405: method_not_allowed,
-    HTTPException: http_exception,
-    CustomWSException: custom_ws_exception_handler,
+    500: ExceptionHandler(error_500),
+    405: ExceptionHandler(method_not_allowed),
+    HTTPException: ExceptionHandler(http_exception),
+    CustomWSException: ExceptionHandler(custom_ws_exception_handler),
 }
 
 middleware = [


### PR DESCRIPTION
In PR #2042 I pointed out problems with type checking of exception_handlers.  Due to untyped handler functions in the unit tests, we didn't catch the fact that handlers were not conforming to the type hints after the support for handling WebSockets errors was added.

This PR aims to help this situation by introducing an `ExceptionHandler` class which wraps the handler function and provides proper type checking on the handler function.  Unwrapped functions with the previous signature are still accepted as a fallback.