### PR TITLE
Add middleware per `Route`/`WebSocketRoute`

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -217,6 +217,7 @@ class Route(BaseRoute):
         methods: typing.Optional[typing.List[str]] = None,
         name: typing.Optional[str] = None,
         include_in_schema: bool = True,
+        middleware: typing.Optional[typing.Sequence[Middleware]] = None,
     ) -> None:
         assert path.startswith("/"), "Routed paths must start with '/'"
         self.path = path
@@ -235,6 +236,10 @@ class Route(BaseRoute):
         else:
             # Endpoint is a class. Treat it as ASGI.
             self.app = endpoint
+
+        if middleware is not None:
+            for cls, options in reversed(middleware):
+                self.app = cls(app=self.app, **options)
 
         if methods is None:
             self.methods = None
@@ -309,6 +314,7 @@ class WebSocketRoute(BaseRoute):
         endpoint: typing.Callable[..., typing.Any],
         *,
         name: typing.Optional[str] = None,
+        middleware: typing.Optional[typing.Sequence[Middleware]] = None,
     ) -> None:
         assert path.startswith("/"), "Routed paths must start with '/'"
         self.path = path
@@ -324,6 +330,10 @@ class WebSocketRoute(BaseRoute):
         else:
             # Endpoint is a class. Treat it as ASGI.
             self.app = endpoint
+
+        if middleware is not None:
+            for cls, options in reversed(middleware):
+                self.app = cls(app=self.app, **options)
 
         self.path_regex, self.path_format, self.param_convertors = compile_path(path)
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -710,7 +710,7 @@ class TestClient(httpx.Client):
 
     def websocket_connect(
         self, url: str, subprotocols: typing.Sequence[str] = None, **kwargs: typing.Any
-    ) -> typing.Any:
+    ) -> "WebSocketTestSession":
         url = urljoin("ws://testserver", url)
         headers = kwargs.get("headers", {})
         headers.setdefault("connection", "upgrade")


### PR DESCRIPTION
Tom expressed his opinion about this on https://github.com/encode/starlette/pull/1286#issuecomment-966156328.

This will prevent the need of #2175, since we can add a middleware that limits the request body on the `Route` with it.

## Related issues

- #1464
- #1286
- ~Does it solve #685?~ No.