### PR TITLE
♻️ Refactor logic to handle `root_path` to keep compatibility with ASGI and compatibility with other non-Starlette-specific libraries like a2wsgi

### DIFF
--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -90,6 +90,7 @@ def collapse_excgroups() -> typing.Generator[None, None, None]:
 
         raise exc
 
+
 def get_route_path(scope: Scope) -> str:
     root_path = scope.get("root_path", "")
     route_path = re.sub(r"^" + root_path, "", scope["path"])

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -1,8 +1,11 @@
 import asyncio
 import functools
+import re
 import sys
 import typing
 from contextlib import contextmanager
+
+from starlette.types import Scope
 
 if sys.version_info >= (3, 10):  # pragma: no cover
     from typing import TypeGuard
@@ -86,3 +89,8 @@ def collapse_excgroups() -> typing.Generator[None, None, None]:
                 exc = exc.exceptions[0]  # pragma: no cover
 
         raise exc
+
+def get_route_path(scope: Scope) -> str:
+    root_path = scope.get("root_path", "")
+    route_path = re.sub(r"^" + root_path, "", scope["path"])
+    return route_path

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -30,7 +30,7 @@ class URL:
             assert not components, 'Cannot set both "scope" and "**components".'
             scheme = scope.get("scheme", "http")
             server = scope.get("server", None)
-            path = scope.get("root_path", "") + scope["path"]
+            path = scope["path"]
             query_string = scope.get("query_string", b"")
 
             host_header = None

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -1,6 +1,5 @@
 import io
 import math
-import os
 import sys
 import typing
 import warnings
@@ -16,13 +15,6 @@ warnings.warn(
     DeprecationWarning,
 )
 
