### PR TITLE
Treat repeated query param names as list

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -388,7 +388,7 @@ class MultiDict(ImmutableMultiDict[typing.Any, typing.Any]):
         self._dict.update(value)
 
 
-class QueryParams(ImmutableMultiDict[str, str]):
+class QueryParams(ImmutableMultiDict[str, typing.Union[str, typing.List[str]]]):
     """
     An immutable multidict.
     """
@@ -426,11 +426,11 @@ class QueryParams(ImmutableMultiDict[str, str]):
             # An array may be represented as repeated keys in query params.
             # If a value is already present for a key, append to what is
             # already there rather than overwriting it.
-            existing_v = self._dict.get(k)
+            existing_v = self._dict[k]
             if isinstance(existing_v, list):
                 existing_v.append(v)
             else:
-                self._dict[k] = [self._dict[k], v]
+                self._dict[k] = [existing_v, v]
 
     def __str__(self) -> str:
         return urlencode(self._list)

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -417,7 +417,20 @@ class QueryParams(ImmutableMultiDict[str, str]):
         else:
             super().__init__(*args, **kwargs)  # type: ignore[arg-type]
         self._list = [(str(k), str(v)) for k, v in self._list]
-        self._dict = {str(k): str(v) for k, v in self._dict.items()}
+
+        self._dict = {}
+        for k, v in self._list:
+            if k not in self._dict:
+                self._dict[k] = v
+                continue
+            # An array may be represented as repeated keys in query params.
+            # If a value is already present for a key, append to what is
+            # already there rather than overwriting it.
+            existing_v = self._dict.get(k)
+            if isinstance(existing_v, list):
+                existing_v.append(v)
+            else:
+                self._dict[k] = [self._dict[k], v]
 
     def __str__(self) -> str:
         return urlencode(self._list)

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -262,16 +262,16 @@ def test_queryparams():
     assert "a" in q
     assert "A" not in q
     assert "c" not in q
-    assert q["a"] == "456"
-    assert q.get("a") == "456"
+    assert q["a"] == ["123", "456"]
+    assert q.get("a") == ["123", "456"]
     assert q.get("nope", default=None) is None
     assert q.getlist("a") == ["123", "456"]
     assert list(q.keys()) == ["a", "b"]
-    assert list(q.values()) == ["456", "789"]
-    assert list(q.items()) == [("a", "456"), ("b", "789")]
+    assert list(q.values()) == [["123", "456"], "789"]
+    assert list(q.items()) == [("a", ["123", "456"]), ("b", "789")]
     assert len(q) == 2
     assert list(q) == ["a", "b"]
-    assert dict(q) == {"a": "456", "b": "789"}
+    assert dict(q) == {"a": ["123", "456"], "b": "789"}
     assert str(q) == "a=123&a=456&b=789"
     assert repr(q) == "QueryParams('a=123&a=456&b=789')"
     assert QueryParams({"a": "123", "b": "456"}) == QueryParams(


### PR DESCRIPTION
# Summary

An array may be represented as repeated keys in query params.

If a value is already present for a key, append to what is already there rather than overwriting it.
e.g.
```
a=123&a=456
```

With the current behavior of `QueryParams` repeated key names will override previous values.
This change converts the value to a list in the event of repeated key names.

I ran into this using `hx-vals` in htmx like so:
```html
hx-vals='{"params": [{"name": "a"}, {"name": "b"}]}'
```

The resulting `QueryParams._dict` was:

```python
{'params': '{"name":"b"}'}
```

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
