### PR TITLE
Use `Iterable` instead `Iterator` on `iterate_in_threadpool`

### DIFF
--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -55,8 +55,8 @@ def _next(iterator: typing.Iterator[T]) -> T:
 
 
 async def iterate_in_threadpool(
-    iterator: typing.Iterator[T],
-) -> typing.AsyncIterator[T]:
+    iterator: typing.Iterable[T],
+) -> typing.AsyncIterable[T]:
     while True:
         try:
             yield await anyio.to_thread.run_sync(_next, iterator)

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -55,8 +55,9 @@ def _next(iterator: typing.Iterator[T]) -> T:
 
 
 async def iterate_in_threadpool(
-    iterator: typing.Iterable[T],
+    iterable: typing.Iterable[T],
 ) -> typing.AsyncIterable[T]:
+    iterator = iter(iterable)
     while True:
         try:
             yield await anyio.to_thread.run_sync(_next, iterator)

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -55,11 +55,11 @@ def _next(iterator: typing.Iterator[T]) -> T:
 
 
 async def iterate_in_threadpool(
-    iterable: typing.Iterable[T],
-) -> typing.AsyncIterable[T]:
-    iterator = iter(iterable)
+    iterator: typing.Iterable[T],
+) -> typing.AsyncIterator[T]:
+    as_iterator = iter(iterator)
     while True:
         try:
-            yield await anyio.to_thread.run_sync(_next, iterator)
+            yield await anyio.to_thread.run_sync(_next, as_iterator)
         except _StopIteration:
             break

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -220,7 +220,7 @@ class StreamingResponse(Response):
         media_type: typing.Optional[str] = None,
         background: typing.Optional[BackgroundTask] = None,
     ) -> None:
-        if isinstance(content, typing.AsyncIterable):
+        if isinstance(content, typing.AsyncIterator):
             self.body_iterator = content
         else:
             self.body_iterator = iterate_in_threadpool(content)

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -205,7 +205,7 @@ class RedirectResponse(Response):
 
 Content = typing.Union[str, bytes]
 SyncContentStream = typing.Iterator[Content]
-AsyncContentStream = typing.AsyncIterable[Content]
+AsyncContentStream = typing.AsyncIterator[Content]
 ContentStream = typing.Union[AsyncContentStream, SyncContentStream]
 
 

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -204,8 +204,8 @@ class RedirectResponse(Response):
 
 
 Content = typing.Union[str, bytes]
-SyncContentStream = typing.Iterator[Content]
-AsyncContentStream = typing.AsyncIterator[Content]
+SyncContentStream = typing.Iterable[Content]
+AsyncContentStream = typing.AsyncIterable[Content]
 ContentStream = typing.Union[AsyncContentStream, SyncContentStream]
 
 
@@ -220,7 +220,7 @@ class StreamingResponse(Response):
         media_type: typing.Optional[str] = None,
         background: typing.Optional[BackgroundTask] = None,
     ) -> None:
-        if isinstance(content, typing.AsyncIterator):
+        if isinstance(content, typing.AsyncIterable):
             self.body_iterator = content
         else:
             self.body_iterator = iterate_in_threadpool(content)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -4,7 +4,7 @@ import anyio
 import pytest
 
 from starlette.applications import Starlette
-from starlette.concurrency import run_until_first_complete
+from starlette.concurrency import iterate_in_threadpool, run_until_first_complete
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import Route
@@ -40,3 +40,12 @@ def test_accessing_context_from_threaded_sync_endpoint(test_client_factory) -> N
 
     resp = client.get("/")
     assert resp.content == b"data"
+
+
+@pytest.mark.anyio
+async def test_iterate_in_threadpool() -> None:
+    class CustomIterable:
+        def __iter__(self):
+            yield from range(3)
+
+    assert [v async for v in iterate_in_threadpool(CustomIterable())] == [0, 1, 2]


### PR DESCRIPTION
# Summary

Having `AsyncContentStream` match typing of `SyncContentStream`, they should both be `Iterator` or `Iterable`, not separate.

~Given `iterate_in_threadpool` is typed with `Iterator`, and returns an `AsyncIterator`, I think then `AsyncContentStream` should be an `Iterator` as well~

From `mypy` inferred types in `test_streaming_response_custom_iterable`, it seems `AsyncIterable` is required. So, this PR standardizes on `Iterable`/`AsyncIterable`

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
