### PR TITLE
Fix TrustedHostMiddleware Handling for WebSocket Connections

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -51,10 +51,13 @@ class TrustedHostMiddleware:
             await self.app(scope, receive, send)
         else:
             response: Response
-            if found_www_redirect and self.www_redirect:
-                url = URL(scope=scope)
-                redirect_url = url.replace(netloc="www." + url.netloc)
-                response = RedirectResponse(url=str(redirect_url))
+            if scope["type"] == "websocket":
+                await send({"type": "websocket.close", "code": 4001})
             else:
-                response = PlainTextResponse("Invalid host header", status_code=400)
-            await response(scope, receive, send)
+                if found_www_redirect and self.www_redirect:
+                    url = URL(scope=scope)
+                    redirect_url = url.replace(netloc="www." + url.netloc)
+                    response = RedirectResponse(url=str(redirect_url))
+                else:
+                    response = PlainTextResponse("Invalid host header", status_code=400)
+                await response(scope, receive, send)

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -649,32 +649,21 @@ def test_app():
             WebSocketRoute("/ws", endpoint=websocket_endpoint),
         ]
     )
-    # Apply your TrustedHostMiddleware with a configuration that only allows a specific host
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=["allowedhost.com"])
     return app
 
 
-def test_websocket_request_with_invalid_host(test_app):
+def test_websocket_request_invalid_host(test_app):
     client = TestClient(test_app)
-    # Attempt to connect with an invalid 'Host' header
     with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect("/ws", headers={"Host": "invalidhost.com"}):
-            pass  # This block should not execute because the connection should be denied
-    # Check that the connection was closed with the specific status code for invalid host header
-    assert (
-        exc_info.value.code == 4001
-    )  # Assuming 4001 is the code used for invalid host header
+            pass
+    assert exc_info.value.code == 4001
 
 
 def test_websocket_request_without_host_header(test_app):
     client = TestClient(test_app)
-    # Simulate a WebSocket connection attempt without the 'Host' header
-    # Note: The Starlette TestClient might automatically add a 'Host' header. If so, consider using a different
-    # testing approach or tool that allows removing the 'Host' header entirely.
     with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect("/ws", headers={}):
-            pass  # This block should not execute because the connection should be denied
-    # Check that the connection was closed with the specific status code for missing host header
-    assert (
-        exc_info.value.code == 4001
-    )  # Assuming 4001 is also used for missing host header
+            pass
+    assert exc_info.value.code == 4001

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -11,7 +11,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import Response
 from starlette.routing import WebSocketRoute
 from starlette.testclient import TestClient, WebSocketDenialResponse
-from starlette.types import Message, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 TestClientFactory = Callable[..., TestClient]
@@ -638,8 +638,8 @@ def test_receive_wrong_message_type(test_client_factory: TestClientFactory) -> N
 
 
 @pytest.fixture
-def test_app():
-    async def websocket_endpoint(websocket):
+def test_app() -> ASGIApp:
+    async def websocket_endpoint(websocket: WebSocket) -> None:
         await websocket.accept()
         await websocket.send_text("This should not be reached")
         await websocket.close()
@@ -653,7 +653,7 @@ def test_app():
     return app
 
 
-def test_websocket_request_invalid_host(test_app):
+def test_websocket_request_invalid_host(test_app: ASGIApp) -> None:
     client = TestClient(test_app)
     with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect("/ws", headers={"Host": "invalidhost.com"}):
@@ -661,7 +661,7 @@ def test_websocket_request_invalid_host(test_app):
     assert exc_info.value.code == 4001
 
 
-def test_websocket_request_without_host_header(test_app):
+def test_websocket_request_without_host_header(test_app: ASGIApp) -> None:
     client = TestClient(test_app)
     with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect("/ws", headers={}):

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -636,6 +636,7 @@ def test_receive_wrong_message_type(test_client_factory: TestClientFactory) -> N
         with client.websocket_connect("/") as websocket:
             websocket.send({"type": "websocket.connect"})
 
+
 @pytest.fixture
 def test_app():
     async def websocket_endpoint(websocket):
@@ -643,12 +644,15 @@ def test_app():
         await websocket.send_text("This should not be reached")
         await websocket.close()
 
-    app = Starlette(routes=[
-        WebSocketRoute("/ws", endpoint=websocket_endpoint),
-    ])
+    app = Starlette(
+        routes=[
+            WebSocketRoute("/ws", endpoint=websocket_endpoint),
+        ]
+    )
     # Apply your TrustedHostMiddleware with a configuration that only allows a specific host
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=["allowedhost.com"])
     return app
+
 
 def test_websocket_request_with_invalid_host(test_app):
     client = TestClient(test_app)
@@ -657,7 +661,10 @@ def test_websocket_request_with_invalid_host(test_app):
         with client.websocket_connect("/ws", headers={"Host": "invalidhost.com"}):
             pass  # This block should not execute because the connection should be denied
     # Check that the connection was closed with the specific status code for invalid host header
-    assert exc_info.value.code == 4001  # Assuming 4001 is the code used for invalid host header
+    assert (
+        exc_info.value.code == 4001
+    )  # Assuming 4001 is the code used for invalid host header
+
 
 def test_websocket_request_without_host_header(test_app):
     client = TestClient(test_app)
@@ -668,4 +675,6 @@ def test_websocket_request_without_host_header(test_app):
         with client.websocket_connect("/ws", headers={}):
             pass  # This block should not execute because the connection should be denied
     # Check that the connection was closed with the specific status code for missing host header
-    assert exc_info.value.code == 4001  # Assuming 4001 is also used for missing host header
+    assert (
+        exc_info.value.code == 4001
+    )  # Assuming 4001 is also used for missing host header


### PR DESCRIPTION
# Summary

This PR addresses a runtime exception encountered when making WebSocket requests without a Host header or with an invalid Host header, resulting in a RuntimeError due to an inappropriate response type. The existing TrustedHostMiddleware does not properly handle WebSocket connections in such scenarios, attempting to send an HTTP response where a WebSocket response is expected.

fix #2420 

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
