### PR TITLE
Clarify the origin of disallowed response

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -56,5 +56,5 @@ class TrustedHostMiddleware:
                 redirect_url = url.replace(netloc="www." + url.netloc)
                 response = RedirectResponse(url=str(redirect_url))
             else:
-                response = PlainTextResponse("Invalid host header", status_code=400)
+                response = PlainTextResponse("TrustedHostMiddleware: Invalid host header", status_code=400)
             await response(scope, receive, send)


### PR DESCRIPTION
After spending a few hours trying to understand why my API didn't work after it's initial deployment, I found that this was the origin of the response. Had it been something less generic than "Invalid host header" a google search would have done the job wonderfully.

The starting point for contributions should usually be [a discussion](https://github.com/encode/starlette/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise please ensure you've discussed your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes have been okayed by the maintainers.

- [ ] Initially raised as discussion #...
