### PR TITLE
Use try/except instead of checking environment version.

### DIFF
--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -3,23 +3,21 @@ from __future__ import annotations
 import asyncio
 import functools
 import re
-import sys
 import typing
 from contextlib import contextmanager
 
 from starlette.types import Scope
 
-if sys.version_info >= (3, 10):  # pragma: no cover
+try:
     from typing import TypeGuard
-else:  # pragma: no cover
+except ImportError:
     from typing_extensions import TypeGuard
 
 has_exceptiongroups = True
-if sys.version_info < (3, 11):  # pragma: no cover
-    try:
-        from exceptiongroup import BaseExceptionGroup
-    except ImportError:
-        has_exceptiongroups = False
+try:
+    from exceptiongroup import BaseExceptionGroup
+except ImportError:
+    has_exceptiongroups = False
 
 T = typing.TypeVar("T")
 AwaitableCallable = typing.Callable[..., typing.Awaitable[T]]

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import sys
 import typing
 import warnings
 
-if sys.version_info >= (3, 10):  # pragma: no cover
+try:
     from typing import ParamSpec
-else:  # pragma: no cover
+except ImportError:
     from typing_extensions import ParamSpec
 
 from starlette.datastructures import State, URLPath

--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import functools
 import inspect
-import sys
 import typing
 from urllib.parse import urlencode
 
-if sys.version_info >= (3, 10):  # pragma: no cover
+try:
     from typing import ParamSpec
-else:  # pragma: no cover
+except ImportError:
     from typing_extensions import ParamSpec
 
 from starlette._utils import is_async_callable

--- a/starlette/background.py
+++ b/starlette/background.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import sys
 import typing
 
-if sys.version_info >= (3, 10):  # pragma: no cover
+try:
     from typing import ParamSpec
-else:  # pragma: no cover
+except ImportError:
     from typing_extensions import ParamSpec
 
 from starlette._utils import is_async_callable

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import functools
-import sys
 import typing
 import warnings
 
 import anyio.to_thread
 
-if sys.version_info >= (3, 10):  # pragma: no cover
+try:
     from typing import ParamSpec
-else:  # pragma: no cover
+except ImportError:
     from typing_extensions import ParamSpec
 
 P = ParamSpec("P")

--- a/starlette/middleware/__init__.py
+++ b/starlette/middleware/__init__.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import sys
 from typing import Any, Iterator, Protocol
 
-if sys.version_info >= (3, 10):  # pragma: no cover
+try:
     from typing import ParamSpec
-else:  # pragma: no cover
+except ImportError:
     from typing_extensions import ParamSpec
 
 from starlette.types import ASGIApp, Receive, Scope, Send

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -6,7 +6,6 @@ import io
 import json
 import math
 import queue
-import sys
 import typing
 import warnings
 from concurrent.futures import Future
@@ -24,9 +23,9 @@ from starlette._utils import is_async_callable
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocketDisconnect
 
-if sys.version_info >= (3, 10):  # pragma: no cover
+try:
     from typing import TypeGuard
-else:  # pragma: no cover
+except ImportError:
     from typing_extensions import TypeGuard
 
 try:


### PR DESCRIPTION
# Summary

Instead calling `sys.version_info` and checking the version before importing it's better to just use a try/except block. Saves having to even check the version altogether.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
