### PR TITLE
Clarify lifespan vs on_startup/on_shutdown priority

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -41,7 +41,9 @@ class Starlette:
     standard functions, or async functions.
     * **lifespan** - A lifespan context function, which can be used to perform
     startup and shutdown tasks. This is a newer style that replaces the
-    `on_startup` and `on_shutdown` handlers. Use one or the other, not both.
+    `on_startup` and `on_shutdown` handlers. Use one or the other, not both. If
+    both lifespan and on_startup/on_shutdown are used, only lifespan would be
+    used.
     """
 
     def __init__(

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -41,9 +41,7 @@ class Starlette:
     standard functions, or async functions.
     * **lifespan** - A lifespan context function, which can be used to perform
     startup and shutdown tasks. This is a newer style that replaces the
-    `on_startup` and `on_shutdown` handlers. Use one or the other, not both. If
-    both lifespan and on_startup/on_shutdown are used, only lifespan would be
-    used.
+    `on_startup` and `on_shutdown` handlers. Use one or the other, not both.
     """
 
     def __init__(

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -606,15 +606,14 @@ class Router:
                 "See more about it on https://www.starlette.io/lifespan/.",
                 DeprecationWarning,
             )
+            if lifespan:
+                warnings.warn(
+                    "The `lifespan` parameter cannot be used with `on_startup` or `on_shutdown`. "
+                    "Both `on_startup` and `on_shutdown` will be ignored."
+                )
 
         if lifespan is None:
             self.lifespan_context: Lifespan = _DefaultLifespan(self)
-
-        if (on_startup or on_shutdown) and lifespan is not None:
-            warnings.warn(
-                "Lifespan cannot be used together with on_startup, on_shutdown.  The "
-                "on_startup, on_shutdown parameters will be ignored!"
-            )
 
         elif inspect.isasyncgenfunction(lifespan):
             warnings.warn(

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -610,6 +610,12 @@ class Router:
         if lifespan is None:
             self.lifespan_context: Lifespan = _DefaultLifespan(self)
 
+        if (on_startup or on_shutdown) and lifespan is not None:
+            warnings.warn(
+                "Lifespan cannot be used together with on_startup, on_shutdown.  The "
+                "on_startup, on_shutdown parameters will be ignored!"
+            )
+
         elif inspect.isasyncgenfunction(lifespan):
             warnings.warn(
                 "async generator function lifespans are deprecated, "

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -608,8 +608,9 @@ class Router:
             )
             if lifespan:
                 warnings.warn(
-                    "The `lifespan` parameter cannot be used with `on_startup` or `on_shutdown`. "
-                    "Both `on_startup` and `on_shutdown` will be ignored."
+                    "The `lifespan` parameter cannot be used with `on_startup` or "
+                    "`on_shutdown`. Both `on_startup` and `on_shutdown` will be "
+                    "ignored."
                 )
 
         if lifespan is None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -663,7 +663,8 @@ def test_lifespan_with_on_events():
         return PlainTextResponse("hello, world")
 
     with pytest.warns(
-        UserWarning, match="The `lifespan` parameter cannot be used with `on_startup` or `on_shutdown`."
+        UserWarning,
+        match="The `lifespan` parameter cannot be used with `on_startup` or `on_shutdown`.",
     ):
         Router(
             on_startup=[run_startup],

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -648,6 +648,31 @@ def test_lifespan_async(test_client_factory):
     assert shutdown_complete
 
 
+def test_lifespan_with_on_events():
+    @contextlib.asynccontextmanager
+    async def lifespan(app):
+        yield {"foo": "bar"}
+
+    def run_startup():
+        pass
+
+    def run_shutdown():
+        pass
+
+    def hello_world(request):
+        return PlainTextResponse("hello, world")
+
+    with pytest.warns(
+        UserWarning, match="Lifespan cannot be used together with on_startup"
+    ):
+        Router(
+            on_startup=[run_startup],
+            on_shutdown=[run_shutdown],
+            lifespan=lifespan,
+            routes=[Route("/", hello_world)],
+        )
+
+
 def test_lifespan_sync(test_client_factory):
     startup_complete = False
     shutdown_complete = False

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -664,7 +664,10 @@ def test_lifespan_with_on_events():
 
     with pytest.warns(
         UserWarning,
-        match="The `lifespan` parameter cannot be used with `on_startup` or `on_shutdown`.",
+        match=(
+            "The `lifespan` parameter cannot be used with `on_startup` or "
+            "`on_shutdown`."
+        ),
     ):
         Router(
             on_startup=[run_startup],

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -663,7 +663,7 @@ def test_lifespan_with_on_events():
         return PlainTextResponse("hello, world")
 
     with pytest.warns(
-        UserWarning, match="Lifespan cannot be used together with on_startup"
+        UserWarning, match="The `lifespan` parameter cannot be used with `on_startup` or `on_shutdown`."
     ):
         Router(
             on_startup=[run_startup],


### PR DESCRIPTION
As per discussion (https://github.com/encode/starlette/discussions/2192), I am trying to make it more clear that if both lifespan AND on_startup/on_shutdown are used, regardless of the subtle hint that both should NOT be used, then only lifespan would be used and  on_startup/on_shutdown would silently be ignored.


