### PR TITLE
Create `anyio.Event` using a blocking portal

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -95,7 +95,7 @@ class WebSocketTestSession:
     def __enter__(self) -> WebSocketTestSession:
         self.exit_stack = contextlib.ExitStack()
         self.portal = self.exit_stack.enter_context(self.portal_factory())
-        self.should_close = anyio.Event()
+        self.should_close = self.portal.call(anyio.Event)
 
         try:
             _: Future[None] = self.portal.start_task_soon(self._run)

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -92,7 +92,6 @@ class WebSocketTestSession:
         self._receive_queue: queue.Queue[Message] = queue.Queue()
         self._send_queue: queue.Queue[Message | BaseException] = queue.Queue()
         self.extra_headers = None
-        self._should_close: anyio.Event | None = None
 
     def __enter__(self) -> WebSocketTestSession:
         self.exit_stack = contextlib.ExitStack()
@@ -112,9 +111,7 @@ class WebSocketTestSession:
 
     @cached_property
     def should_close(self) -> anyio.Event:
-        if self._should_close is None:
-            self._should_close = anyio.Event()
-        return self._should_close
+        return anyio.Event()
 
     async def _notify_close(self) -> None:
         self.should_close.set()


### PR DESCRIPTION
This fixes Starlette for anyio < 4.2.0.

We need a way to test both low and max version on anyio on Starlette.