-ENC, ESC = sys.getfilesystemencoding(), "surrogateescape"
-
-
-def unicode_to_wsgi(u: str) -> str:
-    """Convert an environment variable to a WSGI "bytes-as-unicode" string"""
-    return u.encode(ENC, ESC).decode("iso-8859-1")
-
 
 def build_environ(scope: Scope, body: bytes) -> typing.Dict[str, typing.Any]:
     """
@@ -33,10 +25,6 @@ def build_environ(scope: Scope, body: bytes) -> typing.Dict[str, typing.Any]:
     path_info = scope["path"].encode("utf8").decode("latin1")
     if path_info.startswith(script_name):
         path_info = path_info[len(script_name) :]
-
-    script_name_environ_var = os.environ.get("SCRIPT_NAME", "")
-    if script_name_environ_var:
-        script_name = unicode_to_wsgi(script_name_environ_var)
 
     environ = {
         "REQUEST_METHOD": scope["method"],

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -19,7 +19,7 @@ warnings.warn(
 ENC, ESC = sys.getfilesystemencoding(), "surrogateescape"
 
 
-def unicode_to_wsgi(u):
+def unicode_to_wsgi(u: str) -> str:
     """Convert an environment variable to a WSGI "bytes-as-unicode" string"""
     return u.encode(ENC, ESC).decode("iso-8859-1")
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -99,9 +99,18 @@ class HTTPConnection(typing.Mapping[str, typing.Any]):
     def base_url(self) -> URL:
         if not hasattr(self, "_base_url"):
             base_url_scope = dict(self.scope)
-            base_url_scope["path"] = "/"
+            # This is used by request.url_for, it might be used inside a Mount which
+            # would have its own child scope with its own root_path, but the base URL
+            # for url_for should still be the top level app root path.
+            app_root_path = base_url_scope.get(
+                "app_root_path", base_url_scope.get("root_path", "")
+            )
+            path = app_root_path
+            if not path.endswith("/"):
+                path += "/"
+            base_url_scope["path"] = path
             base_url_scope["query_string"] = b""
-            base_url_scope["root_path"] = base_url_scope.get("root_path", "")
+            base_url_scope["root_path"] = app_root_path
             self._base_url = URL(scope=base_url_scope)
         return self._base_url
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -441,7 +441,6 @@ class Mount(BaseRoute):
                     # uses the app_root_path to build the URL path.
                     "app_root_path": scope.get("app_root_path", root_path),
                     "root_path": root_path + matched_path,
-                    # "path": remaining_path,
                     "endpoint": self.app,
                 }
                 return Match.FULL, child_scope

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -10,7 +10,7 @@ from contextlib import asynccontextmanager
 from enum import Enum
 
 from starlette._exception_handler import wrap_app_handling_exceptions
-from starlette._utils import is_async_callable
+from starlette._utils import get_route_path, is_async_callable
 from starlette.concurrency import run_in_threadpool
 from starlette.convertors import CONVERTOR_TYPES, Convertor
 from starlette.datastructures import URL, Headers, URLPath
@@ -253,9 +253,8 @@ class Route(BaseRoute):
     def matches(self, scope: Scope) -> typing.Tuple[Match, Scope]:
         path_params: "typing.Dict[str, typing.Any]"
         if scope["type"] == "http":
-            root_path = scope.get("route_root_path", scope.get("root_path", ""))
-            path = scope.get("route_path", re.sub(r"^" + root_path, "", scope["path"]))
-            match = self.path_regex.match(path)
+            route_path = get_route_path(scope)
+            match = self.path_regex.match(route_path)
             if match:
                 matched_params = match.groupdict()
                 for key, value in matched_params.items():
@@ -343,9 +342,8 @@ class WebSocketRoute(BaseRoute):
     def matches(self, scope: Scope) -> typing.Tuple[Match, Scope]:
         path_params: "typing.Dict[str, typing.Any]"
         if scope["type"] == "websocket":
-            root_path = scope.get("route_root_path", scope.get("root_path", ""))
-            path = scope.get("route_path", re.sub(r"^" + root_path, "", scope["path"]))
-            match = self.path_regex.match(path)
+            route_path = get_route_path(scope)
+            match = self.path_regex.match(route_path)
             if match:
                 matched_params = match.groupdict()
                 for key, value in matched_params.items():
@@ -418,9 +416,8 @@ class Mount(BaseRoute):
     def matches(self, scope: Scope) -> typing.Tuple[Match, Scope]:
         path_params: "typing.Dict[str, typing.Any]"
         if scope["type"] in ("http", "websocket"):
-            path = scope["path"]
-            root_path = scope.get("route_root_path", scope.get("root_path", ""))
-            route_path = scope.get("route_path", re.sub(r"^" + root_path, "", path))
+            root_path = scope.get("root_path", "")
+            route_path = get_route_path(scope)
             match = self.path_regex.match(route_path)
             if match:
                 matched_params = match.groupdict()
@@ -430,11 +427,21 @@ class Mount(BaseRoute):
                 matched_path = route_path[: -len(remaining_path)]
                 path_params = dict(scope.get("path_params", {}))
                 path_params.update(matched_params)
-                root_path = scope.get("root_path", "")
                 child_scope = {
                     "path_params": path_params,
-                    "route_root_path": root_path + matched_path,
-                    "route_path": remaining_path,
+                    # app_root_path will only be set at the top level scope,
+                    # initialized with the (optional) value of a root_path
+                    # set above/before Starlette. And even though any
+                    # mount will have its own child scope with its own respective
+                    # root_path, the app_root_path will always be available in all
+                    # the child scopes with the same top level value because it's
+                    # set only once here with a default, any other child scope will
+                    # just inherit that app_root_path default value stored in the
+                    # scope. All this is needed to support Request.url_for(), as it
+                    # uses the app_root_path to build the URL path.
+                    "app_root_path": scope.get("app_root_path", root_path),
+                    "root_path": root_path + matched_path,
+                    # "path": remaining_path,
                     "endpoint": self.app,
                 }
                 return Match.FULL, child_scope
@@ -785,15 +792,12 @@ class Router:
             await partial.handle(scope, receive, send)
             return
 
-        root_path = scope.get("route_root_path", scope.get("root_path", ""))
-        path = scope.get("route_path", re.sub(r"^" + root_path, "", scope["path"]))
-        if scope["type"] == "http" and self.redirect_slashes and path != "/":
+        route_path = get_route_path(scope)
+        if scope["type"] == "http" and self.redirect_slashes and route_path != "/":
             redirect_scope = dict(scope)
-            if path.endswith("/"):
-                redirect_scope["route_path"] = path.rstrip("/")
+            if route_path.endswith("/"):
                 redirect_scope["path"] = redirect_scope["path"].rstrip("/")
             else:
-                redirect_scope["route_path"] = path + "/"
                 redirect_scope["path"] = redirect_scope["path"] + "/"
 
             for route in self.routes:

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -1,6 +1,5 @@
 import importlib.util
 import os
-import re
 import stat
 import typing
 from email.utils import parsedate

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -111,7 +111,7 @@ class StaticFiles:
         with OS specific path separators, and any '..', '.' components removed.
         """
         route_path = get_route_path(scope)
-        return os.path.normpath(os.path.join(*route_path.split("/")))  # type: ignore[no-any-return]  # noqa: E501
+        return os.path.normpath(os.path.join(*route_path.split("/")))  # noqa: E501
 
     async def get_response(self, path: str, scope: Scope) -> Response:
         """

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -8,6 +8,7 @@ from email.utils import parsedate
 import anyio
 import anyio.to_thread
 
+from starlette._utils import get_route_path
 from starlette.datastructures import URL, Headers
 from starlette.exceptions import HTTPException
 from starlette.responses import FileResponse, RedirectResponse, Response
@@ -110,9 +111,8 @@ class StaticFiles:
         Given the ASGI scope, return the `path` string to serve up,
         with OS specific path separators, and any '..', '.' components removed.
         """
