### PR TITLE
Fix `Lifespan State` docs typing import

### DIFF
--- a/docs/lifespan.md
+++ b/docs/lifespan.md
@@ -39,7 +39,7 @@ can be used to share the objects between the lifespan, and the requests.
 
 ```python
 import contextlib
-from typing import TypedDict
+from typing import AsyncIterator, TypedDict
 
 import httpx
 from starlette.applications import Starlette
@@ -53,7 +53,7 @@ class State(TypedDict):
 
 
 @contextlib.asynccontextmanager
-async def lifespan(app: Starlette) -> typing.AsyncIterator[State]:
+async def lifespan(app: Starlette) -> AsyncIterator[State]:
     async with httpx.AsyncClient() as client:
         yield {"http_client": client}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Fixes `typing.AsyncIterator` import error in `Lifespan State` code example

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
