### PR TITLE
Remove processed background task objects

### DIFF
--- a/starlette/background.py
+++ b/starlette/background.py
@@ -41,5 +41,7 @@ class BackgroundTasks(BackgroundTask):
         self.tasks.append(task)
 
     async def __call__(self) -> None:
-        for task in self.tasks:
+        for task in self.tasks.copy():
             await task()
+            if task in self.tasks:
+                self.tasks.remove(task)


### PR DESCRIPTION
Remove already processed background task objects once a task is processed

# Summary

When a background task is processed it is not removed from the array and it is very difficult to implement features in which we want to find length of queued background tasks

This can be used to freeze shutdowns when handling OS signals for enabling graceful shutdowns. Thus, if there are already enqueued background tasks wait and only then stop the server once all the tasks are finished.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
