### PR TITLE
Don't group duplicated headers on a single string on the `TestClient` 

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -223,7 +223,10 @@ class _TestClientTransport(httpx.BaseTransport):
             headers = [(b"host", (f"{host}:{port}").encode())]
 
         # Include other request headers.
-        headers += [(key, value) for _, key, value in request.headers.raw]
+        headers += [
+            (key.lower().encode(), value.encode())
+            for key, value in request.headers.multi_items()
+        ]
 
         scope: typing.Dict[str, typing.Any]
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -223,7 +223,7 @@ class _TestClientTransport(httpx.BaseTransport):
             headers = [(b"host", (f"{host}:{port}").encode())]
 
         # Include other request headers.
-        headers += [(key, value) for _, key, value in request.headers._list]
+        headers += [(key, value) for _, key, value in request.headers.raw]
 
         scope: typing.Dict[str, typing.Any]
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -223,10 +223,7 @@ class _TestClientTransport(httpx.BaseTransport):
             headers = [(b"host", (f"{host}:{port}").encode())]
 
         # Include other request headers.
-        headers += [
-            (key.lower().encode(), value.encode())
-            for key, value in request.headers.items()
-        ]
+        headers += [(key, value) for _, key, value in request.headers._list]
 
         scope: typing.Dict[str, typing.Any]
 


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

The testclient handles headers with duplicate field names differently.

when request with headers with duplicate field name, starlette can handles like this 

#### starlette
```python
# request header
[("x-token", "foo"), ("x-token", "bar")]
```

``` python
# in starlette
request.headers.getlist("x-token")
--> ["foo", "bar"]
```

<br>

but testclient(httpx client) not handles like that

### testclient
``` python
# request header
[("x-token", "foo"), ("x-token", "bar")]
```

``` python
# in starlette
request.headers.getlist("x-token")
--> ["foo, bar"]
```


so i fixed the testclient same as starlette to handle headers with duplicate field name

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
