### PR TITLE
Fixed import error when exceptiongroup isn't available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ types-contextvars==2.4.7.2
 types-PyYAML==6.0.12.10
 types-dataclasses==0.6.6
 pytest==7.4.0
-trio==0.22.1
+trio==0.21.0
 anyio==3.7.1
 
 # Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ types-PyYAML==6.0.12.10
 types-dataclasses==0.6.6
 pytest==7.4.0
 trio==0.22.1
-anyio@git+https://github.com/agronholm/anyio.git
+anyio==4.0.0rc1
 
 # Documentation
 mkdocs==1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ types-PyYAML==6.0.12.10
 types-dataclasses==0.6.6
 pytest==7.4.0
 trio==0.22.1
-anyio==4.0.0rc1
+anyio==3.7.1
 
 # Documentation
 mkdocs==1.4.3

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -2,11 +2,19 @@ import asyncio
 import functools
 import sys
 import typing
+from contextlib import contextmanager
 
 if sys.version_info >= (3, 10):  # pragma: no cover
     from typing import TypeGuard
 else:  # pragma: no cover
     from typing_extensions import TypeGuard
+
+has_exceptiongroups = True
+if sys.version_info < (3, 11):  # pragma: no cover
+    try:
+        from exceptiongroup import BaseExceptionGroup
+    except ImportError:
+        has_exceptiongroups = False
 
 T = typing.TypeVar("T")
 AwaitableCallable = typing.Callable[..., typing.Awaitable[T]]
@@ -66,3 +74,15 @@ class AwaitableOrContextManagerWrapper(typing.Generic[SupportsAsyncCloseType]):
     async def __aexit__(self, *args: typing.Any) -> typing.Union[None, bool]:
         await self.entered.close()
         return None
+
+
+@contextmanager
+def collapse_excgroups() -> typing.Generator[None, None, None]:
+    try:
+        yield
+    except BaseException as exc:
+        if has_exceptiongroups:
+            while isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
+                exc = exc.exceptions[0]
+
+        raise exc

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -83,6 +83,6 @@ def collapse_excgroups() -> typing.Generator[None, None, None]:
     except BaseException as exc:
         if has_exceptiongroups:
             while isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
-                exc = exc.exceptions[0]
+                exc = exc.exceptions[0]  # pragma: no cover
 
         raise exc

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -1,15 +1,13 @@
-import sys
 import typing
-from contextlib import contextmanager
 
 import anyio
 from anyio.abc import ObjectReceiveStream, ObjectSendStream
 
+from starlette._utils import collapse_excgroups
 from starlette.background import BackgroundTask
 from starlette.requests import ClientDisconnect, Request
 from starlette.responses import ContentStream, Response, StreamingResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
-from starlette._utils import collapse_excgroups
 
 RequestResponseEndpoint = typing.Callable[[Request], typing.Awaitable[Response]]
 DispatchFunction = typing.Callable[

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -9,31 +9,13 @@ from starlette.background import BackgroundTask
 from starlette.requests import ClientDisconnect, Request
 from starlette.responses import ContentStream, Response, StreamingResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
-
-has_exceptiongroups = True
-if sys.version_info < (3, 11):  # pragma: no cover
-    try:
-        from exceptiongroup import BaseExceptionGroup
-    except ImportError:
-        has_exceptiongroups = False
+from starlette._utils import collapse_excgroups
 
 RequestResponseEndpoint = typing.Callable[[Request], typing.Awaitable[Response]]
 DispatchFunction = typing.Callable[
     [Request, RequestResponseEndpoint], typing.Awaitable[Response]
 ]
 T = typing.TypeVar("T")
-
-
-@contextmanager
-def _convert_excgroups() -> typing.Generator[None, None, None]:
-    try:
-        yield
-    except BaseException as exc:
-        if has_exceptiongroups:
-            while isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
-                exc = exc.exceptions[0]
-
-        raise exc
 
 
 class _CachedRequest(Request):
@@ -206,7 +188,7 @@ class BaseHTTPMiddleware:
             response.raw_headers = message["headers"]
             return response
 
-        with _convert_excgroups():
+        with collapse_excgroups():
             async with anyio.create_task_group() as task_group:
                 response = await self.dispatch_func(request, call_next)
                 await response(scope, wrapped_receive, send)

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -10,8 +10,12 @@ from starlette.requests import ClientDisconnect, Request
 from starlette.responses import ContentStream, Response, StreamingResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+has_exceptiongroups = True
 if sys.version_info < (3, 11):  # pragma: no cover
-    from exceptiongroup import BaseExceptionGroup
+    try:
+        from exceptiongroup import BaseExceptionGroup
+    except ImportError:
+        has_exceptiongroups = False
 
 RequestResponseEndpoint = typing.Callable[[Request], typing.Awaitable[Response]]
 DispatchFunction = typing.Callable[
@@ -25,8 +29,9 @@ def _convert_excgroups() -> typing.Generator[None, None, None]:
     try:
         yield
     except BaseException as exc:
-        while isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
-            exc = exc.exceptions[0]
+        if has_exceptiongroups:
+            while isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
+                exc = exc.exceptions[0]
 
         raise exc
 

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -5,9 +5,6 @@ import pytest
 from starlette._utils import collapse_excgroups
 from starlette.middleware.wsgi import WSGIMiddleware, build_environ
 
-if sys.version_info < (3, 11):  # pragma: no cover
-    from exceptiongroup import ExceptionGroup
-
 
 def hello_world(environ, start_response):
     status = "200 OK"
@@ -70,7 +67,7 @@ def test_wsgi_exception(test_client_factory):
     # The HTTP protocol implementations would catch this error and return 500.
     app = WSGIMiddleware(raise_exception)
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError) as exc, collapse_excgroups():
+    with pytest.raises(RuntimeError), collapse_excgroups():
         client.get("/")
 
 

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 
+from starlette._utils import collapse_excgroups
 from starlette.middleware.wsgi import WSGIMiddleware, build_environ
 
 if sys.version_info < (3, 11):  # pragma: no cover
@@ -69,11 +70,8 @@ def test_wsgi_exception(test_client_factory):
     # The HTTP protocol implementations would catch this error and return 500.
     app = WSGIMiddleware(raise_exception)
     client = test_client_factory(app)
-    with pytest.raises(ExceptionGroup) as exc:
+    with pytest.raises(RuntimeError) as exc, collapse_excgroups():
         client.get("/")
-
-    assert len(exc.value.exceptions) == 1
-    assert isinstance(exc.value.exceptions[0], RuntimeError)
 
 
 def test_wsgi_exc_info(test_client_factory):


### PR DESCRIPTION
Fixes #2227. Closes #2229. This is an alternate version of the linked PR.

<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Last minute changes to the AnyIO 4.0 compatibility PR inadvertently caused an `ImportError` on Pythons earlier than 3.11 when the `exceptiongroup` back-port wasn't installed. This makes the import optional and thus restores compatibility with AnyIO 3.x.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.
