### PR TITLE
Fix: Caching of request body for passing down to middlewares

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -25,7 +25,7 @@ class _CachedRequest(Request):
     """
 
     def __init__(self, scope: Scope, receive: Receive):
-        super().__init__(scope, receive)
+        super().__init__(scope, receive, enable_request_caching=True)
         self._wrapped_rcv_disconnected = False
         self._wrapped_rcv_consumed = False
         self._wrapped_rc_stream = self.stream()


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->
# Summary
Hey all, I was trying to figure out a way to get the request body inside a middleware that I need for logging the audit logs. But seems like, we don't have that much flexibility for getting the `multipart/form-data` #495 .

<!-- Write a small summary about what is happening here. -->
I tried to make it work by caching the data in the `state` itself. I don't know whether it is the best way to fix this thing. I'm quite new to this community, please assist me for fixing this issue.

Thanks

# Checklist 
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
