### PR TITLE
(docs) Updating Sentry: 3rd Party Middlewares

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -773,9 +773,9 @@ A middleware class for reading/generating request IDs and attaching them to appl
 
 A middleware class for logging exceptions, errors, and log messages to [Rollbar](https://www.rollbar.com).
 
-#### [SentryMiddleware](https://github.com/encode/sentry-asgi)
+#### [SentryMiddleware](https://docs.sentry.io/platforms/python/guides/starlette/)
 
-A middleware class for logging exceptions to [Sentry](https://sentry.io/).
+Sentry provides a dedicated integration for Starlette. A middleware class for logging exceptions to [Sentry](https://sentry.io/). Integrations available for collecting performance data, in the form of spans and traces. If you already use [OpenTelemetry](https://docs.sentry.io/platforms/python/guides/starlette/performance/instrumentation/opentelemetry/), there is also support to send those traces and spans with their SDK.
 
 #### [StarletteOpentracing](https://github.com/acidjunk/starlette-opentracing)
 


### PR DESCRIPTION
Sentry has a dedicated integration for Starlette. Checking the other 3rd part support here, I thought it might be relevant to add the support for performance data collection, including links to the OpenTelemetry support

Discussion comment: https://github.com/encode/starlette/discussions/1787#discussioncomment-3314878

Related PR: https://github.com/encode/starlette/pull/2044

Apologies, I am a bit late to following up from the discussion :) 