### PR TITLE
Add testclient test for domain restricted cookies

### DIFF
--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -273,3 +273,38 @@ def test_query_params(test_client_factory, param: str):
     client = test_client_factory(app)
     response = client.get("/", params={"param": param})
     assert response.text == param
+
+
+@pytest.mark.parametrize(
+    "domain, ok",
+    [
+        ("testserver", True),
+        ("testserver.local", True),
+        ("localhost", False),
+        ("example.com", False),
+    ],
+)
+def test_domain_restricted_cookies(test_client_factory, monkeypatch, domain, ok):
+    """
+    Test that test client discards domain restricted cookies which do not match the
+    base_url of the testclient (`http://testserver` by default).
+
+    The domain `testserver.local` works because the Python http.cookiejar module derives
+    the "effective domain" by appending `.local` to non-dotted request domains
+    in accordance with RFC 2965.
+    """
+
+    async def app(scope, receive, send):
+        response = Response("Hello, world!", media_type="text/plain")
+        response.set_cookie(
+            "mycookie",
+            "myvalue",
+            path="/",
+            domain=domain,
+        )
+        await response(scope, receive, send)
+
+    client = test_client_factory(app)
+    response = client.get("/")
+    cookie_set = len(response.cookies) == 1
+    assert cookie_set == ok

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -1,4 +1,5 @@
 import itertools
+import sys
 from asyncio import current_task as asyncio_current_task
 from contextlib import asynccontextmanager
 
@@ -278,7 +279,17 @@ def test_query_params(test_client_factory, param: str):
 @pytest.mark.parametrize(
     "domain, ok",
     [
-        ("testserver", True),
+        pytest.param(
+            "testserver",
+            True,
+            marks=[
+                pytest.mark.xfail(
+                    sys.version_info < (3, 11),
+                    reason="Fails due to domain handling in http.cookiejar module (see "
+                    "#2152)",
+                ),
+            ],
+        ),
         ("testserver.local", True),
         ("localhost", False),
         ("example.com", False),

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -295,7 +295,7 @@ def test_query_params(test_client_factory, param: str):
         ("example.com", False),
     ],
 )
-def test_domain_restricted_cookies(test_client_factory, monkeypatch, domain, ok):
+def test_domain_restricted_cookies(test_client_factory, domain, ok):
     """
     Test that test client discards domain restricted cookies which do not match the
     base_url of the testclient (`http://testserver` by default).


### PR DESCRIPTION
# Summary

This adds a test for #2152 which creates responses with domain restricted cookies for different domains.

The test with the `testserver` domain parametrization succeeds in Python 3.11 but fails on Python 3.10 and below.

Note that this PR just adds a partially failing test, but doesn't resolve #2152 (e.g. by changing documentation or changing the test client default `base_url`).


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
