### PR TITLE
Support lifespan state

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -9,7 +9,7 @@ from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import BaseRoute, Router
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send
 
 
 class Starlette:
@@ -55,9 +55,7 @@ class Starlette:
         ] = None,
         on_startup: typing.Optional[typing.Sequence[typing.Callable]] = None,
         on_shutdown: typing.Optional[typing.Sequence[typing.Callable]] = None,
-        lifespan: typing.Optional[
-            typing.Callable[["Starlette"], typing.AsyncContextManager]
-        ] = None,
+        lifespan: typing.Optional[Lifespan] = None,
     ) -> None:
         # The lifespan context function is a newer style that replaces
         # on_startup / on_shutdown handlers. Use one or the other, not both.

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -679,22 +679,20 @@ class Router:
         """
         started = False
         app = scope.get("app")
+        state = scope.get("state")
         await receive()
         lifespan_needs_state = (
             len(inspect.signature(self.lifespan_context).parameters) == 2
         )
-        server_supports_state = "state" in scope
+        server_supports_state = state is not None
         if lifespan_needs_state and not server_supports_state:
             raise RuntimeError(
-                'This server does not support "state" in the lifespan scope.'
-                " Please try updating your ASGI server."
+                'The server does not support "state" in the lifespan scope.'
             )
         try:
             lifespan_context: Lifespan
             if lifespan_needs_state:
-                lifespan_context = functools.partial(
-                    self.lifespan_context, state=scope["state"]
-                )
+                lifespan_context = functools.partial(self.lifespan_context, state=state)
             else:
                 lifespan_context = typing.cast(StatelessLifespan, self.lifespan_context)
             async with lifespan_context(app):

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -1,12 +1,9 @@
-import contextlib
 import functools
 import inspect
 import re
 import traceback
-import types
 import typing
 import warnings
-from contextlib import asynccontextmanager
 from enum import Enum
 
 from starlette._utils import is_async_callable
@@ -17,7 +14,7 @@ from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, RedirectResponse
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send, StatelessLifespan
 from starlette.websockets import WebSocket, WebSocketClose
 
 
@@ -530,32 +527,7 @@ class Host(BaseRoute):
 _T = typing.TypeVar("_T")
 
 
-class _AsyncLiftContextManager(typing.AsyncContextManager[_T]):
-    def __init__(self, cm: typing.ContextManager[_T]):
-        self._cm = cm
-
-    async def __aenter__(self) -> _T:
-        return self._cm.__enter__()
-
-    async def __aexit__(
-        self,
-        exc_type: typing.Optional[typing.Type[BaseException]],
-        exc_value: typing.Optional[BaseException],
-        traceback: typing.Optional[types.TracebackType],
-    ) -> typing.Optional[bool]:
-        return self._cm.__exit__(exc_type, exc_value, traceback)
-
-
-def _wrap_gen_lifespan_context(
-    lifespan_context: typing.Callable[[typing.Any], typing.Generator]
-) -> typing.Callable[[typing.Any], typing.AsyncContextManager]:
-    cmgr = contextlib.contextmanager(lifespan_context)
-
-    @functools.wraps(cmgr)
-    def wrapper(app: typing.Any) -> _AsyncLiftContextManager:
-        return _AsyncLiftContextManager(cmgr(app))
-
-    return wrapper
+_TDefaultLifespan = typing.TypeVar("_TDefaultLifespan", bound="_DefaultLifespan")
 
 
 class _DefaultLifespan:
@@ -563,12 +535,17 @@ class _DefaultLifespan:
         self._router = router
 
     async def __aenter__(self) -> None:
-        await self._router.startup()
+        await self._router.startup(state=self._state)
 
     async def __aexit__(self, *exc_info: object) -> None:
-        await self._router.shutdown()
+        await self._router.shutdown(state=self._state)
 
-    def __call__(self: _T, app: object) -> _T:
+    def __call__(
+        self: _TDefaultLifespan,
+        app: object,
+        state: typing.Optional[typing.Dict[str, typing.Any]],
+    ) -> _TDefaultLifespan:
+        self._state = state
         return self
 
 
@@ -580,9 +557,7 @@ class Router:
         default: typing.Optional[ASGIApp] = None,
         on_startup: typing.Optional[typing.Sequence[typing.Callable]] = None,
         on_shutdown: typing.Optional[typing.Sequence[typing.Callable]] = None,
-        lifespan: typing.Optional[
-            typing.Callable[[typing.Any], typing.AsyncContextManager]
-        ] = None,
+        lifespan: typing.Optional[Lifespan] = None,
     ) -> None:
         self.routes = [] if routes is None else list(routes)
         self.redirect_slashes = redirect_slashes
@@ -591,27 +566,13 @@ class Router:
         self.on_shutdown = [] if on_shutdown is None else list(on_shutdown)
 
         if lifespan is None:
-            self.lifespan_context: typing.Callable[
-                [typing.Any], typing.AsyncContextManager
-            ] = _DefaultLifespan(self)
-
-        elif inspect.isasyncgenfunction(lifespan):
-            warnings.warn(
-                "async generator function lifespans are deprecated, "
-                "use an @contextlib.asynccontextmanager function instead",
-                DeprecationWarning,
-            )
-            self.lifespan_context = asynccontextmanager(
-                lifespan,  # type: ignore[arg-type]
-            )
-        elif inspect.isgeneratorfunction(lifespan):
-            warnings.warn(
-                "generator function lifespans are deprecated, "
-                "use an @contextlib.asynccontextmanager function instead",
-                DeprecationWarning,
-            )
-            self.lifespan_context = _wrap_gen_lifespan_context(
-                lifespan,  # type: ignore[arg-type]
+            self.lifespan_context: Lifespan = _DefaultLifespan(self)
+        elif inspect.isasyncgenfunction(lifespan) or inspect.isgeneratorfunction(
+            lifespan
+        ):
+            raise RuntimeError(
+                "Generator functions are not supported for lifespan, "
+                "use an @contextlib.asynccontextmanager function instead."
             )
         else:
             self.lifespan_context = lifespan
@@ -639,21 +600,31 @@ class Router:
                 pass
         raise NoMatchFound(name, path_params)
 
-    async def startup(self) -> None:
+    async def startup(
+        self, state: typing.Optional[typing.Dict[str, typing.Any]]
+    ) -> None:
         """
         Run any `.on_startup` event handlers.
         """
         for handler in self.on_startup:
+            sig = inspect.signature(handler)
+            if len(sig.parameters) == 1 and state is not None:
+                handler = functools.partial(handler, state)
             if is_async_callable(handler):
                 await handler()
             else:
                 handler()
 
-    async def shutdown(self) -> None:
+    async def shutdown(
+        self, state: typing.Optional[typing.Dict[str, typing.Any]]
+    ) -> None:
         """
         Run any `.on_shutdown` event handlers.
         """
         for handler in self.on_shutdown:
+            sig = inspect.signature(handler)
+            if len(sig.parameters) == 1 and state is not None:
+                handler = functools.partial(handler, state)
             if is_async_callable(handler):
                 await handler()
             else:
@@ -666,9 +637,18 @@ class Router:
         """
         started = False
         app = scope.get("app")
