### PR TITLE
Fix compatibility with anyio v3: MemoryObjectReceiveStream has no attribute 'close'

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -134,7 +134,7 @@ class BaseHTTPMiddleware:
 
             async def close_recv_stream_on_response_sent() -> None:
                 await response_sent.wait()
-                recv_stream.close()
+                await recv_stream.aclose()
 
             async def send_no_error(message: Message) -> None:
                 try:


### PR DESCRIPTION
# Summary

Fixes: https://github.com/encode/starlette/issues/2517
Anyio v4 has a synchronous `.close()` method on memory object streams. Anyio v3 requires `.aclose()`.

This fixes the following issue:
```python
    | Traceback (most recent call last):
    |   File "/home/jonathan/git/starlette/starlette/middleware/base.py", line 137, in close_recv_stream_on_response_sent
    |     recv_stream.close()
    | AttributeError: 'MemoryObjectReceiveStream' object has no attribute 'close'
```

The fix is trivial and probably does not require documentation or a discussions.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
