### PR TITLE
Raise `FileNotFoundError` when the `env_file` parameter on `Config` is not valid

### DIFF
--- a/starlette/config.py
+++ b/starlette/config.py
@@ -58,7 +58,9 @@ class Config:
         self.environ = environ
         self.env_prefix = env_prefix
         self.file_values: typing.Dict[str, str] = {}
-        if env_file is not None and os.path.isfile(env_file):
+        if env_file is not None:
+            if not os.path.isfile(env_file):
+                raise FileNotFoundError(f"Config file '{env_file}' not found.")
             self.file_values = self._read_file(env_file)
 
     @typing.overload

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -103,6 +103,11 @@ def test_config(tmpdir, monkeypatch):
     with pytest.raises(ValueError):
         config.get("BOOL_AS_INT", cast=bool)
 
+def test_missing_env_file_raises(tmpdir):
+    path = os.path.join(tmpdir, ".env")
+
+    with pytest.raises(FileNotFoundError, match=f"Config file '{path}' not found."):
+        Config(path)
 
 def test_environ():
     environ = Environ()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -103,11 +103,13 @@ def test_config(tmpdir, monkeypatch):
     with pytest.raises(ValueError):
         config.get("BOOL_AS_INT", cast=bool)
 
+
 def test_missing_env_file_raises(tmpdir):
     path = os.path.join(tmpdir, ".env")
 
     with pytest.raises(FileNotFoundError, match=f"Config file '{path}' not found."):
         Config(path)
+
 
 def test_environ():
     environ = Environ()


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Addresses #2101

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

-> I think this if ok without doc update. Let me know otherwise.
