### PR TITLE
Change JSONResponse headers type annotation

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -189,7 +189,7 @@ class JSONResponse(Response):
         self,
         content: typing.Any,
         status_code: int = 200,
-        headers: typing.Optional[typing.Dict[str, str]] = None,
+        headers: typing.Optional[typing.Mapping[str, str]] = None,
         media_type: typing.Optional[str] = None,
         background: typing.Optional[BackgroundTask] = None,
     ) -> None:


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
As agreed in this discussion (https://github.com/encode/starlette/discussions/2186), the type annotation for the `headers` parameter of `JSONResponse` is changed from `typing.Optional[typing.Dict[str, str]]` to `typing.Optional[typing.Mapping[str, str]]` to align with the other response classes.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
