### PR TITLE
♻️ Do not use the deprecated `method` parameter in `FileResponse` inside of `StaticFiles`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ filterwarnings = [
     "ignore: The `allow_redirects` argument is deprecated. Use `follow_redirects` instead.:DeprecationWarning",
     "ignore: 'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning",
     "ignore: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.:RuntimeWarning",
-    "ignore: The 'method' parameter is not used, and it will be removed.:DeprecationWarning:starlette",
 ]
 
 [tool.coverage.run]

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -184,11 +184,10 @@ class StaticFiles:
         scope: Scope,
         status_code: int = 200,
     ) -> Response:
-        method = scope["method"]
         request_headers = Headers(scope=scope)
 
         response = FileResponse(
-            full_path, status_code=status_code, stat_result=stat_result, method=method
+            full_path, status_code=status_code, stat_result=stat_result
         )
         if self.is_not_modified(response.headers, request_headers):
             return NotModifiedResponse(response.headers)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -324,6 +324,11 @@ def test_file_response_with_inline_disposition(tmpdir, test_client_factory):
     assert response.headers["content-disposition"] == expected_disposition
 
 
+def test_file_response_with_method_warns(tmpdir, test_client_factory):
+    with pytest.warns(DeprecationWarning):
+        FileResponse(path=tmpdir, filename="example.png", method="GET")
+
+
 def test_set_cookie(test_client_factory, monkeypatch):
     # Mock time used as a reference for `Expires` by stdlib `SimpleCookie`.
     mocked_now = dt.datetime(2037, 1, 22, 12, 0, 0, tzinfo=dt.timezone.utc)


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

♻️ Do not use the deprecated `method` parameter in `FileResponse` inside of `StaticFiles`

This is a continuation of https://github.com/encode/starlette/pull/2366

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
