### PR TITLE
Fix `docs/staticfiles.md` wrong signature

### DIFF
--- a/docs/staticfiles.md
+++ b/docs/staticfiles.md
@@ -3,7 +3,7 @@ Starlette also includes a `StaticFiles` class for serving files in a given direc
 
 ### StaticFiles
 
-Signature: `StaticFiles(directory=None, packages=None, check_dir=True, follow_symlink=False)`
+Signature: `StaticFiles(directory=None, packages=None, html=False, check_dir=True, follow_symlink=False)`
 
 * `directory` - A string or [os.Pathlike][pathlike] denoting a directory path.
 * `packages` - A list of strings or list of tuples of strings of python packages.


### PR DESCRIPTION
The code:
```
class StaticFiles:
    def __init__(
        self,
        *,
        directory: typing.Optional[PathLike] = None,
        packages: typing.Optional[
            typing.List[typing.Union[str, typing.Tuple[str, str]]]
        ] = None,
        html: bool = False,
        check_dir: bool = True,
        follow_symlink: bool = False,
    ) -> None:
```
I found this while reading the doc: https://www.starlette.io/staticfiles/