+        state = scope.get("state")
         await receive()
         try:
-            async with self.lifespan_context(app):
+            lifespan_context: Lifespan
+            if (
+                len(inspect.signature(self.lifespan_context).parameters) == 2
+                and state is not None
+            ):
+                lifespan_context = functools.partial(self.lifespan_context, state=state)
+            else:
+                lifespan_context = typing.cast(StatelessLifespan, self.lifespan_context)
+            async with lifespan_context(app):
                 await send({"type": "lifespan.startup.complete"})
                 started = True
                 await receive()

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -679,15 +679,22 @@ class Router:
         """
         started = False
         app = scope.get("app")
-        state = scope.get("state")
         await receive()
+        lifespan_needs_state = (
+            len(inspect.signature(self.lifespan_context).parameters) == 2
+        )
+        server_supports_state = "state" in scope
+        if lifespan_needs_state and not server_supports_state:
+            raise RuntimeError(
+                'This server does not support "state" in the lifespan scope.'
+                " Please try updating your ASGI server."
+            )
         try:
             lifespan_context: Lifespan
-            if (
-                len(inspect.signature(self.lifespan_context).parameters) == 2
-                and state is not None
-            ):
-                lifespan_context = functools.partial(self.lifespan_context, state=state)
+            if lifespan_needs_state:
+                lifespan_context = functools.partial(
+                    self.lifespan_context, state=scope["state"]
+                )
             else:
                 lifespan_context = typing.cast(StatelessLifespan, self.lifespan_context)
             async with lifespan_context(app):

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -188,11 +188,13 @@ class _TestClientTransport(httpx.BaseTransport):
         portal_factory: _PortalFactoryType,
         raise_server_exceptions: bool = True,
         root_path: str = "",
+        state: typing.Optional[typing.Dict[str, typing.Any]] = None,
     ) -> None:
         self.app = app
         self.raise_server_exceptions = raise_server_exceptions
         self.root_path = root_path
         self.portal_factory = portal_factory
+        self.state = state
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         scheme = request.url.scheme
@@ -243,6 +245,7 @@ class _TestClientTransport(httpx.BaseTransport):
                 "client": ["testclient", 50000],
                 "server": [host, port],
                 "subprotocols": subprotocols,
+                "state": self.state,
             }
             session = WebSocketTestSession(self.app, scope, self.portal_factory)
             raise _Upgrade(session)
@@ -260,6 +263,7 @@ class _TestClientTransport(httpx.BaseTransport):
             "client": ["testclient", 50000],
             "server": [host, port],
             "extensions": {"http.response.debug": {}},
+            "state": self.state,
         }
 
         request_complete = False
@@ -380,11 +384,13 @@ class TestClient(httpx.Client):
             app = typing.cast(ASGI2App, app)  # type: ignore[assignment]
             asgi_app = _WrapASGI2(app)  # type: ignore[arg-type]
         self.app = asgi_app
+        self.app_state: typing.Dict[str, typing.Any] = {}
         transport = _TestClientTransport(
             self.app,
             portal_factory=self._portal_factory,
             raise_server_exceptions=raise_server_exceptions,
             root_path=root_path,
+            state=self.app_state,
         )
         if headers is None:
             headers = {}
@@ -749,7 +755,7 @@ class TestClient(httpx.Client):
         self.exit_stack.close()
 
     async def lifespan(self) -> None:
-        scope = {"type": "lifespan"}
+        scope = {"type": "lifespan", "state": self.app_state}
         try:
             await self.app(scope, self.stream_receive.receive, self.stream_send.send)
         finally:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -188,13 +188,14 @@ class _TestClientTransport(httpx.BaseTransport):
         portal_factory: _PortalFactoryType,
         raise_server_exceptions: bool = True,
         root_path: str = "",
-        state: typing.Optional[typing.Dict[str, typing.Any]] = None,
+        *,
+        app_state: typing.Dict[str, typing.Any],
     ) -> None:
         self.app = app
         self.raise_server_exceptions = raise_server_exceptions
         self.root_path = root_path
         self.portal_factory = portal_factory
-        self.state = state
+        self.app_state = app_state
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         scheme = request.url.scheme
@@ -245,7 +246,7 @@ class _TestClientTransport(httpx.BaseTransport):
                 "client": ["testclient", 50000],
                 "server": [host, port],
                 "subprotocols": subprotocols,
-                "state": self.state,
+                "state": self.app_state.copy(),
             }
             session = WebSocketTestSession(self.app, scope, self.portal_factory)
             raise _Upgrade(session)
@@ -263,7 +264,7 @@ class _TestClientTransport(httpx.BaseTransport):
             "client": ["testclient", 50000],
             "server": [host, port],
             "extensions": {"http.response.debug": {}},
-            "state": self.state,
+            "state": self.app_state.copy(),
         }
 
         request_complete = False
@@ -390,7 +391,7 @@ class TestClient(httpx.Client):
             portal_factory=self._portal_factory,
             raise_server_exceptions=raise_server_exceptions,
             root_path=root_path,
-            state=self.app_state,
+            app_state=self.app_state,
         )
         if headers is None:
             headers = {}

--- a/starlette/types.py
+++ b/starlette/types.py
@@ -7,3 +7,9 @@ Receive = typing.Callable[[], typing.Awaitable[Message]]
 Send = typing.Callable[[Message], typing.Awaitable[None]]
 
 ASGIApp = typing.Callable[[Scope, Receive, Send], typing.Awaitable[None]]
+
+StatelessLifespan = typing.Callable[[object], typing.AsyncContextManager]
+StateLifespan = typing.Callable[
+    [typing.Any, typing.Dict[str, typing.Any]], typing.AsyncContextManager
+]
+Lifespan = typing.Union[StatelessLifespan, StateLifespan]

--- a/starlette/types.py
+++ b/starlette/types.py
@@ -8,8 +8,8 @@ Send = typing.Callable[[Message], typing.Awaitable[None]]
 
 ASGIApp = typing.Callable[[Scope, Receive, Send], typing.Awaitable[None]]
 
-StatelessLifespan = typing.Callable[[object], typing.AsyncContextManager]
+StatelessLifespan = typing.Callable[[object], typing.AsyncContextManager[typing.Any]]
 StateLifespan = typing.Callable[
-    [typing.Any, typing.Dict[str, typing.Any]], typing.AsyncContextManager
+    [typing.Any, typing.Dict[str, typing.Any]], typing.AsyncContextManager[typing.Any]
 ]
 Lifespan = typing.Union[StatelessLifespan, StateLifespan]

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -381,57 +381,22 @@ def test_app_async_cm_lifespan(test_client_factory):
     assert cleanup_complete
 
 
-deprecated_lifespan = pytest.mark.filterwarnings(
-    r"ignore"
-    r":(async )?generator function lifespans are deprecated, use an "
-    r"@contextlib\.asynccontextmanager function instead"
-    r":DeprecationWarning"
-    r":starlette.routing"
-)
+async def async_gen_lifespan():
+    yield  # pragma: no cover
 
 
-@deprecated_lifespan
-def test_app_async_gen_lifespan(test_client_factory):
-    startup_complete = False
-    cleanup_complete = False
-
-    async def lifespan(app):
-        nonlocal startup_complete, cleanup_complete
-        startup_complete = True
-        yield
-        cleanup_complete = True
-
-    app = Starlette(lifespan=lifespan)
-
-    assert not startup_complete
-    assert not cleanup_complete
-    with test_client_factory(app):
-        assert startup_complete
-        assert not cleanup_complete
-    assert startup_complete
-    assert cleanup_complete
+def sync__gen_lifespan():
+    yield  # pragma: no cover
 
 
-@deprecated_lifespan
-def test_app_sync_gen_lifespan(test_client_factory):
-    startup_complete = False
-    cleanup_complete = False
-
-    def lifespan(app):
-        nonlocal startup_complete, cleanup_complete
-        startup_complete = True
-        yield
-        cleanup_complete = True
-
-    app = Starlette(lifespan=lifespan)
-
-    assert not startup_complete
-    assert not cleanup_complete
-    with test_client_factory(app):
-        assert startup_complete
-        assert not cleanup_complete
-    assert startup_complete
-    assert cleanup_complete
+@pytest.mark.parametrize("lifespan", [async_gen_lifespan, sync__gen_lifespan])
+def test_app_gen_lifespan(lifespan):
+    with pytest.raises(
+        RuntimeError,
+        match="Generator functions are not supported for lifespan"
+        ", use an @contextlib.asynccontextmanager function instead.",
+    ):
+        Starlette(lifespan=lifespan)
 
 
 def test_decorator_deprecations() -> None:

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -381,22 +381,57 @@ def test_app_async_cm_lifespan(test_client_factory):
     assert cleanup_complete
 
 
-async def async_gen_lifespan():
-    yield  # pragma: no cover
+deprecated_lifespan = pytest.mark.filterwarnings(
+    r"ignore"
+    r":(async )?generator function lifespans are deprecated, use an "
+    r"@contextlib\.asynccontextmanager function instead"
+    r":DeprecationWarning"
+    r":starlette.routing"
+)
 
 
-def sync__gen_lifespan():
-    yield  # pragma: no cover
+@deprecated_lifespan
+def test_app_async_gen_lifespan(test_client_factory):
+    startup_complete = False
+    cleanup_complete = False
+
+    async def lifespan(app):
+        nonlocal startup_complete, cleanup_complete
+        startup_complete = True
+        yield
+        cleanup_complete = True
+
+    app = Starlette(lifespan=lifespan)
+
+    assert not startup_complete
+    assert not cleanup_complete
+    with test_client_factory(app):
+        assert startup_complete
+        assert not cleanup_complete
+    assert startup_complete
+    assert cleanup_complete
 
 
-@pytest.mark.parametrize("lifespan", [async_gen_lifespan, sync__gen_lifespan])
-def test_app_gen_lifespan(lifespan):
-    with pytest.raises(
-        RuntimeError,
-        match="Generator functions are not supported for lifespan"
-        ", use an @contextlib.asynccontextmanager function instead.",
-    ):
-        Starlette(lifespan=lifespan)
+@deprecated_lifespan
+def test_app_sync_gen_lifespan(test_client_factory):
+    startup_complete = False
+    cleanup_complete = False
+
+    def lifespan(app):
+        nonlocal startup_complete, cleanup_complete
+        startup_complete = True
+        yield
+        cleanup_complete = True
+
+    app = Starlette(lifespan=lifespan)
+
+    assert not startup_complete
+    assert not cleanup_complete
+    with test_client_factory(app):
+        assert startup_complete
+        assert not cleanup_complete
+    assert startup_complete
+    assert cleanup_complete
 
 
 def test_decorator_deprecations() -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -717,6 +717,27 @@ def test_lifespan_with_state(test_client_factory):
     assert shutdown_complete
 
 
+def test_lifespan_state_unsupported(test_client_factory):
+    @contextlib.asynccontextmanager
+    async def lifespan(app, scope):
+        yield None  # pragma: no cover
+
+    app = Router(
+        lifespan=lifespan,
+        routes=[Mount("/", PlainTextResponse("hello, world"))],
+    )
+
+    async def no_state_wrapper(scope, receive, send):
+        del scope["state"]
+        await app(scope, receive, send)
+
+    with pytest.raises(
+        RuntimeError, match='This server does not support "state" in the lifespan scope'
+    ):
+        with test_client_factory(no_state_wrapper):
+            raise AssertionError("Should not be called")  # pragma: no cover
+
+
 def test_lifespan_async_cm(test_client_factory):
     startup_complete = False
     shutdown_complete = False

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -732,7 +732,7 @@ def test_lifespan_state_unsupported(test_client_factory):
         await app(scope, receive, send)
 
     with pytest.raises(
-        RuntimeError, match='This server does not support "state" in the lifespan scope'
+        RuntimeError, match='The server does not support "state" in the lifespan scope'
     ):
         with test_client_factory(no_state_wrapper):
             raise AssertionError("Should not be called")  # pragma: no cover


### PR DESCRIPTION
- This PR implements the Lifespan state mentioned on the ASGI spec: https://github.com/django/asgiref/pull/354.
- This PR complements https://github.com/encode/uvicorn/pull/1818.

## Changes
- Implement lifespan state.
- Remove _generator function way_ to use lifespan.

## How to review

You need to have both this branch and the one from https://github.com/encode/uvicorn/pull/1818 on your virtual environment, and then you can use this application to test the behavior:

```python
from contextlib import asynccontextmanager
from typing import Any, Dict

from starlette.applications import Starlette
from starlette.responses import PlainTextResponse
from starlette.routing import Route


# async def startup(state: Dict[str, Any]):
#     print(state)
#     state["potato"] = True
#     print(state)
#     print("startup")


# async def stateless_startup():
#     print("stateless_startup")


@asynccontextmanager
async def state_manager(app, state):
    state["haha"] = True
    print(state)
    yield
    print(state)

@asynccontextmanager
async def stateless_manager(app):
    print("stateless manager")
    yield

async def homepage(request):
    print(request.state)
    return PlainTextResponse("Hello, world!")


app = Starlette(
    routes=[Route("/", homepage)],
    # on_startup=[startup, stateless_startup],
    lifespan=state_manager,
    # lifespan=stateless_manager,
)
```

Play with the comments above. :eyes: 