### PR TITLE
Restore old documented functionality, add optional warning, document the warning

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -11,7 +11,8 @@ from starlette.config import Config
 from starlette.datastructures import CommaSeparatedStrings, Secret
 
 # Config will be read from environment variables and/or ".env" files.
-config = Config(".env")
+# If warn_missing is set then warning is given if .env -file is not found.
+config = Config(".env", warn_missing=True)
 
 DEBUG = config('DEBUG', cast=bool, default=False)
 DATABASE_URL = config('DATABASE_URL')

--- a/starlette/config.py
+++ b/starlette/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import typing
+import warnings
 from pathlib import Path
 
 
@@ -56,13 +57,17 @@ class Config:
         env_file: str | Path | None = None,
         environ: typing.Mapping[str, str] = environ,
         env_prefix: str = "",
+        *,
+        warn_missing: bool = False,
     ) -> None:
         self.environ = environ
         self.env_prefix = env_prefix
         self.file_values: typing.Dict[str, str] = {}
         if env_file is not None:
             if not os.path.isfile(env_file):
-                raise FileNotFoundError(f"Config file '{env_file}' not found.")
+                if warn_missing:
+                    warnings.warn(f"{env_file} not found")
+                return
             self.file_values = self._read_file(env_file)
 
     @typing.overload

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import os
 import typing
+import warnings
 from pathlib import Path
 from typing import Any, Optional
 
@@ -105,11 +106,15 @@ def test_config(tmpdir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         config.get("BOOL_AS_INT", cast=bool)
 
 
-def test_missing_env_file_raises(tmpdir: Path) -> None:
+def test_missing_env_file_warns_only_if_requested(tmpdir: Path) -> None:
     path = os.path.join(tmpdir, ".env")
 
-    with pytest.raises(FileNotFoundError, match=f"Config file '{path}' not found."):
+    with warnings.catch_warnings(record=True) as caught:
         Config(path)
+        assert not caught
+        with pytest.raises(UserWarning):
+            Config(path, warn_missing=True)
+            assert caught
 
 
 def test_environ() -> None:


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

As per https://github.com/encode/starlette/discussions/2446 the new "raise by default" broke a ton of containerized apps where environment is used in the container but developers use .env files locally.

This will restore old documented functionality to a pattern that is just about everywhere but also adds an option to issue warning if the file is missing.

IDK why coverage on CI is being a silly bugger, my [local coverage report](https://imgur.com/a/ZSdjPvN) says all modified code paths are covered


# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.
