### PR TITLE
Add handling of Authorization header in CORS requests

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -69,6 +69,7 @@ class CORSMiddleware:
         self.allow_origin_regex = compiled_allow_origin_regex
         self.simple_headers = simple_headers
         self.preflight_headers = preflight_headers
+        self.allow_credentials = allow_credentials
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":  # pragma: no cover
@@ -157,11 +158,13 @@ class CORSMiddleware:
         headers.update(self.simple_headers)
         origin = request_headers["Origin"]
         has_cookie = "cookie" in request_headers
+        has_authorization = "Authorization" in request_headers
 
         # If request includes any cookie headers, then we must respond
         # with the specific origin instead of '*'.
-        if self.allow_all_origins and has_cookie:
-            self.allow_explicit_origin(headers, origin)
+        if self.allow_all_origins:
+            if self.allow_credentials and has_authorization or has_cookie:
+                self.allow_explicit_origin(headers, origin)
 
         # If we only allow specific origins, then we have to mirror back
         # the Origin header in the response.

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -66,6 +66,15 @@ def test_cors_allow_all(
     assert response.headers["access-control-expose-headers"] == "X-Status"
     assert response.headers["access-control-allow-credentials"] == "true"
 
+    # Test Authorization order
+    headers = {"Origin": "https://example.org", "Authorization": "Some_token"}
+    response = client.get("/", headers=headers)
+    assert response.status_code == 200
+    assert response.text == "Homepage"
+    assert response.headers["access-control-allow-origin"] == "https://example.org"
+    assert response.headers["access-control-expose-headers"] == "X-Status"
+    assert response.headers["access-control-allow-credentials"] == "true"
+
     # Test non-CORS response
     response = client.get("/")
     assert response.status_code == 200


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

if the allow_credential is true then handle the Authorization header in CORS request
# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
