### PR TITLE
Add env argument to Jinja2Templates, remove **env_options. (ref #2134)

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -61,7 +61,7 @@ templates.env.filters['marked'] = marked_filter
 
 ## Using custom jinja2.Environment instance
 
-Starlette also accepts a preconfigured `jinja2.Environment` instance. 
+Starlette also accepts a preconfigured [`jinja2.Environment`](https://jinja.palletsprojects.com/en/3.0.x/api/#api) instance. 
 
 
 ```python

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -58,6 +58,21 @@ templates = Jinja2Templates(directory='templates')
 templates.env.filters['marked'] = marked_filter
 ```
 
+
+## Using custom jinja2.Environment instance
+
+Starlette also accepts a preconfigured `jinja2.Environment` instance. 
+
+
+```python
+import jinja2
+from starlette.templating import Jinja2Templates
+
+env = jinja2.Environment(...)
+templates = Jinja2Templates(env=env)
+```
+
+
 ## Context processors
 
 A context processor is a function that returns a dictionary to be merged into a template context.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -50,6 +50,21 @@ templates = Jinja2Templates(directory='templates')
 templates.env.filters['marked'] = marked_filter
 ```
 
+
+## Using custom jinja2.Environment instance
+
+Starlette also accepts a preconfigured `jinja2.Environment` instance. 
+
+
+```python
+import jinja2
+from starlette.templating import Jinja2Templates
+
+env = jinja2.Environment(...)
+templates = Jinja2Templates(env=env)
+```
+
+
 ## Context processors
 
 A context processor is a function that returns a dictionary to be merged into a template context.

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -71,11 +71,12 @@ class Jinja2Templates:
             typing.List[typing.Callable[[Request], typing.Dict[str, typing.Any]]]
         ] = None,
         env: typing.Optional[jinja2.Environment] = None,
+        **env_options: typing.Any,
     ) -> None:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         assert directory or env, "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []
-        self.env = env or self._create_env(str(directory))
+        self.env = env or self._create_env(str(directory), **env_options)
 
     def _create_env(
         self,
@@ -92,7 +93,10 @@ class Jinja2Templates:
             return request.url_for(__name, **path_params)
 
         loader = jinja2.FileSystemLoader(directory)
-        env = jinja2.Environment(loader=loader, autoescape=True)
+        env_options.setdefault("loader", loader)
+        env_options.setdefault("autoescape", True)
+
+        env = jinja2.Environment(**env_options)
         env.globals["url_for"] = url_for
         return env
 

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -1,4 +1,5 @@
 import typing
+import warnings
 from os import PathLike
 
 from starlette.background import BackgroundTask
@@ -73,6 +74,11 @@ class Jinja2Templates:
         env: typing.Optional[jinja2.Environment] = None,
         **env_options: typing.Any,
     ) -> None:
+        if env_options:
+            warnings.warn(
+                "Extra environment options are deprecated. Use a preconfigured jinja2.Environment instead.",  # noqa: E501
+                DeprecationWarning,
+            )
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         assert directory or env, "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -73,10 +73,7 @@ class Jinja2Templates:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         assert directory or env, "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []
-        if env:
-            self.env = env
-        else:
-            self.env = self._create_env(str(directory))
+        self.env = env or self._create_env(str(directory))
 
     def _create_env(
         self, directory: typing.Union[str, PathLike]

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -82,7 +82,7 @@ class Jinja2Templates:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         assert directory or env, "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []
-        self.env = env or self._create_env(str(directory), **env_options)
+        self.env = env or self._create_env(directory, **env_options)
 
     def _create_env(
         self,

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -75,10 +75,7 @@ class Jinja2Templates:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         assert directory or env, "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []
-        if env:
-            self.env = env
-        else:
-            self.env = self._create_env(str(directory))
+        self.env = env or self._create_env(str(directory))
 
     def _create_env(
         self,

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -71,7 +71,7 @@ class Jinja2Templates:
         context_processors: typing.Optional[
             typing.List[typing.Callable[[Request], typing.Dict[str, typing.Any]]]
         ] = None,
-        env: typing.Optional[jinja2.Environment] = None,
+        env: typing.Optional["jinja2.Environment"] = None,
         **env_options: typing.Any,
     ) -> None:
         if env_options:

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -1,4 +1,5 @@
 import typing
+import warnings
 from os import PathLike
 
 from starlette.background import BackgroundTask
@@ -71,6 +72,11 @@ class Jinja2Templates:
         env: typing.Optional[jinja2.Environment] = None,
         **env_options: typing.Any,
     ) -> None:
+        if env_options:
+            warnings.warn(
+                "Extra environment options are deprecated. Use a preconfigured jinja2.Environment instead.",  # noqa: E501
+                DeprecationWarning,
+            )
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         assert directory or env, "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -82,7 +82,10 @@ class Jinja2Templates:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         assert directory or env, "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []
-        self.env = env or self._create_env(directory, **env_options)
+        if directory is not None:
+            self.env = self._create_env(directory, **env_options)
+        elif env is not None:
+            self.env = env
 
     def _create_env(
         self,

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -69,14 +69,17 @@ class Jinja2Templates:
             typing.List[typing.Callable[[Request], typing.Dict[str, typing.Any]]]
         ] = None,
         env: typing.Optional[jinja2.Environment] = None,
+        **env_options: typing.Any,
     ) -> None:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
         assert directory or env, "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []
-        self.env = env or self._create_env(str(directory))
+        self.env = env or self._create_env(str(directory), **env_options)
 
     def _create_env(
-        self, directory: typing.Union[str, PathLike]
+        self,
+        directory: typing.Union[str, PathLike],
+        **env_options: typing.Any,
     ) -> "jinja2.Environment":
         @pass_context
         def url_for(context: dict, name: str, **path_params: typing.Any) -> URL:
@@ -84,7 +87,10 @@ class Jinja2Templates:
             return request.url_for(name, **path_params)
 
         loader = jinja2.FileSystemLoader(directory)
-        env = jinja2.Environment(loader=loader, autoescape=True)
+        env_options.setdefault("loader", loader)
+        env_options.setdefault("autoescape", True)
+
+        env = jinja2.Environment(**env_options)
         env.globals["url_for"] = url_for
         return env
 

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -63,11 +63,39 @@ class Jinja2Templates:
     return templates.TemplateResponse("index.html", {"request": request})
     """
 
+    @typing.overload
+    def __init__(
+        self,
+        directory: typing.Union[
+            str,
+            PathLike,
+            typing.Sequence[typing.Union[str, PathLike]],
+        ],
+        *,
+        context_processors: typing.Optional[
+            typing.List[typing.Callable[[Request], typing.Dict[str, typing.Any]]]
+        ] = None,
+        **env_options: typing.Any,
+    ) -> None:
+        ...
+
+    @typing.overload
+    def __init__(
+        self,
+        *,
+        env: "jinja2.Environment",
+        context_processors: typing.Optional[
+            typing.List[typing.Callable[[Request], typing.Dict[str, typing.Any]]]
+        ] = None,
+    ) -> None:
+        ...
+
     def __init__(
         self,
         directory: typing.Union[
             str, PathLike, typing.Sequence[typing.Union[str, PathLike]], None
         ] = None,
+        *,
         context_processors: typing.Optional[
             typing.List[typing.Callable[[Request], typing.Dict[str, typing.Any]]]
         ] = None,

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -65,16 +65,20 @@ class Jinja2Templates:
     def __init__(
         self,
         directory: typing.Union[
-            str, PathLike, typing.Sequence[typing.Union[str, PathLike]]
-        ],
+            str, PathLike, typing.Sequence[typing.Union[str, PathLike]], None
+        ] = None,
         context_processors: typing.Optional[
             typing.List[typing.Callable[[Request], typing.Dict[str, typing.Any]]]
         ] = None,
-        **env_options: typing.Any,
+        env: typing.Optional[jinja2.Environment] = None,
     ) -> None:
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
-        self.env = self._create_env(directory, **env_options)
+        assert directory or env, "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []
+        if env:
+            self.env = env
+        else:
+            self.env = self._create_env(str(directory))
 
     def _create_env(
         self,
@@ -91,10 +95,7 @@ class Jinja2Templates:
             return request.url_for(__name, **path_params)
 
         loader = jinja2.FileSystemLoader(directory)
-        env_options.setdefault("loader", loader)
-        env_options.setdefault("autoescape", True)
-
-        env = jinja2.Environment(**env_options)
+        env = jinja2.Environment(loader=loader, autoescape=True)
         env.globals["url_for"] = url_for
         return env
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -138,7 +138,7 @@ def test_templates_with_directory(tmpdir):
     path = os.path.join(tmpdir, "index.html")
     with open(path, "w") as file:
         file.write("Hello")
-        
+
     templates = Jinja2Templates(directory=str(tmpdir))
     template = templates.get_template("index.html")
     assert template.render({}) == "Hello"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -102,7 +102,7 @@ def test_templates_with_directory(tmpdir):
     path = os.path.join(tmpdir, "index.html")
     with open(path, "w") as file:
         file.write("Hello")
-        
+
     templates = Jinja2Templates(directory=str(tmpdir))
     template = templates.get_template("index.html")
     assert template.render({}) == "Hello"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+import jinja2
 import pytest
 
 from starlette.applications import Starlette
@@ -124,3 +125,30 @@ def test_templates_with_directories(tmp_path: Path, test_client_factory):
     assert response.text == "<html><a href='http://testserver/b'></a> b</html>"
     assert response.template.name == "template_b.html"
     assert set(response.context.keys()) == {"request"}
+
+
+def test_templates_require_directory_or_environment():
+    with pytest.raises(
+        AssertionError, match="either 'directory' or 'env' arguments must be passed"
+    ):
+        Jinja2Templates()
+
+
+def test_templates_with_directory(tmpdir):
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("Hello")
+    templates = Jinja2Templates(directory=str(tmpdir))
+    template = templates.get_template("index.html")
+    assert template.render({}) == "Hello"
+
+
+def test_templates_with_environment(tmpdir):
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("Hello")
+
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(tmpdir)))
+    templates = Jinja2Templates(env=env)
+    template = templates.get_template("index.html")
+    assert template.render({}) == "Hello"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -138,6 +138,7 @@ def test_templates_with_directory(tmpdir):
     path = os.path.join(tmpdir, "index.html")
     with open(path, "w") as file:
         file.write("Hello")
+        
     templates = Jinja2Templates(directory=str(tmpdir))
     template = templates.get_template("index.html")
     assert template.render({}) == "Hello"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -153,3 +153,8 @@ def test_templates_with_environment(tmpdir):
     templates = Jinja2Templates(env=env)
     template = templates.get_template("index.html")
     assert template.render({}) == "Hello"
+
+
+def test_templates_with_environment_options_emit_warning(tmpdir):
+    with pytest.warns(DeprecationWarning):
+        Jinja2Templates(str(tmpdir), autoescape=True)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -102,6 +102,7 @@ def test_templates_with_directory(tmpdir):
     path = os.path.join(tmpdir, "index.html")
     with open(path, "w") as file:
         file.write("Hello")
+        
     templates = Jinja2Templates(directory=str(tmpdir))
     template = templates.get_template("index.html")
     assert template.render({}) == "Hello"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -131,7 +131,7 @@ def test_templates_require_directory_or_environment():
     with pytest.raises(
         AssertionError, match="either 'directory' or 'env' arguments must be passed"
     ):
-        Jinja2Templates()
+        Jinja2Templates()  # type: ignore[call-overload]
 
 
 def test_templates_with_directory(tmpdir):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,5 +1,6 @@
 import os
 
+import jinja2
 import pytest
 
 from starlette.applications import Starlette
@@ -88,3 +89,30 @@ def test_template_with_middleware(tmpdir, test_client_factory):
     assert response.text == "<html>Hello, <a href='http://testserver/'>world</a></html>"
     assert response.template.name == "index.html"
     assert set(response.context.keys()) == {"request"}
+
+
+def test_templates_require_directory_or_environment():
+    with pytest.raises(
+        AssertionError, match="either 'directory' or 'env' arguments must be passed"
+    ):
+        Jinja2Templates()
+
+
+def test_templates_with_directory(tmpdir):
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("Hello")
+    templates = Jinja2Templates(directory=str(tmpdir))
+    template = templates.get_template("index.html")
+    assert template.render({}) == "Hello"
+
+
+def test_templates_with_environment(tmpdir):
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("Hello")
+
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(tmpdir)))
+    templates = Jinja2Templates(env=env)
+    template = templates.get_template("index.html")
+    assert template.render({}) == "Hello"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -117,3 +117,8 @@ def test_templates_with_environment(tmpdir):
     templates = Jinja2Templates(env=env)
     template = templates.get_template("index.html")
     assert template.render({}) == "Hello"
+
+
+def test_templates_with_environment_options_emit_warning(tmpdir):
+    with pytest.warns(DeprecationWarning):
+        Jinja2Templates(str(tmpdir), autoescape=True)


### PR DESCRIPTION
This PR adds `env` argument to `Jinja2Templates` class and removes `**env_options`. 

**Motivation**
See this discussion - #2134

1. arguments of `Jinja2Templates` configure only this class and nothing else
2. users can configure `jinja2.Environment` and use it in the app without limits
3. the `Environment` class may be used by other app components, not just by Starlette

This is a  breaking change!

**Example**
```python
import jinja2
from starlette.templating import Jinja2Templates

env = jinja2.Environment(...)
templates = Jinja2Templates(env=env)
```