### PR TITLE
Remove deprecated `app` argument passed to `httpx.Client` on the `TestClient`

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -453,7 +453,6 @@ class TestClient(httpx.Client):
             headers = {}
         headers.setdefault("user-agent", "testclient")
         super().__init__(
-            app=self.app,
             base_url=base_url,
             headers=headers,
             transport=transport,


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

Fixes: #2524 
This fixes the following deprecation warning when using `TestClient` with httpx 0.27:

```
E           DeprecationWarning: The 'app' shortcut is now deprecated. Use the explicit style 'transport=WSGITransport(app=...)' instead.
```

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
