### PR TITLE
Convert ImportErrors into ModuleNotFoundError

### DIFF
--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -9,7 +9,7 @@ from starlette.datastructures import FormData, Headers, UploadFile
 try:
     import multipart
     from multipart.multipart import parse_options_header
-except ImportError:  # pragma: nocover
+except ModuleNotFoundError:  # pragma: nocover
     parse_options_header = None
     multipart = None
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -12,7 +12,7 @@ from starlette.types import Message, Receive, Scope, Send
 
 try:
     from multipart.multipart import parse_options_header
-except ImportError:  # pragma: nocover
+except ModuleNotFoundError:  # pragma: nocover
     parse_options_header = None
 
 

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -8,7 +8,7 @@ from starlette.routing import BaseRoute, Mount, Route
 
 try:
     import yaml
-except ImportError:  # pragma: nocover
+except ModuleNotFoundError:  # pragma: nocover
     yaml = None  # type: ignore[assignment]
 
 

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -18,7 +18,7 @@ try:
         pass_context = jinja2.pass_context
     else:  # pragma: nocover
         pass_context = jinja2.contextfunction  # type: ignore[attr-defined]
-except ImportError:  # pragma: nocover
+except ModuleNotFoundError:  # pragma: nocover
     jinja2 = None  # type: ignore[assignment]
 
 


### PR DESCRIPTION
This makes errors less confusing if the module fails to import for a reason other than not existing