### PR TITLE
Session cookie fix

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -106,7 +106,7 @@ The following arguments are supported:
 * `same_site` - SameSite flag prevents the browser from sending session cookie along with cross-site requests. Defaults to `'lax'`.
 * `https_only` - Indicate that Secure flag should be set (can be used with HTTPS only). Defaults to `False`.
 * `persist_session` - Sets the session cookie that's created to persist between connections. Defaults to `False`.
-* `auto_refresh_window` - Refresh window in seconds before max_age. If the cookie is max_age - auto_refresh_window the cookie will be refreshed with a new session cookie. Default is 0 seconds, and if set overrides persist_session. 
+* `auto_refresh_window` - Refresh window in seconds before max_age. If the cookies age is max_age - auto_refresh_window the cookie will be refreshed with a new session cookie. Default is 0 seconds, and if set overrides persist_session. 
 * `domain` - Domain of the cookie used to share cookie between subdomains or cross-domains. The browser defaults the domain to the same host that set the cookie, excluding subdomains [refrence](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#domain_attribute).
 
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -105,6 +105,8 @@ The following arguments are supported:
 * `max_age` - Session expiry time in seconds. Defaults to 2 weeks. If set to `None` then the cookie will last as long as the browser session.
 * `same_site` - SameSite flag prevents the browser from sending session cookie along with cross-site requests. Defaults to `'lax'`.
 * `https_only` - Indicate that Secure flag should be set (can be used with HTTPS only). Defaults to `False`.
+* `persist_session` - Sets the session cookie that's created to persist between connections. Defaults to `False`.
+* `auto_refresh_window` - Refresh window in seconds before max_age. If the cookie is max_age - auto_refresh_window the cookie will be refreshed with a new session cookie. Default is 0 seconds, and if set overrides persist_session. 
 * `domain` - Domain of the cookie used to share cookie between subdomains or cross-domains. The browser defaults the domain to the same host that set the cookie, excluding subdomains [refrence](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#domain_attribute).
 
 

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -7,7 +7,7 @@ import itsdangerous
 from itsdangerous.exc import BadSignature, SignatureExpired
 
 from starlette.datastructures import MutableHeaders, Secret
-from starlette.requests import HTTPConnection, Request
+from starlette.requests import HTTPConnection
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -108,4 +108,4 @@ class SessionMiddleware:
             await send(message)
 
         await self.app(scope, receive, send_wrapper)
-        
+

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -1,9 +1,9 @@
 import json
 import typing
+from datetime import datetime, timedelta, timezone
 from base64 import b64decode, b64encode
-
 import itsdangerous
-from itsdangerous.exc import BadSignature
+from itsdangerous.exc import BadSignature, SignatureExpired
 
 from starlette.datastructures import MutableHeaders, Secret
 from starlette.requests import HTTPConnection
@@ -20,6 +20,8 @@ class SessionMiddleware:
         path: str = "/",
         same_site: typing.Literal["lax", "strict", "none"] = "lax",
         https_only: bool = False,
+        persist_session: bool = False,
+        auto_refresh_window: int = 0, # seconds, default 0 to not auto refresh, 240 seconds for 4 minute window to refresh
         domain: typing.Optional[str] = None,
     ) -> None:
         self.app = app
@@ -28,34 +30,49 @@ class SessionMiddleware:
         self.max_age = max_age
         self.path = path
         self.security_flags = "httponly; samesite=" + same_site
+        self.persist_session = persist_session
+        self.auto_refresh_window = auto_refresh_window
         if https_only:  # Secure flag can be used with HTTPS only
             self.security_flags += "; secure"
         if domain is not None:
             self.security_flags += f"; domain={domain}"
-
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] not in ("http", "websocket"):  # pragma: no cover
             await self.app(scope, receive, send)
             return
 
         connection = HTTPConnection(scope)
-        initial_session_was_empty = True
-
+        inject_session = True
+        
         if self.session_cookie in connection.cookies:
             data = connection.cookies[self.session_cookie].encode("utf-8")
             try:
-                data = self.signer.unsign(data, max_age=self.max_age)
-                scope["session"] = json.loads(b64decode(data))
-                initial_session_was_empty = False
-            except BadSignature:
+                data = self.signer.unsign(data, max_age=self.max_age,return_timestamp=True)
+                scope["session"] = json.loads(b64decode(data[0]))
+                session_exp = data[1] + timedelta(seconds=self.max_age)
+                now = datetime.now(timezone.utc)
+                if self.auto_refresh_window:
+                    if now >= (session_exp - timedelta(seconds=self.auto_refresh_window)) and now <= session_exp:
+                        #Session needs refreshing
+                        inject_session = True
+                    else:
+                        #Session does not need to be refreshed
+                        inject_session = False
+                elif not self.persist_session:
+                    #Sessions are not auto refresed, has an existing session. Catch statement should catch it if its expired.
+                    inject_session = False
+                
+            except (BadSignature, SignatureExpired):
+                #itsdangerous should throw BadSignature or SignatureExpired so clear the session.
                 scope["session"] = {}
         else:
             scope["session"] = {}
 
+
         async def send_wrapper(message: Message) -> None:
             if message["type"] == "http.response.start":
-                if scope["session"]:
-                    # We have session data to persist.
+                if scope["session"] and inject_session:
+                    # We have data that needs to be persisted or refreshed. Don't inject a session if no session exists.
                     data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
                     data = self.signer.sign(data)
                     headers = MutableHeaders(scope=message)
@@ -67,8 +84,8 @@ class SessionMiddleware:
                         security_flags=self.security_flags,
                     )
                     headers.append("Set-Cookie", header_value)
-                elif not initial_session_was_empty:
-                    # The session has been cleared.
+                elif not inject_session and not scope["session"]:
+                    # The session is cleared. BadSignature or initial_session_was_empty
                     headers = MutableHeaders(scope=message)
                     header_value = "{session_cookie}={data}; path={path}; {expires}{security_flags}".format(  # noqa E501
                         session_cookie=self.session_cookie,


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This is regarding Issue #2019  

It adds persistent session features, and also the option for refreshing the current session before it expires while it's still valid (refresh window)  and if it's beyond that window the session is invalid.

The default behavior without the new features should also remain the same was it was prior to the changes, every single requests results in a new session cookie.

I feel like there's possibly a much better way of doing this like being able to handle it all with in the __call__ before the send_wrapper.  However this is my first time delving into the ASGI framework so I'm not sure if I am able to obtain the new session data and compare it to the old session data only within the __call__ and not have to make one cookie in __call__ and another one with in send_wraper to resolve the current cookie and compare it to the new data.

Haven't added any tests to test_session.py yet, since I think this is a pretty large change and I can go ahead and work on that if this appears to be something that maybe accepted. The existing test suite passes however, and manually testing individual behaviors from the update work as expected.

There's no single change here, its a pretty big overall change to the middleware.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] Passes existing tests.
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
