### PR TITLE
Stop `body_stream` in case `more_body=False`

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -170,6 +170,8 @@ class BaseHTTPMiddleware:
                         body = message.get("body", b"")
                         if body:
                             yield body
+                        if not message.get("more_body", False):
+                            break
 
                 if app_exc is not None:
                     raise app_exc

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -276,7 +276,6 @@ async def test_do_not_block_on_background_tasks():
         await anyio.sleep(0.1)
         events.append("Background task finished")
 
-
     async def endpoint_with_background_task(_):
         return PlainTextResponse(
             content="Hello", background=BackgroundTask(sleep_and_set)

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -266,6 +266,72 @@ async def test_run_background_tasks_even_if_client_disconnects():
 
 
 @pytest.mark.anyio
+async def test_do_not_block_on_background_tasks():
+    request_body_sent = False
+    response_complete = anyio.Event()
+    events: List[str | Message] = []
+
+    async def sleep_and_set():
+        events.append("Background task started")
+        await anyio.sleep(0.1)
+        events.append("Background task finished")
+
+
+    async def endpoint_with_background_task(_):
+        return PlainTextResponse(
+            content="Hello", background=BackgroundTask(sleep_and_set)
+        )
+
+    async def passthrough(
+        request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        return await call_next(request)
+
+    app = Starlette(
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=passthrough)],
+        routes=[Route("/", endpoint_with_background_task)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+    }
+
+    async def receive() -> Message:
+        nonlocal request_body_sent
+        if not request_body_sent:
+            request_body_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await response_complete.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message):
+        if message["type"] == "http.response.body":
+            events.append(message)
+            if not message.get("more_body", False):
+                response_complete.set()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(app, scope, receive, send)
+        tg.start_soon(app, scope, receive, send)
+
+    # Without the fix, the background tasks would start and finish before the
+    # last http.response.body is sent.
+    assert events == [
+        {"body": b"Hello", "more_body": True, "type": "http.response.body"},
+        {"body": b"", "more_body": False, "type": "http.response.body"},
+        {"body": b"Hello", "more_body": True, "type": "http.response.body"},
+        {"body": b"", "more_body": False, "type": "http.response.body"},
+        "Background task started",
+        "Background task started",
+        "Background task finished",
+        "Background task finished",
+    ]
+
+
+@pytest.mark.anyio
 async def test_run_context_manager_exit_even_if_client_disconnects():
     # test for https://github.com/encode/starlette/issues/1678#issuecomment-1172916042
     request_body_sent = False

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -269,7 +269,7 @@ async def test_run_background_tasks_even_if_client_disconnects():
 async def test_do_not_block_on_background_tasks():
     request_body_sent = False
     response_complete = anyio.Event()
-    events: List[str | Message] = []
+    events: List[Union[str, Message]] = []
 
     async def sleep_and_set():
         events.append("Background task started")


### PR DESCRIPTION
Closes https://github.com/encode/starlette/issues/2093

We need to check how this interacts with FastAPI: https://github.com/encode/starlette/pull/1609#issuecomment-1307600095

I've tested this with the following application:

```py
from asyncio import sleep
from typing import Any, Coroutine

from starlette.applications import Starlette
from starlette.background import BackgroundTasks
from starlette.middleware import Middleware
from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
from starlette.middleware.gzip import GZipMiddleware
from starlette.requests import Request
from starlette.responses import JSONResponse, Response, StreamingResponse
from starlette.routing import Route

n = 0


async def task() -> None:
    global n
    local = n
    print(f"Start {local}.")
    n += 1
    await sleep(3)
    print(f"Finish {local}.")


class CustomMiddleware(BaseHTTPMiddleware):
    async def dispatch(
        self, request: Request, call_next: RequestResponseEndpoint
    ) -> Coroutine[Any, Any, Response]:
        return await call_next(request)


async def homepage(request: Request) -> ...:
    tasks = BackgroundTasks()
    tasks.add_task(task)
    return JSONResponse(content={"potato": "potato"}, background=tasks)


def exc_stream(request: Request):
    return StreamingResponse(_generate_faulty_stream())


def _generate_faulty_stream():
    yield b"Ok"
    raise Exception("Faulty Stream")


def empty(request: Request):
    return Response(status_code=200)


app = Starlette(
    routes=[
        Route("/", endpoint=homepage),
        Route("/stream", endpoint=exc_stream),
        Route("/empty", endpoint=empty),
    ],
    middleware=[Middleware(GZipMiddleware), Middleware(CustomMiddleware), Middleware(GZipMiddleware)],
)
```

Run with `uvicorn --http h11 main:app --reload`.

I've used the following client:

```py
from httpx import Client

with Client(base_url="http://localhost:8000") as client:
    print("Calling '/'")
    for n in range(5):
        client.get("/")

    print("Calling '/empty'")
    for n in range(5):
        client.get("/empty")

#     print("Calling '/stream'")
#     for n in range(5):
#         client.get("/stream")
```

Run with `python client.py`.