### PR TITLE
Fix 'no response returned' RuntimeError during cancellation in BaseHTTPMiddleware

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -163,6 +163,8 @@ class BaseHTTPMiddleware:
             except anyio.EndOfStream:
                 if app_exc is not None:
                     raise app_exc
+                if request._is_disconnected:
+                    return Response()  # pragma: nocover
                 raise RuntimeError("No response returned.")
 
             assert message["type"] == "http.response.start"


### PR DESCRIPTION
Fixes: https://github.com/encode/starlette/issues/2516

If an incoming request is disconnected before a response gets produced, don't raise a RuntimeError. This fixes a race condition that occurs when many `BaseHTTPMiddleware` instances are wrapped within each other and the client (e.g., web browser) disconnects before the start of the response has been produced by the endpoint.

An alternative fix, possibly better, would be to always return a dummy `Response` and never raise the `RuntimeError`, regardless of whether `_is_disconnected` is set.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
