### PR TITLE
Gracefully handle OSErrors in StaticFiles

### DIFF
--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -123,8 +123,8 @@ class StaticFiles:
             )
         except PermissionError:
             raise HTTPException(status_code=401)
-        except OSError:
-            raise
+        except OSError as e:
+            raise HTTPException(status_code=400) from e
 
         if stat_result and stat.S_ISREG(stat_result.st_mode):
             # We have a static file to serve.

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -429,7 +429,7 @@ def test_staticfiles_access_file_as_dir_returns_404(tmpdir, test_client_factory)
     assert response.text == "Not Found"
 
 
-def test_staticfiles_unhandled_os_error_returns_500(
+def test_staticfiles_os_error_returns_400(
     tmpdir, test_client_factory, monkeypatch
 ):
     def mock_timeout(*args, **kwargs):
@@ -446,8 +446,8 @@ def test_staticfiles_unhandled_os_error_returns_500(
     monkeypatch.setattr("starlette.staticfiles.StaticFiles.lookup_path", mock_timeout)
 
     response = client.get("/example.txt")
-    assert response.status_code == 500
-    assert response.text == "Internal Server Error"
+    assert response.status_code == 400
+    assert response.text == "Bad Request"
 
 
 def test_staticfiles_follows_symlinks(tmpdir, test_client_factory):

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -548,3 +548,12 @@ def test_staticfiles_avoids_path_traversal(tmp_path: Path):
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Not Found"
+
+def test_staticfiles_with_too_large_filename_returns_400(tmpdir, test_client_factory):
+    routes = [Mount("/", app=StaticFiles(directory=tmpdir), name="static")]
+    app = Starlette(routes=routes)
+    client = test_client_factory(app)
+
+    response = client.get(f"/{'a' * 256}")
+    assert response.status_code == 400
+    assert response.text == "Bad Request"

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -429,9 +429,7 @@ def test_staticfiles_access_file_as_dir_returns_404(tmpdir, test_client_factory)
     assert response.text == "Not Found"
 
 
-def test_staticfiles_os_error_returns_400(
-    tmpdir, test_client_factory, monkeypatch
-):
+def test_staticfiles_os_error_returns_400(tmpdir, test_client_factory, monkeypatch):
     def mock_timeout(*args, **kwargs):
         raise TimeoutError
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -549,6 +549,7 @@ def test_staticfiles_avoids_path_traversal(tmp_path: Path):
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "Not Found"
 
+
 def test_staticfiles_with_too_large_filename_returns_400(tmpdir, test_client_factory):
     routes = [Mount("/", app=StaticFiles(directory=tmpdir), name="static")]
     app = Starlette(routes=routes)


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
Instead of reraising the OSError, handle it and raise an HTTPException with a Bad Request status code response. Arguably this could be a 404 to avoid leaking anything, but a 400 seemed reasonable (and better than not catching the error).

Implements solution 1 to the discussion here: https://github.com/encode/starlette/discussions/2221

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
