### PR TITLE
Fix bug in routing when using Mount and "fixes" path expected by Uvicorn logger

### DIFF
--- a/starlette/convertors.py
+++ b/starlette/convertors.py
@@ -38,6 +38,16 @@ class PathConvertor(Convertor[str]):
         return str(value)
 
 
+class MountPathConvertor(Convertor[str]):
+    regex = ".+"
+
+    def convert(self, value: str) -> str:
+        return str(value)
+
+    def to_string(self, value: str) -> str:
+        return str(value)
+
+
 class IntegerConvertor(Convertor[int]):
     regex = "[0-9]+"
 
@@ -77,6 +87,7 @@ class UUIDConvertor(Convertor[uuid.UUID]):
 CONVERTOR_TYPES: typing.Dict[str, Convertor[typing.Any]] = {
     "str": StringConvertor(),
     "path": PathConvertor(),
+    "mountpath": MountPathConvertor(),
     "int": IntegerConvertor(),
     "float": FloatConvertor(),
     "uuid": UUIDConvertor(),

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -285,8 +285,8 @@ class Route(BaseRoute):
                 )
             await response(scope, receive, send)
         else:
-            # Update the scope path to match what Uvicorn expects. Uvicorn can then log the
-            # actual full path and not only the route path.
+            # Update the scope path to match what Uvicorn expects. Uvicorn can then
+            # log the actual full path and not only the route path.
             # Also, why is the 500 error class of Uvicorn used for 200 responses?
             scope["path"] = scope["root_path"] + scope["path"]
             await self.app(scope, receive, send)

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -398,7 +398,7 @@ class Mount(BaseRoute):
 
         if self.path == "":
             self.path_regex, self.path_format, self.param_convertors = compile_path(
-                self.path = "/"
+                self.path + "/"
             )
         else:
             self.path_regex, self.path_format, self.param_convertors = compile_path(


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Solves a bug in Starlettes routing when using Mounts and a dirty fix to provide the full path to the Uvicorn logger for paths to be correctly logged. 

Solves the problems in discussion: https://github.com/encode/starlette/discussions/2299



# Checklist
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
