### PR TITLE
Add metadata to route classes.

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -331,3 +331,17 @@ The `endpoint` argument can be one of:
 
 * An async function, which accepts a single `websocket` argument.
 * A class that implements the ASGI interface, such as Starlette's [WebSocketEndpoint](endpoints.md#websocketendpoint).
+
+
+## Routing metadata
+
+You can attach arbitrary metadata to route instances.
+Metadata allows user-defined data to be associated with this route instance.
+
+
+```python
+routes = [
+    Route("/", endpoint=websocket_index, metadata={"foo": "bar"}),
+    WebSocketRoute("/{name}", endpoint=websocket_user, metadata={"foo": "bar"}),
+]
+```

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -218,12 +218,14 @@ class Route(BaseRoute):
         name: typing.Optional[str] = None,
         include_in_schema: bool = True,
         middleware: typing.Optional[typing.Sequence[Middleware]] = None,
+        metadata: typing.Optional[typing.Mapping[str, typing.Any]] = None,
     ) -> None:
         assert path.startswith("/"), "Routed paths must start with '/'"
         self.path = path
         self.endpoint = endpoint
         self.name = get_name(endpoint) if name is None else name
         self.include_in_schema = include_in_schema
+        self.metadata = metadata or {}
 
         endpoint_handler = endpoint
         while isinstance(endpoint_handler, functools.partial):
@@ -318,11 +320,13 @@ class WebSocketRoute(BaseRoute):
         *,
         name: typing.Optional[str] = None,
         middleware: typing.Optional[typing.Sequence[Middleware]] = None,
+        metadata: typing.Optional[typing.Mapping[str, typing.Any]] = None,
     ) -> None:
         assert path.startswith("/"), "Routed paths must start with '/'"
         self.path = path
         self.endpoint = endpoint
         self.name = get_name(endpoint) if name is None else name
+        self.metadata = metadata or {}
 
         endpoint_handler = endpoint
         while isinstance(endpoint_handler, functools.partial):
@@ -392,6 +396,7 @@ class Mount(BaseRoute):
         name: typing.Optional[str] = None,
         *,
         middleware: typing.Optional[typing.Sequence[Middleware]] = None,
+        metadata: typing.Optional[typing.Mapping[str, typing.Any]] = None,
     ) -> None:
         assert path == "" or path.startswith("/"), "Routed paths must start with '/'"
         assert (
@@ -407,6 +412,7 @@ class Mount(BaseRoute):
             for cls, args, kwargs in reversed(middleware):
                 self.app = cls(app=self.app, *args, **kwargs)
         self.name = name
+        self.metadata = metadata or {}
         self.path_regex, self.path_format, self.param_convertors = compile_path(
             self.path + "/{path:path}"
         )
@@ -491,12 +497,17 @@ class Mount(BaseRoute):
 
 class Host(BaseRoute):
     def __init__(
-        self, host: str, app: ASGIApp, name: typing.Optional[str] = None
+        self,
+        host: str,
+        app: ASGIApp,
+        name: typing.Optional[str] = None,
+        metadata: typing.Optional[typing.Mapping[str, typing.Any]] = None,
     ) -> None:
         assert not host.startswith("/"), "Host must not start with '/'"
         self.host = host
         self.app = app
         self.name = name
+        self.metadata = metadata or {}
         self.host_regex, self.host_format, self.param_convertors = compile_path(host)
 
     @property

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1284,3 +1284,35 @@ def test_paths_with_root_path(test_client_factory: typing.Callable[..., TestClie
         "path": "/root/root/path",
         "root_path": "/root",
     }
+
+
+def test_route_metadata():
+    route = Route(path="/", endpoint=homepage)
+    assert route.metadata == {}
+
+    route = Route(path="/", endpoint=homepage, metadata={"foo": "bar"})
+    assert route.metadata == {"foo": "bar"}
+
+
+def test_websocket_route_metadata():
+    route = WebSocketRoute(path="/", endpoint=homepage)
+    assert route.metadata == {}
+
+    route = WebSocketRoute(path="/", endpoint=homepage, metadata={"foo": "bar"})
+    assert route.metadata == {"foo": "bar"}
+
+
+def test_mount_route_metadata():
+    route = Mount(path="/", app=app)
+    assert route.metadata == {}
+
+    route = Mount(path="/", app=app, metadata={"foo": "bar"})
+    assert route.metadata == {"foo": "bar"}
+
+
+def test_host_route_metadata():
+    route = Host("example.com", app=app)
+    assert route.metadata == {}
+
+    route = Host("example.com", app=app, metadata={"foo": "bar"})
+    assert route.metadata == {"foo": "bar"}


### PR DESCRIPTION
This PR adds metadata to route classes.
Metadata is an arbitrary data that can be associated with the route.

The primary audience of this PR is library/framework developers.
One of the use cases can be Open API integration. User can define schema on route and some tool generates Open API docs by scanning available routes.

```
Route('/', index, metadata={'description': 'some route info'})
```

My use case: I am building a decorator that provides dependency injection and generates API docs. It makes sense to me to do that in one pass:
```python
def create_route_from_endpoint(route_spec: RouteSpec, endpoint: Endpoint) -> BaseRoute:
    resolvers = create_dependency_resolvers(endpoint)

   # scan request, response and function parameters for open api components
    components = ....

    async def real_endpoint(request: Request) -> Response:
        dependencies = await resolve_dependencies(request, resolvers)
        return await endpoint(**dependencies)

    return Route(
        path=route_spec.path,
        name=route_spec.name,
        methods=list(route_spec.methods),
        endpoint=real_endpoint,
        metadata={'openapi':  components}, # usage here
        include_in_schema=route_spec.include_in_schema,
    )

```