### PR TITLE
Add `UploadFile.__repr__`

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -482,6 +482,10 @@ class UploadFile:
         else:
             await run_in_threadpool(self.file.close)
 
+    def __repr__(self) -> str:
+        class_name = self.__class__.__name__
+        return f"{class_name}(filename={self.filename!r}, size={self.size!r}, headers={self.headers!r})"
+
 
 class FormData(ImmutableMultiDict[str, typing.Union[UploadFile, str]]):
     """

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -483,8 +483,12 @@ class UploadFile:
             await run_in_threadpool(self.file.close)
 
     def __repr__(self) -> str:
-        class_name = self.__class__.__name__
-        return f"{class_name}(filename={self.filename!r}, size={self.size!r}, headers={self.headers!r})"
+        return (
+            f"{self.__class__.__name__}("
+            f"filename={self.filename!r}, "
+            f"size={self.size!r}, "
+            f"headers={self.headers!r})"
+        )
 
 
 class FormData(ImmutableMultiDict[str, typing.Union[UploadFile, str]]):

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -380,7 +380,10 @@ async def test_upload_file_repr():
 async def test_upload_file_repr_headers():
     stream = io.BytesIO(b"data")
     file = UploadFile(filename="file", file=stream, headers=Headers({"foo": "bar"}))
-    assert repr(file) == "UploadFile(filename='file', size=None, headers=Headers({'foo': 'bar'}))"
+    assert (
+        repr(file)
+        == "UploadFile(filename='file', size=None, headers=Headers({'foo': 'bar'}))"
+    )
 
 
 def test_multidict():

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -369,6 +369,20 @@ def test_formdata():
     assert FormData({"a": "123", "b": "789"}) != {"a": "123", "b": "789"}
 
 
+@pytest.mark.anyio
+async def test_upload_file_repr():
+    stream = io.BytesIO(b"data")
+    file = UploadFile(filename="file", file=stream, size=4)
+    assert repr(file) == "UploadFile(filename='file', size=4, headers=Headers({}))"
+
+
+@pytest.mark.anyio
+async def test_upload_file_repr_headers():
+    stream = io.BytesIO(b"data")
+    file = UploadFile(filename="file", file=stream, headers=Headers({"foo": "bar"}))
+    assert repr(file) == "UploadFile(filename='file', size=None, headers=Headers({'foo': 'bar'}))"
+
+
 def test_multidict():
     q = MultiDict([("a", "123"), ("a", "456"), ("b", "789")])
     assert "a" in q


### PR DESCRIPTION
# Summary

I'm using `UploadFile`s directly and it's unhelpful that they don't have an informative `repr`, this adds that repr in the style of dataclasses.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly. - do I need to do this?
