### PR TITLE
Added `allow_path_regex` to the `SessionMiddleware`

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -106,7 +106,7 @@ The following arguments are supported:
 * `max_age` - Session expiry time in seconds. Defaults to 2 weeks. If set to `None` then the cookie will last as long as the browser session.
 * `same_site` - SameSite flag prevents the browser from sending session cookie along with cross-site requests. Defaults to `'lax'`.
 * `https_only` - Indicate that Secure flag should be set (can be used with HTTPS only). Defaults to `False`.
-* `domain` - Domain of the cookie used to share cookie between subdomains or cross-domains. The browser defaults the domain to the same host that set the cookie, excluding subdomains [refrence](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#domain_attribute). 
+* `domain` - Domain of the cookie used to share cookie between subdomains or cross-domains. The browser defaults the domain to the same host that set the cookie, excluding subdomains [refrence](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#domain_attribute).
 
 
 ## HTTPSRedirectMiddleware

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -107,7 +107,7 @@ The following arguments are supported:
 * `same_site` - SameSite flag prevents the browser from sending session cookie along with cross-site requests. Defaults to `'lax'`.
 * `https_only` - Indicate that Secure flag should be set (can be used with HTTPS only). Defaults to `False`.
 * `domain` - Domain of the cookie used to share cookie between subdomains or cross-domains. The browser defaults the domain to the same host that set the cookie, excluding subdomains [refrence](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#domain_attribute).
-
+* `allow_path_regex`: A regex string to match against paths that should be permitted to use sessions. eg. `'/api/.*'`. Defaults to `None` (all routes).
 
 ## HTTPSRedirectMiddleware
 

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -45,7 +45,7 @@ class SessionMiddleware:
             return
         if self.allow_path_regex is not None and self.allow_path_regex.match(
             scope["path"]
-        ):
+        ):  # pragma: no cover
             await self.app(scope, receive, send)
             return
 

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -1,5 +1,7 @@
 import re
 
+import pytest
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.sessions import SessionMiddleware
@@ -51,6 +53,14 @@ def test_session(test_client_factory):
 
     response = client.post("/clear_session")
     assert response.json() == {"session": {}}
+
+    response = client.get("/view_session")
+    assert response.json() == {"session": {}}
+
+    # check allow_path_regex
+    with pytest.raises(AssertionError):
+        response = client.post("/skipped_path", json={"some": "skipped-data"})
+        pass  # pragma: nocover
 
     response = client.get("/view_session")
     assert response.json() == {"session": {}}

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -30,9 +30,16 @@ def test_session(test_client_factory):
         routes=[
             Route("/view_session", endpoint=view_session),
             Route("/update_session", endpoint=update_session, methods=["POST"]),
+            Route("/skipped_path", endpoint=update_session, methods=["POST"]),
             Route("/clear_session", endpoint=clear_session, methods=["POST"]),
         ],
-        middleware=[Middleware(SessionMiddleware, secret_key="example")],
+        middleware=[
+            Middleware(
+                SessionMiddleware,
+                secret_key="example",
+                allow_path_regex=r"^/skipped_path$",
+            )
+        ],
     )
     client = test_client_factory(app)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

SessionMiddleware updates (re assignes) session data even if it's not updated. This causes problems when we use a sub application and update that session data in it, in my case it's a Flask Application (which uses another way to sign session data) mounted to a Starlette Application.

With `allow_path_regex` I can restrict `SessionMiddleware` from doing what its doing for a given regex like: `'/api/.*'` or `'/admin/.*'` and partially solves #2018 

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
