### PR TITLE
fix empty_receive for exception handler

### DIFF
--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -161,7 +161,7 @@ class ServerErrorMiddleware:
         try:
             await self.app(scope, receive, _send)
         except Exception as exc:
-            request = Request(scope)
+            request = Request(scope, receive=receive)
             if self.debug:
                 # In debug mode, return traceback responses.
                 response = self.debug_response(request, exc)


### PR DESCRIPTION
As describe in #892, I only want to get request body in exception handler but don't want implement it use APIRouter in fastAPI.
I think the simple way is send the `receive` argument replace to the empty_receiver.