### PR TITLE
Set `ensure_ascii=False` on `json.dumps()` for `WebSocket.send_json()`

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -147,7 +147,7 @@ class WebSocketTestSession:
 
     def send_json(self, data: typing.Any, mode: str = "text") -> None:
         assert mode in ["text", "binary"]
-        text = json.dumps(data, separators=(",", ":"))
+        text = json.dumps(data, separators=(",", ":"), ensure_ascii=False)
         if mode == "text":
             self.send({"type": "websocket.receive", "text": text})
         else:

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -168,7 +168,7 @@ class WebSocket(HTTPConnection):
     async def send_json(self, data: typing.Any, mode: str = "text") -> None:
         if mode not in {"text", "binary"}:
             raise RuntimeError('The "mode" argument should be "text" or "binary".')
-        text = json.dumps(data, separators=(",", ":"))
+        text = json.dumps(data, separators=(",", ":"), ensure_ascii=False)
         if mode == "text":
             await self.send({"type": "websocket.send", "text": text})
         else:

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -39,6 +39,24 @@ def test_websocket_binary_json(test_client_factory):
         assert data == {"test": "data"}
 
 
+def test_websocket_ensure_unicode_on_send_json(
+    test_client_factory: Callable[..., TestClient]
+):
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive=receive, send=send)
+
+        await websocket.accept()
+        message = await websocket.receive_json(mode="text")
+        await websocket.send_json(message, mode="text")
+        await websocket.close()
+
+    client = test_client_factory(app)
+    with client.websocket_connect("/123?a=abc") as websocket:
+        websocket.send_json({"test": "数据"}, mode="text")
+        data = websocket.receive_text()
+        assert data == '{"test":"数据"}'
+
+
 def test_websocket_query_params(test_client_factory):
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         websocket = WebSocket(scope, receive=receive, send=send)


### PR DESCRIPTION
# Summary

When the data output by the `send_json` function is in Chinese, it will force Chinese characters to be converted to Unicode, so I fixed this issue.(The most fundamental reason is that the value of the `ensure_ascii` parameter was not modified when using the `json.dumps` function)

# Checklist

- [√] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [√] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [√] I've updated the documentation accordingly.
