### PR TITLE
fix(response): avoid duplicated charset

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -12,8 +12,8 @@ Signature: `Response(content, status_code=200, headers=None, media_type=None)`
 * `media_type` - A string giving the media type. eg. "text/html"
 
 Starlette will automatically include a Content-Length header. It will also
-include a Content-Type header, based on the media_type and appending a utf-8 charset
-for text types unless a charset has already been specified in the media_type.
+include a Content-Type header, based on the media_type and appending a charset
+for text types, unless a charset has already been specified in the `media_type`.
 
 Once you've instantiated a response, you can send it by calling it as an
 ASGI application instance.

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -12,8 +12,8 @@ Signature: `Response(content, status_code=200, headers=None, media_type=None)`
 * `media_type` - A string giving the media type. eg. "text/html"
 
 Starlette will automatically include a Content-Length header. It will also
-include a Content-Type header, based on the media_type and appending a charset
-for text types.
+include a Content-Type header, based on the media_type and appending a utf-8 charset
+for text types unless a charset has already been specified in the media_type.
 
 Once you've instantiated a response, you can send it by calling it as an
 ASGI application instance.

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -73,7 +73,10 @@ class Response:
 
         content_type = self.media_type
         if content_type is not None and populate_content_type:
-            if content_type.startswith("text/"):
+            if (
+                content_type.startswith("text/")
+                and "charset=" not in content_type.lower()
+            ):
                 content_type += "; charset=" + self.charset
             raw_headers.append((b"content-type", content_type.encode("latin-1")))
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -473,6 +473,13 @@ def test_non_empty_response(test_client_factory):
     assert response.headers["content-length"] == "2"
 
 
+def test_response_do_not_add_redundant_charset(test_client_factory):
+    app = Response(media_type="text/plain; charset=utf-8")
+    client = test_client_factory(app)
+    response = client.get("/")
+    assert response.headers["content-type"] == "text/plain; charset=utf-8"
+
+
 def test_file_response_known_size(tmpdir, test_client_factory):
     path = os.path.join(tmpdir, "xyz")
     content = b"<file content>" * 1000


### PR DESCRIPTION
# Summary
When populating the `media_type` with a MIME-type explicitly indcluding the `; charset=` for `text/` MIME-types, Starlette would by default append an additional default `; charset=utf-8` to the corresponding headers response `Content-Type`, which would result in a duplicated `charset`.
This PR introduces a check if either `; charset=` or `;charset=` has already been included in the `media_type` to avoid `charset` being set twice.

**Before:**
```python
Response(media_type="text/plain;charset=UTF-8")
```
Response header Content-Type:
`Content-Type: text/xml;charset=UTF-8; charset=utf-8`

**After:**
```python
Response(media_type="text/plain;charset=UTF-8")
```
Response header Content-Type:
`Content-Type: text/xml;charset=UTF-8`


# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.
