### PR TITLE
Add `scope_client` parameter to `TestClient`

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -215,12 +215,14 @@ class _TestClientTransport(httpx.BaseTransport):
         root_path: str = "",
         *,
         app_state: dict[str, typing.Any],
+        client: typing.Optional[typing.List[typing.Union[str, int]]],
     ) -> None:
         self.app = app
         self.raise_server_exceptions = raise_server_exceptions
         self.root_path = root_path
         self.portal_factory = portal_factory
         self.app_state = app_state
+        self.client = client
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         scheme = request.url.scheme
@@ -268,7 +270,7 @@ class _TestClientTransport(httpx.BaseTransport):
                 "scheme": scheme,
                 "query_string": query.encode(),
                 "headers": headers,
-                "client": None,
+                "client": self.client,
                 "server": [host, port],
                 "subprotocols": subprotocols,
                 "state": self.app_state.copy(),
@@ -286,7 +288,7 @@ class _TestClientTransport(httpx.BaseTransport):
             "scheme": scheme,
             "query_string": query.encode(),
             "headers": headers,
-            "client": None,
+            "client": self.client,
             "server": [host, port],
             "extensions": {"http.response.debug": {}},
             "state": self.app_state.copy(),
@@ -400,6 +402,7 @@ class TestClient(httpx.Client):
         cookies: httpx._types.CookieTypes | None = None,
         headers: typing.Dict[str, str] | None = None,
         follow_redirects: bool = True,
+        client: typing.Optional[typing.List[typing.Union[str, int]]] = ["testclient", 50000],
     ) -> None:
         self.async_backend = _AsyncBackend(
             backend=backend, backend_options=backend_options or {}
@@ -417,6 +420,7 @@ class TestClient(httpx.Client):
             raise_server_exceptions=raise_server_exceptions,
             root_path=root_path,
             app_state=self.app_state,
+            client=client,
         )
         if headers is None:
             headers = {}

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -215,14 +215,14 @@ class _TestClientTransport(httpx.BaseTransport):
         root_path: str = "",
         *,
         app_state: dict[str, typing.Any],
-        client: typing.Optional[typing.List[typing.Union[str, int]]],
+        scope_client: typing.Optional[typing.List[typing.Union[str, int]]],
     ) -> None:
         self.app = app
         self.raise_server_exceptions = raise_server_exceptions
         self.root_path = root_path
         self.portal_factory = portal_factory
         self.app_state = app_state
-        self.client = client
+        self.scope_client = scope_client
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         scheme = request.url.scheme
@@ -270,7 +270,7 @@ class _TestClientTransport(httpx.BaseTransport):
                 "scheme": scheme,
                 "query_string": query.encode(),
                 "headers": headers,
-                "client": self.client,
+                "client": self.scope_client,
                 "server": [host, port],
                 "subprotocols": subprotocols,
                 "state": self.app_state.copy(),
@@ -288,7 +288,7 @@ class _TestClientTransport(httpx.BaseTransport):
             "scheme": scheme,
             "query_string": query.encode(),
             "headers": headers,
-            "client": self.client,
+            "client": self.scope_client,
             "server": [host, port],
             "extensions": {"http.response.debug": {}},
             "state": self.app_state.copy(),
@@ -402,7 +402,7 @@ class TestClient(httpx.Client):
         cookies: httpx._types.CookieTypes | None = None,
         headers: typing.Dict[str, str] | None = None,
         follow_redirects: bool = True,
-        client: typing.Optional[typing.List[typing.Union[str, int]]] = ["testclient", 50000],
+        scope_client: typing.Optional[typing.Tuple[str, int]] = None,
     ) -> None:
         self.async_backend = _AsyncBackend(
             backend=backend, backend_options=backend_options or {}
@@ -420,7 +420,11 @@ class TestClient(httpx.Client):
             raise_server_exceptions=raise_server_exceptions,
             root_path=root_path,
             app_state=self.app_state,
-            client=client,
+            scope_client=(
+                [scope_client[0], scope_client[1]]
+                if scope_client is not None
+                else scope_client
+            ),
         )
         if headers is None:
             headers = {}


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

A breaking change was made when the `TestClient`'s `scope["client"]` was set to None. In cases where an application uses the scope["client"] in places like custom middleware, logging, etc, upgrading to 0.35 becomes a very hard task. Testing middleware/logging/business logic that relies on the client being populated becomes hard if not impossible. Middleware that worked before breaks, and now we need to add checks in application code to disable certain things based on whether or not the test suite is running.

This PR adds the ability for users to specify what the `scope["client"]` should be when using the test client. This way, when using fixtures in a framework like pytest (which is the recommended setup), a one line change is all that is required.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
