### PR TITLE
Documenting how `StreamingResponse` adheres to ASGI spec

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -159,6 +159,11 @@ async def app(scope, receive, send):
 
 Have in mind that <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> objects (like those created by `open()`) are normal iterators. So, you can return them directly in a `StreamingResponse`.
 
+For reference, the way `StreamingResponse` works under the hood is
+the `more_body` parameter within the response body,
+as described in the
+[ASGI specification](https://asgi.readthedocs.io/en/latest/specs/www.html).
+
 ### FileResponse
 
 Asynchronously streams a file as the response.

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -159,10 +159,11 @@ async def app(scope, receive, send):
 
 Have in mind that <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> objects (like those created by `open()`) are normal iterators. So, you can return them directly in a `StreamingResponse`.
 
-For reference, the way `StreamingResponse` works under the hood is
-the `more_body` parameter within the response body,
-as described in the
-[ASGI specification](https://asgi.readthedocs.io/en/latest/specs/www.html).
+!!! info
+    If you are curious how the streaming works under the hood,
+    the streaming protocol comes from the
+    [ASGI specification](https://asgi.readthedocs.io/en/latest/specs/www.html),
+    specifically the `more_body` parameter in the request and response bodies.
 
 ### FileResponse
 


### PR DESCRIPTION
# Summary

I was reading the source code how `StreamingResponse` works, and found myself in-depth researching `more_body`.

This PR just upstreams that knowledge (and links the ASGI spec) in the docs.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
