### PR TITLE
Add support for ASGI `pathsend` extension

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -337,6 +337,8 @@ class FileResponse(Response):
         )
         if scope["method"].upper() == "HEAD":
             await send({"type": "http.response.body", "body": b"", "more_body": False})
+        elif "http.response.pathsend" in scope["extensions"]:
+            await send({"type": "http.response.pathsend", "path": str(self.path)})
         else:
             async with await anyio.open_file(self.path, mode="rb") as file:
                 more_body = True


### PR DESCRIPTION
# Summary

As per title, this adds support for [ASGI pathsend](https://asgi.readthedocs.io/en/latest/extensions.html#path-send) extension on `FileResponse` class for servers implementing it.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
