### PR TITLE
Using `raise from` in `concurrency._next`

### DIFF
--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -45,8 +45,8 @@ def _next(iterator: typing.Iterator[T]) -> T:
     # exception type.
     try:
         return next(iterator)
-    except StopIteration:
-        raise _StopIteration
+    except StopIteration as exc:
+        raise _StopIteration from exc
 
 
 async def iterate_in_threadpool(


### PR DESCRIPTION
# Summary

Minor style change using `raise from` in `_next`

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
