### PR TITLE
Allow multiple Mount objects with the same prefix (fixes #2374)

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -421,9 +421,12 @@ class Mount(BaseRoute):
             path = scope["path"]
             root_path = scope.get("route_root_path", scope.get("root_path", ""))
             route_path = scope.get("route_path", re.sub(r"^" + root_path, "", path))
-            match = self.path_regex.match(route_path)
-            if match:
-                matched_params = match.groupdict()
+            mount_match = self.path_regex.match(route_path)
+            path_match = self.routes == [] or any(
+                [route.matches(scope)[0] == Match.FULL for route in self.routes]
+            )
+            if mount_match and path_match:
+                matched_params = mount_match.groupdict()
                 for key, value in matched_params.items():
                     matched_params[key] = self.param_convertors[key].convert(value)
                 remaining_path = "/" + matched_params.pop("path")


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

This is a proposed fix to solve #2374, similar to the proposed fix for Host() in #2263.

This allows users to have multiple Mount() objects with the same path/prefix set, but use a different name. In essence it allows users to have named route groups, allowing the Mount names to be used directly in the OpenAPI spec, etc...