### PR TITLE
Replace black with ruff formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,10 @@ Source = "https://github.com/encode/starlette"
 [tool.hatch.version]
 path = "starlette/__init__.py"
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["E", "F", "I"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 
 [tool.mypy]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,10 @@
 -e .[full]
 
 # Testing
-black==23.10.1
 coverage==7.3.1
 importlib-metadata==6.8.0
 mypy==1.5.1
-ruff==0.1.3
+ruff==0.1.4
 typing_extensions==4.8.0
 types-contextvars==2.4.7.3
 types-PyYAML==6.0.12.12

--- a/scripts/check
+++ b/scripts/check
@@ -9,7 +9,7 @@ export SOURCE_FILES="starlette tests"
 set -x
 
 ./scripts/sync-version
-${PREFIX}black --check --diff $SOURCE_FILES
+${PREFIX}ruff format --check --diff $SOURCE_FILES
 # TODO: Use `[[tool.mypy.overrides]]` on the `pyproject.toml` when the mypy issue is solved:
 # github.com/python/mypy/issues/10045. Check github.com/encode/starlette/pull/2180 for more info.
 ${PREFIX}mypy starlette

--- a/scripts/lint
+++ b/scripts/lint
@@ -8,5 +8,5 @@ export SOURCE_FILES="starlette tests"
 
 set -x
 
-${PREFIX}black $SOURCE_FILES
+${PREFIX}ruff format $SOURCE_FILES
 ${PREFIX}ruff --fix $SOURCE_FILES

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -137,7 +137,9 @@ class Starlette:
         self.exception_handlers[exc_class_or_status_code] = handler
 
     def add_event_handler(
-        self, event_type: str, func: typing.Callable  # type: ignore[type-arg]
+        self,
+        event_type: str,
+        func: typing.Callable,  # type: ignore[type-arg]
     ) -> None:  # pragma: no cover
         self.router.add_event_handler(event_type, func)
 
@@ -208,9 +210,7 @@ class Starlette:
 
         return decorator
 
-    def websocket_route(
-        self, path: str, name: str | None = None
-    ) -> typing.Callable:  # type: ignore[type-arg]
+    def websocket_route(self, path: str, name: str | None = None) -> typing.Callable:  # type: ignore[type-arg]
         """
         We no longer document this decorator style API, and its usage is discouraged.
         Instead you should use the following approach:

--- a/starlette/middleware/authentication.py
+++ b/starlette/middleware/authentication.py
@@ -24,7 +24,7 @@ class AuthenticationMiddleware:
         self.backend = backend
         self.on_error: typing.Callable[
             [HTTPConnection, AuthenticationError], Response
-        ] = (on_error if on_error is not None else self.default_on_error)
+        ] = on_error if on_error is not None else self.default_on_error
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] not in ["http", "websocket"]:

--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -201,7 +201,10 @@ class ServerErrorMiddleware:
     def generate_frame_html(self, frame: inspect.FrameInfo, is_collapsed: bool) -> str:
         code_context = "".join(
             self.format_line(
-                index, line, frame.lineno, frame.index  # type: ignore[arg-type]
+                index,
+                line,
+                frame.lineno,
+                frame.index,  # type: ignore[arg-type]
             )
             for index, line in enumerate(frame.code_context or [])
         )

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -565,7 +565,7 @@ class _AsyncLiftContextManager(typing.AsyncContextManager[_T]):
 def _wrap_gen_lifespan_context(
     lifespan_context: typing.Callable[
         [typing.Any], typing.Generator[typing.Any, typing.Any, typing.Any]
-    ]
+    ],
 ) -> typing.Callable[[typing.Any], typing.AsyncContextManager[typing.Any]]:
     cmgr = contextlib.contextmanager(lifespan_context)
 


### PR DESCRIPTION
# Summary

Ruff stable release supports both formatter and linter which is compatible with `Black` and can replace it the same way it did for `isort`.
Open to ideas and concerns.

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
