### PR TITLE
Run black before ruff

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -8,5 +8,5 @@ export SOURCE_FILES="starlette tests"
 
 set -x
 
-${PREFIX}ruff --fix $SOURCE_FILES
 ${PREFIX}black $SOURCE_FILES
+${PREFIX}ruff --fix $SOURCE_FILES


### PR DESCRIPTION
Black will wrap lines avoiding ruff errors. But if ruff errors then black won't run so you have to run black by hand.