### PR TITLE
Add missing type hints to Jinja2Templates()

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -24,8 +24,11 @@ routes = [
 app = Starlette(debug=True, routes=routes)
 ```
 
-Note that the incoming `request` instance must be included as part of the
-template context.
+Note that:
+
+* The incoming `request` instance must be included as part of the template context.
+
+* `directory=` can accept a sequence, e.g. `Jinja2Templates(directory=['templates', 'more_templates'])`.
 
 The Jinja2 template context will automatically include a `url_for` function,
 so we can correctly hyperlink to other pages within the application.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -35,8 +35,6 @@ app = Starlette(debug=True, routes=routes)
 Note that the incoming `request` instance must be included as part of the
 template context.
 
-* `directory=` can accept a sequence, e.g. `Jinja2Templates(directory=['templates', 'more_templates'])`.
-
 The Jinja2 template context will automatically include a `url_for` function,
 so we can correctly hyperlink to other pages within the application.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,6 +1,14 @@
 Starlette is not _strictly_ coupled to any particular templating engine, but
 Jinja2 provides an excellent choice.
 
+### Jinja2Templates
+
+Signature: `Jinja2Templates(directory, context_processors=None, **env_options)`
+
+* `directory` - A string, [os.Pathlike][pathlike] or a list of strings or [os.Pathlike][pathlike] denoting a directory path.
+* `context_processors` - A list of functions that return a dictionary to add to the template context.
+* `**env_options` - Additional keyword arguments to pass to the Jinja2 environment.
+
 Starlette provides a simple way to get `jinja2` configured. This is probably
 what you want to use by default.
 
@@ -24,9 +32,8 @@ routes = [
 app = Starlette(debug=True, routes=routes)
 ```
 
-Note that:
-
-* The incoming `request` instance must be included as part of the template context.
+Note that the incoming `request` instance must be included as part of the
+template context.
 
 * `directory=` can accept a sequence, e.g. `Jinja2Templates(directory=['templates', 'more_templates'])`.
 
@@ -131,3 +138,4 @@ for example, strictly evaluate any database queries within the view and
 include the final results in the context.
 
 [jinja2]: https://jinja.palletsprojects.com/en/3.0.x/api/?highlight=environment#writing-filters
+[pathlike]: https://docs.python.org/3/library/os.html#os.PathLike

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -64,7 +64,9 @@ class Jinja2Templates:
 
     def __init__(
         self,
-        directory: typing.Union[str, PathLike],
+        directory: typing.Union[
+            str, PathLike, typing.Sequence[typing.Union[str, PathLike]]
+        ],
         context_processors: typing.Optional[
             typing.List[typing.Callable[[Request], typing.Dict[str, typing.Any]]]
         ] = None,
@@ -75,7 +77,11 @@ class Jinja2Templates:
         self.context_processors = context_processors or []
 
     def _create_env(
-        self, directory: typing.Union[str, PathLike], **env_options: typing.Any
+        self,
+        directory: typing.Union[
+            str, PathLike, typing.Sequence[typing.Union[str, PathLike]]
+        ],
+        **env_options: typing.Any,
     ) -> "jinja2.Environment":
         @pass_context
         def url_for(context: dict, name: str, **path_params: typing.Any) -> URL:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -95,15 +95,15 @@ def test_templates_with_directories(tmp_path: Path, test_client_factory):
     dir_a = tmp_path.resolve() / "a"
     dir_a.mkdir()
     template_a = dir_a / "template_a.html"
-    template_a.write_text("<html>Hello, <a href='{{ url_for('page_a') }}'></a> a</html>")
+    template_a.write_text("<html><a href='{{ url_for('page_a') }}'></a> a</html>")
 
     async def page_a(request):
         return templates.TemplateResponse("template_a.html", {"request": request})
 
     dir_b = tmp_path.resolve() / "b"
     dir_b.mkdir()
-    template_b = dir_a / "template_b.html"
-    template_b.write_text("<html>Hello, <a href='{{ url_for('page_b') }}'></a> b</html>")
+    template_b = dir_b / "template_b.html"
+    template_b.write_text("<html><a href='{{ url_for('page_b') }}'></a> b</html>")
 
     async def page_b(request):
         return templates.TemplateResponse("template_b.html", {"request": request})
@@ -116,11 +116,11 @@ def test_templates_with_directories(tmp_path: Path, test_client_factory):
 
     client = test_client_factory(app)
     response = client.get("/a")
-    assert response.text == "<html>Hello, <a href='http://testserver/a'></a> a</html>"
+    assert response.text == "<html><a href='http://testserver/a'></a> a</html>"
     assert response.template.name == "template_a.html"
     assert set(response.context.keys()) == {"request"}
 
     response = client.get("/b")
-    assert response.text == "<html>Hello, <a href='http://testserver/b'></a> b</html>"
+    assert response.text == "<html><a href='http://testserver/b'></a> b</html>"
     assert response.template.name == "template_b.html"
     assert set(response.context.keys()) == {"request"}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -92,7 +92,7 @@ def test_template_with_middleware(tmpdir, test_client_factory):
 
 
 def test_templates_with_directories(tmp_path, test_client_factory):
-    dir_home: Path = tmp_path / "home"
+    dir_home: Path = tmp_path.resolve() / "home"
     dir_home.mkdir()
     template = dir_home / "index.html"
     with template.open("w") as file:
@@ -101,7 +101,7 @@ def test_templates_with_directories(tmp_path, test_client_factory):
     async def homepage(request):
         return templates.TemplateResponse("index.html", {"request": request})
 
-    dir_A: Path = dir_home.parent / "A"
+    dir_A: Path = dir_home.parent.resolve() / "A"
     dir_A.mkdir()
     template_A = dir_A / "template_A.html"
     with template_A.open("w") as file:
@@ -116,9 +116,11 @@ def test_templates_with_directories(tmp_path, test_client_factory):
     )
     templates = Jinja2Templates(directory=[dir_home, dir_A])
 
-    assert dir_home.absolute() != dir_A.absolute()
-    assert not dir_home.is_relative_to(dir_A)
-    assert not dir_A.is_relative_to(dir_home)
+    assert dir_home != dir_A
+    with pytest.raises(ValueError):
+        dir_home.relative_to(dir_A)
+    with pytest.raises(ValueError):
+        assert not dir_A.relative_to(dir_home)
 
     client = test_client_factory(app)
     response = client.get("/")


### PR DESCRIPTION
# Summary
[`FileSystemLoader()`](https://github.com/pallets/jinja/blob/953acd65b2be5428482dcb60f5b8481b66252ac9/src/jinja2/loaders.py#L151) from jinja2 (see its comment block) has supported both a single `str` / `PathLike` or a
sequence of them for at least four years. Starlette currently only has typehints for a single `str` / `PathLike`.

Mypy passes. Documented and test created.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.
