### PR TITLE
fix: collect routes from Host(#2118)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ venv*/
 .python-version
 build/
 dist/
-env*/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv*/
 .python-version
 build/
 dist/
+env*/

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -50,10 +50,11 @@ class BaseSchemaGenerator:
 
         for route in routes:
             if isinstance(route, (Mount, Host)):
-                path = ""
+                routes = route.routes or []
                 if isinstance(route, Mount):
                     path = self._remove_converter(route.path)
-                routes = route.routes or []  # type: ignore
+                else:
+                    path = ""
                 sub_endpoints = [
                     EndpointInfo(
                         path="".join((path, sub_endpoint.path)),

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -49,24 +49,14 @@ class BaseSchemaGenerator:
         endpoints_info: list = []
 
         for route in routes:
-            if isinstance(route, Mount):
-                path = self._remove_converter(route.path)
-                routes = route.routes or []
+            if isinstance(route, (Mount, Host)):
+                path = ""
+                if isinstance(route, Mount):
+                    path = self._remove_converter(route.path)
+                routes = route.routes or []  # type: ignore
                 sub_endpoints = [
                     EndpointInfo(
                         path="".join((path, sub_endpoint.path)),
-                        http_method=sub_endpoint.http_method,
-                        func=sub_endpoint.func,
-                    )
-                    for sub_endpoint in self.get_endpoints(routes)
-                ]
-                endpoints_info.extend(sub_endpoints)
-
-            elif isinstance(route, Host):
-                routes = route.routes or []
-                sub_endpoints = [
-                    EndpointInfo(
-                        path=sub_endpoint.path,
                         http_method=sub_endpoint.http_method,
                         func=sub_endpoint.func,
                     )

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -4,7 +4,7 @@ import typing
 
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.routing import BaseRoute, Mount, Route
+from starlette.routing import BaseRoute, Host, Mount, Route
 
 try:
     import yaml
@@ -55,6 +55,18 @@ class BaseSchemaGenerator:
                 sub_endpoints = [
                     EndpointInfo(
                         path="".join((path, sub_endpoint.path)),
+                        http_method=sub_endpoint.http_method,
+                        func=sub_endpoint.func,
+                    )
+                    for sub_endpoint in self.get_endpoints(routes)
+                ]
+                endpoints_info.extend(sub_endpoints)
+
+            elif isinstance(route, Host):
+                routes = route.routes or []
+                sub_endpoints = [
+                    EndpointInfo(
+                        path=sub_endpoint.path,
                         http_method=sub_endpoint.http_method,
                         func=sub_endpoint.func,
                     )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,6 +1,6 @@
 from starlette.applications import Starlette
 from starlette.endpoints import HTTPEndpoint
-from starlette.routing import Mount, Route, WebSocketRoute
+from starlette.routing import Host, Mount, Route, Router, WebSocketRoute
 from starlette.schemas import SchemaGenerator
 
 schemas = SchemaGenerator(
@@ -123,6 +123,7 @@ app = Starlette(
         Route("/no-docstring", endpoint=no_docstring),
         Route("/schema", endpoint=schema, methods=["GET"], include_in_schema=False),
         Mount("/subapp", subapp),
+        Host("sub.domain.com", app=Router(routes=[Mount("/subapp2", subapp)])),
     ]
 )
 
@@ -159,6 +160,13 @@ def test_schema_generation():
                 }
             },
             "/subapp/subapp-endpoint": {
+                "get": {
+                    "responses": {
+                        200: {"description": "This endpoint is part of a subapp."}
+                    }
+                }
+            },
+            "/subapp2/subapp-endpoint": {
                 "get": {
                     "responses": {
                         200: {"description": "This endpoint is part of a subapp."}
@@ -220,6 +228,11 @@ paths:
         200:
           description: This is included in the schema.
   /subapp/subapp-endpoint:
+    get:
+      responses:
+        200:
+          description: This endpoint is part of a subapp.
+  /subapp2/subapp-endpoint:
     get:
       responses:
         200:


### PR DESCRIPTION
# Summary

When developer defines Host in application, routes of Host cannot be generated to OpenAPI schemas so this PR fixes that.

I collect routes (in get_endpoints) in Host class when generating OpenAPI schemas


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
