### PR TITLE
Allow global `follow_redirects` option.

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -382,6 +382,7 @@ class TestClient(httpx.Client):
         backend_options: typing.Optional[typing.Dict[str, typing.Any]] = None,
         cookies: httpx._client.CookieTypes = None,
         headers: typing.Dict[str, str] = None,
+        follow_redirects: bool = True,
     ) -> None:
         self.async_backend = _AsyncBackend(
             backend=backend, backend_options=backend_options or {}
@@ -409,7 +410,7 @@ class TestClient(httpx.Client):
             base_url=base_url,
             headers=headers,
             transport=transport,
-            follow_redirects=True,
+            follow_redirects=follow_redirects,
             cookies=cookies,
         )
 


### PR DESCRIPTION
When you have many good-old HTML forms and use post-redirect-get pattern, it quickly becomes noisy to add `follow_redirects=False` to each HTTP call if you want to check the redirect location and headers (like 200/400 for form validation errors and 30x for successful submissions).

Setting `follow_redirects` at `TestClient` level makes things simpler and less repeatable.