### PR TITLE
Add include_router to Starlette and Router

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -237,6 +237,21 @@ class Starlette:
 
         return decorator
 
+    def include_router(
+        self,
+        router: Router,
+        *,
+        prefix: str = "",
+        include_in_schema: bool = True,
+        **kwargs: typing.Any,  # arguments to extend by inherits
+    ) -> None:
+        self.router.include_router(
+            router,
+            prefix=prefix,
+            include_in_schema=include_in_schema,
+            **kwargs,
+        )
+
     def middleware(self, middleware_type: str) -> typing.Callable:
         """
         We no longer document this decorator style API, and its usage is discouraged.

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -751,15 +751,16 @@ class Router:
                 name=route.name,
             )
 
-    def _merge_router_events(self, router: "Router") -> None:
-        for handler in router.on_startup:
-            self.add_event_handler("startup", handler)
-        for handler in router.on_shutdown:
-            self.add_event_handler("shutdown", handler)
-        self.lifespan_context = _merge_lifespan_context(
-            self.lifespan_context,
-            router.lifespan_context,
-        )
+    def _merge_router_events(self, router: typing.Optional["Router"]) -> None:
+        if router is not None:
+            for handler in router.on_startup:
+                self.add_event_handler("startup", handler)
+            for handler in router.on_shutdown:
+                self.add_event_handler("shutdown", handler)
+            self.lifespan_context = _merge_lifespan_context(
+                self.lifespan_context,
+                router.lifespan_context,
+            )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
@@ -820,8 +821,7 @@ class Router:
         self, path: str, app: ASGIApp, name: typing.Optional[str] = None
     ) -> None:  # pragma: nocover
         route = Mount(path, app=app, name=name)
-        if getattr(app, "router", None) is not None:
-            self._merge_router_events(app.router)
+        self._merge_router_events(getattr(app, "router", None))
         self.routes.append(route)
 
     def host(

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -820,7 +820,8 @@ class Router:
         self, path: str, app: ASGIApp, name: typing.Optional[str] = None
     ) -> None:  # pragma: nocover
         route = Mount(path, app=app, name=name)
-        self._merge_router_events(app.router)
+        if getattr(app, "router", None) is not None:
+            self._merge_router_events(app.router)
         self.routes.append(route)
 
     def host(

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -820,6 +820,7 @@ class Router:
         self, path: str, app: ASGIApp, name: typing.Optional[str] = None
     ) -> None:  # pragma: nocover
         route = Mount(path, app=app, name=name)
+        self._merge_router_events(app.router)
         self.routes.append(route)
 
     def host(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1147,19 +1147,19 @@ def test_include_router() -> None:
 
 def test_router_nested_lifespan_state() -> None:
     @contextlib.asynccontextmanager
-    async def lifespan(app: Starlette) -> typing.AsyncGenerator[None, None]:
+    async def lifespan(app: Starlette):
         app.state.app_startup = True
         yield {"app": True}
         app.state.app_shutdown = True
 
     @contextlib.asynccontextmanager
-    async def router_lifespan(app: Starlette) -> typing.AsyncGenerator[None, None]:
+    async def router_lifespan(app: Starlette):
         app.state.router_startup = True
         yield {"router": True}
         app.state.router_shutdown = True
 
     @contextlib.asynccontextmanager
-    async def subrouter_lifespan(app: Starlette) -> typing.AsyncGenerator[None, None]:
+    async def subrouter_lifespan(app: Starlette):
         app.state.sub_router_startup = True
         yield {"sub_router": True}
         app.state.sub_router_shutdown = True

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1129,10 +1129,10 @@ def test_include_router() -> None:
     nested_router = Router(
         routes=[
             Route("/home", endpoint=homepage, include_in_schema=True),
-            WebSocketRoute("/ws", endpoint=ws_helloworld)
+            WebSocketRoute("/ws", endpoint=ws_helloworld),
         ]
     )
-    
+
     base_router.include_router(nested_router, prefix="/nested", include_in_schema=False)
 
     route1 = base_router.routes[0]
@@ -1189,11 +1189,13 @@ def test_router_events() -> None:
     app = Starlette()
 
     with pytest.warns(DeprecationWarning):
+
         @app.on_event("startup")
         def app_startup() -> None:
             app.state.app_startup = True
 
     with pytest.warns(DeprecationWarning):
+
         @app.on_event("shutdown")
         def app_shutdown() -> None:
             app.state.app_shutdown = True
@@ -1201,11 +1203,13 @@ def test_router_events() -> None:
     router = Router()
 
     with pytest.warns(DeprecationWarning):
+
         @router.on_event("startup")
         def router_startup() -> None:
             app.state.router_startup = True
 
     with pytest.warns(DeprecationWarning):
+
         @router.on_event("shutdown")
         def router_shutdown() -> None:
             app.state.router_shutdown = True
@@ -1213,11 +1217,13 @@ def test_router_events() -> None:
     sub_router = Router()
 
     with pytest.warns(DeprecationWarning):
+
         @sub_router.on_event("startup")
         def sub_router_startup() -> None:
             app.state.sub_router_startup = True
 
     with pytest.warns(DeprecationWarning):
+
         @sub_router.on_event("shutdown")
         def sub_router_shutdown() -> None:
             app.state.sub_router_shutdown = True


### PR DESCRIPTION
# Summary

It's a PR connected with **FastAPI** nested lifespan [bugfix](https://github.com/tiangolo/fastapi/pull/9630).
So, there is a raw `include_router` implementation to inherit it by the **FastAPI** next step.
Also, it merge all nested by `mount` applications' events and lifespans to main application (#649).

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