-        root_path = scope.get("route_root_path", scope.get("root_path", ""))
-        path = scope.get("route_path", re.sub(r"^" + root_path, "", scope["path"]))
-        return os.path.normpath(os.path.join(*path.split("/")))  # type: ignore[no-any-return]  # noqa: E501
+        route_path = get_route_path(scope)
+        return os.path.normpath(os.path.join(*route_path.split("/")))  # type: ignore[no-any-return]  # noqa: E501
 
     async def get_response(self, path: str, scope: Scope) -> Response:
         """

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -92,7 +92,8 @@ def test_build_environ():
         "http_version": "1.1",
         "method": "GET",
         "scheme": "https",
-        "path": "/",
+        "path": "/sub/",
+        "root_path": "/sub",
         "query_string": b"a=123&b=456",
         "headers": [
             (b"host", b"www.example.org"),
@@ -117,7 +118,7 @@ def test_build_environ():
         "QUERY_STRING": "a=123&b=456",
         "REMOTE_ADDR": "134.56.78.4",
         "REQUEST_METHOD": "GET",
-        "SCRIPT_NAME": "",
+        "SCRIPT_NAME": "/sub",
         "SERVER_NAME": "www.example.org",
         "SERVER_PORT": 443,
         "SERVER_PROTOCOL": "HTTP/1.1",

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1263,10 +1263,7 @@ echo_paths_routes = [
         name="path",
         methods=["GET"],
     ),
-    Mount(
-        "/asgipath",
-        app=functools.partial(pure_asgi_echo_paths, name="asgipath")
-    ),
+    Mount("/asgipath", app=functools.partial(pure_asgi_echo_paths, name="asgipath")),
     Mount(
         "/sub",
         name="mount",

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -564,12 +564,12 @@ def test_url_for_with_root_path(test_client_factory):
     client = test_client_factory(
         app, base_url="https://www.example.org/", root_path="/sub_path"
     )
-    response = client.get("/")
+    response = client.get("/sub_path/")
     assert response.json() == {
         "index": "https://www.example.org/sub_path/",
         "submount": "https://www.example.org/sub_path/submount/",
     }
-    response = client.get("/submount/")
+    response = client.get("/sub_path/submount/")
     assert response.json() == {
         "index": "https://www.example.org/sub_path/",
         "submount": "https://www.example.org/sub_path/submount/",


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

♻️ Refactor logic to handle `root_path` to keep compatibility with ASGI and compatibility with other non-Starlette-specific libraries like a2wsgi (in the latest version).

# Description

The ASGI spec specifies that `path` should include the full `root_path`, which is different from the equivalent in WSGI, that strips the root path equivalent. This was not the case in Starlette up to https://github.com/encode/starlette/pull/2352 that fixed it and was released in Starlette 0.33.0.

Nevertheless, by that point, Starlette stopped modifying the `root_path` for mounted children ASGI apps. This means that children ASGI apps would share the same `root_path` as the top level Starlette app, when they were actually sub-mounted inside of Starlette, in a path prefix lower than whatever is the path prefix that Starlette was mounted on (the top level `root_path`). Because Starlette stopped modifying and increasing the `root_path` for child scopes, this means that ASGI apps mounted in Starlette with `Mount` would not be able to know what their actual path prefix was, to be able to handle their own routing after that prefix.

The way that other internal parts of Starlette dealt with it in that PR was by adding a couple of ASGI extension scope keys specific only to Starlette `route_root_path` and `route_path`. But that only worked for Starlette-specific components that knew about those (non-standard) scope keys.

This PR stops relying on those new scope keys (and removes them) and restores modifying the child `root_scope`. But keeps being ASGI compliant with the fix from https://github.com/encode/starlette/pull/2352, keeping the full `path` including the `root_path`.

It also fixes a couple of internals that used to depend on the old behavior.

### `TestClient`

The `TestClient` was also updated, when creating a `TestClient`, it received a `root_path` parameter without much information of what it would mean and how it would be used internally. In fact, it was not really used by the TestClient internally, it was just added to the ASGI scope as is.

This PR refactors that to make the client take the used `root_path` into account, if it is set, it will be passed to the ASGI apps, that will internally extract/remove it from the paths. But clients communicating with those ASGI apps, if they are indeed mounted at the defined `root_path`, would have to communicate with it using the `root_path` prefix. So this PR updates the client to actually require/use that, clients created with `root_path` would need to be used the same way that clients communicating with those ASGI apps mounted at some prefix path.

### `root_path`

I think `root_path` in general is sometimes confusing, as it is about path prefixes that exist in some scenarios, for some parties, e.g. the final clients communicating through a proxy with a path prefix (e.g. `/api/v2`), but not for the other parties, e.g. the ASGI apps that has a `root_path` (e.g. the Starlette app that doesn't know anything about `/api/v2`).

It also applies to ASGI apps mounted inside of other things, like other ASGI apps, under a path prefix. For example, a Flask app mounted through a2wsgi `WSGIMiddleware` inside of a Starlette app at `/oldapp`. In this case, Starlette would know about the path prefix `/oldapp`, but the Flask app (through `WSGIMiddleware`) would not know about `/oldapp`, so, `WSGIMiddleware` would be the thing in charge of reading that `/oldapp` from the `root_path` passed to it in its ASGI scope (a child scope) and remove that path prefix from the paths passed to Flask.

I wrote a lot more about `root_path` with diagrams and stuff in the FastAPI docs: https://fastapi.tiangolo.com/advanced/behind-a-proxy/

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
