### PR TITLE
Fix typing of ASGIApp (#2057)

### DIFF
--- a/starlette/types.py
+++ b/starlette/types.py
@@ -1,7 +1,7 @@
 import typing
 
-Scope = typing.MutableMapping[str, typing.Any]
-Message = typing.MutableMapping[str, typing.Any]
+Scope = typing.Dict[str, typing.Any]
+Message = typing.Dict[str, typing.Any]
 
 Receive = typing.Callable[[], typing.Awaitable[Message]]
 Send = typing.Callable[[Message], typing.Awaitable[None]]


### PR DESCRIPTION
According to ASGI spec both scope and event message must be dictionaries, not an arbitrary mutable mapping.

- [x] Initially raised as discussion #2040 
