### PR TITLE
Add `encoder` argument to JSONResponse

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -116,6 +116,33 @@ In general you *probably* want to stick with `JSONResponse` by default unless
 you are micro-optimising a particular endpoint or need to serialize non-standard
 object types.
 
+
+#### Custom JSON encoders
+
+If you need to encode custom data types, you can use a custom JSON encoder.
+
+For example, if you want to automatically serialize `datetime.datetime` instances to strings:
+
+```python
+import datetime
+import json
+
+from starlette.responses import JSONResponse
+
+
+class MyJSONEncoder(json.JSONEncoder):
+    def default(self, value):
+        if isinstance(value, datetime.datetime):
+            return value.isoformat()
+        ...
+
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    response = JSONResponse({'now': datetime.datetime.now()}, encoder=MyJSONEncoder)
+    await response(scope, receive, send)
+```
+
+
 ### RedirectResponse
 
 Returns an HTTP redirect. Uses a 307 status code by default.

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -174,7 +174,9 @@ class JSONResponse(Response):
         headers: typing.Optional[typing.Mapping[str, str]] = None,
         media_type: typing.Optional[str] = None,
         background: typing.Optional[BackgroundTask] = None,
+        encoder: typing.Optional[typing.Type[json.JSONEncoder]] = None,
     ) -> None:
+        self.encoder = encoder
         super().__init__(content, status_code, headers, media_type, background)
 
     def render(self, content: typing.Any) -> bytes:
@@ -184,6 +186,7 @@ class JSONResponse(Response):
             allow_nan=False,
             indent=None,
             separators=(",", ":"),
+            cls=self.encoder,
         ).encode("utf-8")
 
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import json
 import os
 import time
 from http.cookies import SimpleCookie
@@ -48,6 +49,20 @@ def test_json_none_response(test_client_factory):
     response = client.get("/")
     assert response.json() is None
     assert response.content == b"null"
+
+
+def test_json_response_with_custom_encoder(test_client_factory):
+    class DummyEncoder(json.JSONEncoder):
+        def default(self, value):
+            return value.isoformat()
+
+    async def app(scope, receive, send):
+        response = JSONResponse(dt.datetime(2023, 1, 1, 0, 0, 0), encoder=DummyEncoder)
+        await response(scope, receive, send)
+
+    client = test_client_factory(app)
+    response = client.get("/")
+    assert response.content == b'"2023-01-01T00:00:00"'
 
 
 def test_redirect_response(test_client_factory):


### PR DESCRIPTION
This small change allows users to serialize a custom types with a little effort compared to subclassing.

```python
import datetime
import json

from starlette.responses import JSONResponse


class MyJSONEncoder(json.JSONEncoder):
    def default(self, value):
        if isinstance(value, datetime.datetime):
            return value.isoformat()
        ...

async def app(scope, receive, send):
    assert scope['type'] == 'http'
    response = JSONResponse({'now': datetime.datetime.now()}, encoder=MyJSONEncoder)
    await response(scope, receive, send)
```

Similar to Django - https://docs.djangoproject.com/en/4.2/ref/request-response/#jsonresponse-objects