### PR TITLE
Include all files in sdist archives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,6 @@ Source = "https://github.com/encode/starlette"
 [tool.hatch.version]
 path = "starlette/__init__.py"
 
-[tool.hatch.build.targets.sdist]
-include = [
-    "/starlette",
-]
-
 [tool.ruff]
 select = ["E", "F", "I"]
 


### PR DESCRIPTION
# Summary

Remove the restriction on files inclduded in sdist archives in order to include documentation sources and tests there.  This is the default hatchling behavior and it is helpful to packagers (such as Linux distributions or Conda) as it permits using sdist archives to do packaging (instead of GitHub archives that are not guaranteed to be reproducible).  Most of the ordinary users will not be affected since starlette is a pure Python package and therefore pip will prefer wheels to install it everywhere.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
