### PR TITLE
Add option `timeout` to `WebSocketTestSession::receive`

### DIFF
--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -156,6 +156,7 @@ May raise `starlette.websockets.WebSocketDisconnect` if the application does not
 * `.receive_bytes()` - Wait for incoming bytestring sent by the application and return it.
 * `.receive_json(mode="text")` - Wait for incoming json data sent by the application and return it. Use `mode="binary"` to receive JSON over binary data frames.
 
+Pass `timeout=timeout_in_seconds` to raise `Empty` when no message is received within `timeout_in_seconds` to prevent blocking.
 May raise `starlette.websockets.WebSocketDisconnect`.
 
 #### Closing the connection

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -156,25 +156,27 @@ class WebSocketTestSession:
     def close(self, code: int = 1000, reason: typing.Union[str, None] = None) -> None:
         self.send({"type": "websocket.disconnect", "code": code, "reason": reason})
 
-    def receive(self) -> Message:
-        message = self._send_queue.get()
+    def receive(self, timeout: typing.Optional[float] = None) -> Message:
+        message = self._send_queue.get(timeout=timeout)
         if isinstance(message, BaseException):
             raise message
         return message
 
-    def receive_text(self) -> str:
-        message = self.receive()
+    def receive_text(self, timeout: typing.Optional[float] = None) -> str:
+        message = self.receive(timeout=timeout)
         self._raise_on_close(message)
         return typing.cast(str, message["text"])
 
-    def receive_bytes(self) -> bytes:
-        message = self.receive()
+    def receive_bytes(self, timeout: typing.Optional[float] = None) -> bytes:
+        message = self.receive(timeout=timeout)
         self._raise_on_close(message)
         return typing.cast(bytes, message["bytes"])
 
-    def receive_json(self, mode: str = "text") -> typing.Any:
+    def receive_json(
+        self, mode: str = "text", timeout: typing.Optional[float] = None
+    ) -> typing.Any:
         assert mode in ["text", "binary"]
-        message = self.receive()
+        message = self.receive(timeout=timeout)
         self._raise_on_close(message)
         if mode == "text":
             text = message["text"]


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
<!-- Write a small summary about what is happening here. -->
Allows to pass a timeout to various receive methods of `WebSocketTestSession` which is passed into `Queue::get`.
This allows to write tests that raise an exception (which can be expected as well) instead of blocking forever in case the tested app does not send a message on the websocket.

It is a potential fix for #2195, but allows finer control about which call to receive should have a timeout, and which should block instead of setting a generic timeout option to the Session.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
