### PR TITLE
Raise `WebSocketDisconnect` when `WebSocket.send()` excepts `IOError`

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -61,30 +61,36 @@ class WebSocket(HTTPConnection):
         """
         Send ASGI websocket messages, ensuring valid state transitions.
         """
-        if self.application_state == WebSocketState.CONNECTING:
-            message_type = message["type"]
-            if message_type not in {"websocket.accept", "websocket.close"}:
-                raise RuntimeError(
-                    'Expected ASGI message "websocket.accept" or '
-                    f'"websocket.close", but got {message_type!r}'
-                )
-            if message_type == "websocket.close":
-                self.application_state = WebSocketState.DISCONNECTED
+        try:
+            if self.application_state == WebSocketState.CONNECTING:
+                message_type = message["type"]
+                if message_type not in {"websocket.accept", "websocket.close"}:
+                    raise RuntimeError(
+                        'Expected ASGI message "websocket.accept" or '
+                        f'"websocket.close", but got {message_type!r}'
+                    )
+                if message_type == "websocket.close":
+                    self.application_state = WebSocketState.DISCONNECTED
+                else:
+                    self.application_state = WebSocketState.CONNECTED
+                await self._send(message)
+            elif self.application_state == WebSocketState.CONNECTED:
+                message_type = message["type"]
+                if message_type not in {"websocket.send", "websocket.close"}:
+                    raise RuntimeError(
+                        'Expected ASGI message "websocket.send" or "websocket.close", '
+                        f"but got {message_type!r}"
+                    )
+                if message_type == "websocket.close":
+                    self.application_state = WebSocketState.DISCONNECTED
+                await self._send(message)
             else:
-                self.application_state = WebSocketState.CONNECTED
-            await self._send(message)
-        elif self.application_state == WebSocketState.CONNECTED:
-            message_type = message["type"]
-            if message_type not in {"websocket.send", "websocket.close"}:
                 raise RuntimeError(
-                    'Expected ASGI message "websocket.send" or "websocket.close", '
-                    f"but got {message_type!r}"
+                    'Cannot call "send" once a close message has been sent.'
                 )
-            if message_type == "websocket.close":
-                self.application_state = WebSocketState.DISCONNECTED
-            await self._send(message)
-        else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+        except IOError:  # pragma: no cover
+            self.application_state = WebSocketState.DISCONNECTED
+            raise WebSocketDisconnect(code=1006)
 
     async def accept(
         self,


### PR DESCRIPTION
- I don't think I can test this can be tested without fixing https://github.com/encode/starlette/issues/947.

I think we should fix the above issue before merging this.

Uvicorn PR: https://github.com/encode/uvicorn/pull/2218