### PR TITLE
Minify JSON websocket data via `send_json`

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -145,7 +145,7 @@ class WebSocketTestSession:
 
     def send_json(self, data: typing.Any, mode: str = "text") -> None:
         assert mode in ["text", "binary"]
-        text = json.dumps(data)
+        text = json.dumps(data, separators=(",", ":"))
         if mode == "text":
             self.send({"type": "websocket.receive", "text": text})
         else:

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -168,7 +168,7 @@ class WebSocket(HTTPConnection):
     async def send_json(self, data: typing.Any, mode: str = "text") -> None:
         if mode not in {"text", "binary"}:
             raise RuntimeError('The "mode" argument should be "text" or "binary".')
-        text = json.dumps(data)
+        text = json.dumps(data, separators=(",", ":"))
         if mode == "text":
             await self.send({"type": "websocket.send", "text": text})
         else:


### PR DESCRIPTION
# Summary

Similar to how JSON data is minified in the `JSONResponse` class, JSON data sent via websocket should also be minified.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
