### PR TITLE
🪛 [Proposal] - Add new on_startup/on_shutdown events

### DIFF
--- a/starlette/events/context.py
+++ b/starlette/events/context.py
@@ -23,7 +23,7 @@ class AyncLifespanContextManager:
     def __call__(self: _T, app: object) -> _T:
         return self
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> None:
         for handler in self.on_startup:
             if is_async_callable(handler):
                 await handler()
@@ -32,7 +32,7 @@ class AyncLifespanContextManager:
 
     async def __aexit__(
         self, scope: Scope, receive: Receive, send: Send, **kwargs: typing.Any
-    ):
+    ) -> None:
         for handler in self.on_shutdown:
             if is_async_callable(handler):
                 await handler()

--- a/starlette/events/context.py
+++ b/starlette/events/context.py
@@ -1,0 +1,40 @@
+import typing
+from typing import TypeVar
+
+from starlette._utils import is_async_callable
+from starlette.types import Receive, Scope, Send
+
+_T = TypeVar("_T")
+
+
+class AyncLifespanContextManager:
+    """
+    Bridges the on_startup/on_shutdown to the new async context manager.
+    """
+
+    def __init__(
+        self,
+        on_startup: typing.Optional[typing.Sequence[typing.Callable]] = None,
+        on_shutdown: typing.Optional[typing.Sequence[typing.Callable]] = None,
+    ) -> None:
+        self.on_startup = [] if on_startup is None else list(on_startup)
+        self.on_shutdown = [] if on_shutdown is None else list(on_shutdown)
+
+    def __call__(self: _T, app: object) -> _T:
+        return self
+
+    async def __aenter__(self):
+        for handler in self.on_startup:
+            if is_async_callable(handler):
+                await handler()
+            else:
+                handler()
+
+    async def __aexit__(
+        self, scope: Scope, receive: Receive, send: Send, **kwargs: typing.Any
+    ):
+        for handler in self.on_shutdown:
+            if is_async_callable(handler):
+                await handler()
+            else:
+                handler()

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -600,7 +600,7 @@ class Router:
                 "See more about it on https://www.starlette.io/lifespan/.",
                 DeprecationWarning,
             )
-            self.lifespan_context = self.handle_lifespan_events(
+            lifespan = self.handle_lifespan_events(
                 on_startup=on_startup, on_shutdown=on_shutdown, lifespan=lifespan
             )
 


### PR DESCRIPTION
* Add new way of handling on_startup/on_shutdown by generating a lifepsan event to match the new
way and handle legacy versions.

A lot of plugins and addons for Starlette and Starlette related frameworks use the old ways to mabage the events. These are still very useful the way they are.

My initial proposal would be to maintain at least the way it is declared for backwards compatibility and internally convert/generate the new async context manager for the lifespan based on that.

This way we keep the newly lifespan approach and different ways of achieving that while maintaining backwards compatibility for the current packages out there.

This also means this would be only for python 3.8+ since python 3.7 EOL will be in June this year.

@Kludex any thoughts?