### PR TITLE
Fix empty str(exception) when initialized with kwargs

### DIFF
--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -12,12 +12,15 @@ class HTTPException(Exception):
         detail: typing.Optional[str] = None,
         headers: typing.Optional[dict] = None,
     ) -> None:
+        super().__init__()
         if detail is None:
             detail = http.HTTPStatus(status_code).phrase
         self.status_code = status_code
         self.detail = detail
         self.headers = headers
-        super().__init__(detail)
+
+    def __str__(self) -> str:
+        return f"{self.status_code}: {self.detail}"
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
@@ -26,9 +29,12 @@ class HTTPException(Exception):
 
 class WebSocketException(Exception):
     def __init__(self, code: int, reason: typing.Optional[str] = None) -> None:
+        super().__init__()
         self.code = code
         self.reason = reason or ""
-        super().__init__(self.reason)
+
+    def __str__(self) -> str:
+        return f"{self.code}: {self.reason}"
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -12,7 +12,6 @@ class HTTPException(Exception):
         detail: typing.Optional[str] = None,
         headers: typing.Optional[dict] = None,
     ) -> None:
-        super().__init__()
         if detail is None:
             detail = http.HTTPStatus(status_code).phrase
         self.status_code = status_code
@@ -29,7 +28,6 @@ class HTTPException(Exception):
 
 class WebSocketException(Exception):
     def __init__(self, code: int, reason: typing.Optional[str] = None) -> None:
-        super().__init__()
         self.code = code
         self.reason = reason or ""
 

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -17,6 +17,7 @@ class HTTPException(Exception):
         self.status_code = status_code
         self.detail = detail
         self.headers = headers
+        super().__init__(detail)
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
@@ -27,6 +28,7 @@ class WebSocketException(Exception):
     def __init__(self, code: int, reason: typing.Optional[str] = None) -> None:
         self.code = code
         self.reason = reason or ""
+        super().__init__(self.reason)
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+import http
 import warnings
 
 import pytest
@@ -144,13 +145,17 @@ def test_force_500_response(test_client_factory):
     assert response.text == ""
 
 
-def test_http_repr():
-    assert repr(HTTPException(404)) == (
-        "HTTPException(status_code=404, detail='Not Found')"
+def test_http_str_and_repr():
+    exception = HTTPException(404)
+    should_detail = http.HTTPStatus(exception.status_code).phrase
+    assert str(exception) == should_detail
+    assert repr(exception) == (
+        f"HTTPException(status_code=404, detail='{should_detail}')"
     )
-    assert repr(HTTPException(404, detail="Not Found: foo")) == (
-        "HTTPException(status_code=404, detail='Not Found: foo')"
-    )
+    detail = "Not Found: foo"
+    exception = HTTPException(status_code=404, detail=detail)
+    assert str(exception) == detail
+    assert repr(exception) == (f"HTTPException(status_code=404, detail='{detail}')")
 
     class CustomHTTPException(HTTPException):
         pass
@@ -160,10 +165,11 @@ def test_http_repr():
     )
 
 
-def test_websocket_repr():
-    assert repr(WebSocketException(1008, reason="Policy Violation")) == (
-        "WebSocketException(code=1008, reason='Policy Violation')"
-    )
+def test_websocket_str_and_repr():
+    reason = "Policy Violation"
+    exception = WebSocketException(code=1008, reason=reason)
+    assert str(exception) == reason
+    assert repr(exception) == (f"WebSocketException(code=1008, reason='{reason}')")
 
     class CustomWebSocketException(WebSocketException):
         pass

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -145,17 +145,23 @@ def test_force_500_response(test_client_factory):
     assert response.text == ""
 
 
-def test_http_str_and_repr():
-    exception = HTTPException(404)
+def test_http_str():
+    code = 404
+    exception = HTTPException(code)
     should_detail = http.HTTPStatus(exception.status_code).phrase
-    assert str(exception) == should_detail
-    assert repr(exception) == (
-        f"HTTPException(status_code=404, detail='{should_detail}')"
-    )
+    assert str(exception) == f"{code}: {should_detail}"
     detail = "Not Found: foo"
-    exception = HTTPException(status_code=404, detail=detail)
-    assert str(exception) == detail
-    assert repr(exception) == (f"HTTPException(status_code=404, detail='{detail}')")
+    kwargs_exception = HTTPException(status_code=404, detail=detail)
+    assert str(kwargs_exception) == f"{code}: {detail}"
+
+
+def test_http_repr():
+    assert repr(HTTPException(404)) == (
+        "HTTPException(status_code=404, detail='Not Found')"
+    )
+    assert repr(HTTPException(404, detail="Not Found: foo")) == (
+        "HTTPException(status_code=404, detail='Not Found: foo')"
+    )
 
     class CustomHTTPException(HTTPException):
         pass
@@ -165,11 +171,17 @@ def test_http_str_and_repr():
     )
 
 
-def test_websocket_str_and_repr():
+def test_websocket_str():
+    code = 1008
     reason = "Policy Violation"
-    exception = WebSocketException(code=1008, reason=reason)
-    assert str(exception) == reason
-    assert repr(exception) == (f"WebSocketException(code=1008, reason='{reason}')")
+    exception = WebSocketException(code, reason)
+    assert str(exception) == f"{code}: {reason}"
+
+
+def test_websocket_repr():
+    assert repr(WebSocketException(1008, reason="Policy Violation")) == (
+        "WebSocketException(code=1008, reason='Policy Violation')"
+    )
 
     class CustomWebSocketException(WebSocketException):
         pass

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -146,13 +146,9 @@ def test_force_500_response(test_client_factory):
 
 
 def test_http_str():
-    code = 404
-    exception = HTTPException(code)
-    should_detail = http.HTTPStatus(exception.status_code).phrase
-    assert str(exception) == f"{code}: {should_detail}"
-    detail = "Not Found: foo"
-    kwargs_exception = HTTPException(status_code=404, detail=detail)
-    assert str(kwargs_exception) == f"{code}: {detail}"
+    assert str(HTTPException(status_code=404)) == "404: Not Found"
+    assert str(HTTPException(404, "Not Found: foo")) == "404: Not Found: foo"
+    assert str(HTTPException(404, headers={"key": "value"})) == "404: Not Found"
 
 
 def test_http_repr():
@@ -172,10 +168,8 @@ def test_http_repr():
 
 
 def test_websocket_str():
-    code = 1008
-    reason = "Policy Violation"
-    exception = WebSocketException(code, reason)
-    assert str(exception) == f"{code}: {reason}"
+    assert str(WebSocketException(1008)) == "1008: "
+    assert str(WebSocketException(1008, "Policy Violation")) == "1008: Policy Violation"
 
 
 def test_websocket_repr():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,3 @@
-import http
 import warnings
 
 import pytest


### PR DESCRIPTION
Add a `super().__init__` call to sub class of Python standard `Exception`, for two reasons:

* It's convention to call it for sub class
* Like the title says, when `HTTPException` is initialized with kwargs, `str(HTTPException)` is empty, which is just the case I met in this [pytest error case](https://github.com/pytest-dev/pytest/pull/11073).

Thanks for your attention.