### PR TITLE
Only initialize the GZipResponder gzip buffer when needed

### DIFF
--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -36,7 +36,7 @@ class GZipResponder:
         self.content_encoding_set = False
         self.compresslevel = compresslevel
 
-    def _init_gzip_buffer(self):
+    def _init_gzip_buffer(self) -> None:
         # Only initialize these when going to definitely need.
         self.gzip_buffer = io.BytesIO()
         self.gzip_file = gzip.GzipFile(


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
Only initialize self.gzip_buffer / self.gzip_file when going down codepaths where compression will definitely apply. Get those ping responses out faster by making  GzipMiddleware have less per-hit overhead if the hit isn't going to need compression.

I reviewed test_gzip.py and they cover all the codepath variants here already, and pass with 100% coverage over the module.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
