### PR TITLE
Deprecate `FileResponse(method=...)` parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ filterwarnings = [
     "ignore: The `allow_redirects` argument is deprecated. Use `follow_redirects` instead.:DeprecationWarning",
     "ignore: 'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning",
     "ignore: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.:RuntimeWarning",
+    "ignore: The 'method' parameter is not used, and it will be removed.:DeprecationWarning:starlette",
 ]
 
 [tool.coverage.run]

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -3,6 +3,7 @@ import json
 import os
 import stat
 import typing
+import warnings
 from datetime import datetime
 from email.utils import format_datetime, formatdate
 from functools import partial
@@ -10,6 +11,7 @@ from mimetypes import guess_type
 from urllib.parse import quote
 
 import anyio
+import anyio.to_thread
 
 from starlette._compat import md5_hexdigest
 from starlette.background import BackgroundTask
@@ -280,7 +282,11 @@ class FileResponse(Response):
         self.path = path
         self.status_code = status_code
         self.filename = filename
-        self.send_header_only = method is not None and method.upper() == "HEAD"
+        if method is not None:
+            warnings.warn(
+                "The 'method' parameter is not used, and it will be removed.",
+                DeprecationWarning,
+            )
         if media_type is None:
             media_type = guess_type(filename or path)[0] or "text/plain"
         self.media_type = media_type
@@ -329,7 +335,7 @@ class FileResponse(Response):
                 "headers": self.raw_headers,
             }
         )
-        if self.send_header_only:
+        if scope["method"].upper() == "HEAD":
             await send({"type": "http.response.body", "body": b"", "more_body": False})
         else:
             async with await anyio.open_file(self.path, mode="rb") as file:

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -6,6 +6,7 @@ import typing
 from email.utils import parsedate
 
 import anyio
+import anyio.to_thread
 
 from starlette.datastructures import URL, Headers
 from starlette.exceptions import HTTPException
@@ -154,12 +155,7 @@ class StaticFiles:
                 self.lookup_path, "404.html"
             )
             if stat_result and stat.S_ISREG(stat_result.st_mode):
-                return FileResponse(
-                    full_path,
-                    stat_result=stat_result,
-                    method=scope["method"],
-                    status_code=404,
-                )
+                return FileResponse(full_path, stat_result=stat_result, status_code=404)
         raise HTTPException(status_code=404)
 
     def lookup_path(

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -272,6 +272,8 @@ async def test_file_response_on_head_method(tmpdir: Path):
             assert message["body"] == b""
             assert message["more_body"] is False
 
+    # Since the TestClient drops the response body on HEAD requests, we need to test
+    # this directly.
     await app({"type": "http", "method": "head"}, receive, send)
 
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -256,8 +256,8 @@ async def test_file_response_on_head_method(tmpdir: Path):
 
     app = FileResponse(path=path, filename="example.png")
 
-    async def receive() -> Message:
-        return {"type": "http.request", "body": b"", "more_body": False}
+    async def receive() -> Message:  # type: ignore[empty-body]
+        ...  # pragma: no cover
 
     async def send(message: Message) -> None:
         if message["type"] == "http.response.start":


### PR DESCRIPTION
The server drops the body on `HEAD` anyway, so even if we don't have this logic at all, the client still receives an empty body.

The idea of still having to check the method is to avoid opening the file.