### PR TITLE
refactor: Use @staticmethod decorator to optimize performance

### DIFF
--- a/starlette/config.py
+++ b/starlette/config.py
@@ -117,7 +117,8 @@ class Config:
             return self._perform_cast(key, default, cast)
         raise KeyError(f"Config '{key}' is missing, and has no default.")
 
-    def _read_file(self, file_name: str | Path) -> dict[str, str]:
+    @staticmethod
+    def _read_file(file_name: str | Path) -> dict[str, str]:
         file_values: dict[str, str] = {}
         with open(file_name) as input_file:
             for line in input_file.readlines():
@@ -129,8 +130,8 @@ class Config:
                     file_values[key] = value
         return file_values
 
+    @staticmethod
     def _perform_cast(
-        self,
         key: str,
         value: typing.Any,
         cast: typing.Callable[[typing.Any], typing.Any] | None = None,

--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -185,9 +185,8 @@ class ServerErrorMiddleware:
             # to optionally raise the error within the test case.
             raise exc
 
-    def format_line(
-        self, index: int, line: str, frame_lineno: int, frame_index: int
-    ) -> str:
+    @staticmethod
+    def format_line(index: int, line: str, frame_lineno: int, frame_index: int) -> str:
         values = {
             # HTML escape - line could contain < or >
             "line": html.escape(line).replace(" ", "&nbsp"),
@@ -245,7 +244,8 @@ class ServerErrorMiddleware:
 
         return TEMPLATE.format(styles=STYLES, js=JS, error=error, exc_html=exc_html)
 
-    def generate_plain_text(self, exc: Exception) -> str:
+    @staticmethod
+    def generate_plain_text(exc: Exception) -> str:
         return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
 
     def debug_response(self, request: Request, exc: Exception) -> Response:
@@ -257,5 +257,6 @@ class ServerErrorMiddleware:
         content = self.generate_plain_text(exc)
         return PlainTextResponse(content, status_code=500)
 
-    def error_response(self, request: Request, exc: Exception) -> Response:
+    @staticmethod
+    def error_response(request: Request, exc: Exception) -> Response:
         return PlainTextResponse("Internal Server Error", status_code=500)

--- a/starlette/middleware/exceptions.py
+++ b/starlette/middleware/exceptions.py
@@ -64,7 +64,8 @@ class ExceptionMiddleware:
 
         await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
 
-    def http_exception(self, request: Request, exc: Exception) -> Response:
+    @staticmethod
+    def http_exception(request: Request, exc: Exception) -> Response:
         assert isinstance(exc, HTTPException)
         if exc.status_code in {204, 304}:
             return Response(status_code=exc.status_code, headers=exc.headers)
@@ -72,6 +73,7 @@ class ExceptionMiddleware:
             exc.detail, status_code=exc.status_code, headers=exc.headers
         )
 
-    async def websocket_exception(self, websocket: WebSocket, exc: Exception) -> None:
+    @staticmethod
+    async def websocket_exception(websocket: WebSocket, exc: Exception) -> None:
         assert isinstance(exc, WebSocketException)
         await websocket.close(code=exc.code, reason=exc.reason)  # pragma: no cover

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -233,7 +233,8 @@ class StreamingResponse(Response):
         self.background = background
         self.init_headers(headers)
 
-    async def listen_for_disconnect(self, receive: Receive) -> None:
+    @staticmethod
+    async def listen_for_disconnect(receive: Receive) -> None:
         while True:
             message = await receive()
             if message["type"] == "http.disconnect":

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -677,7 +677,8 @@ class Router:
             for cls, args, kwargs in reversed(middleware):
                 self.middleware_stack = cls(self.middleware_stack, *args, **kwargs)
 
-    async def not_found(self, scope: Scope, receive: Receive, send: Send) -> None:
+    @staticmethod
+    async def not_found(scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "websocket":
             websocket_close = WebSocketClose()
             await websocket_close(scope, receive, send)

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -86,7 +86,8 @@ class BaseSchemaGenerator:
 
         return endpoints_info
 
-    def _remove_converter(self, path: str) -> str:
+    @staticmethod
+    def _remove_converter(path: str) -> str:
         """
         Remove the converter from the path.
         For example, a route like this:
@@ -95,8 +96,9 @@ class BaseSchemaGenerator:
         """
         return re.sub(r":\w+}", "}", path)
 
+    @staticmethod
     def parse_docstring(
-        self, func_or_method: typing.Callable[..., typing.Any]
+        func_or_method: typing.Callable[..., typing.Any],
     ) -> dict[str, typing.Any]:
         """
         Given a function, parse the docstring as YAML and return a dictionary of info.

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -58,8 +58,8 @@ class StaticFiles:
         if check_dir and directory is not None and not os.path.isdir(directory):
             raise RuntimeError(f"Directory '{directory}' does not exist")
 
+    @staticmethod
     def get_directories(
-        self,
         directory: PathLike | None = None,
         packages: list[str | tuple[str, str]] | None = None,
     ) -> list[PathLike]:
@@ -103,7 +103,8 @@ class StaticFiles:
         response = await self.get_response(path, scope)
         await response(scope, receive, send)
 
-    def get_path(self, scope: Scope) -> str:
+    @staticmethod
+    def get_path(scope: Scope) -> str:
         """
         Given the ASGI scope, return the `path` string to serve up,
         with OS specific path separators, and any '..', '.' components removed.
@@ -209,9 +210,8 @@ class StaticFiles:
                 f"StaticFiles path '{self.directory}' is not a directory."
             )
 
-    def is_not_modified(
-        self, response_headers: Headers, request_headers: Headers
-    ) -> bool:
+    @staticmethod
+    def is_not_modified(response_headers: Headers, request_headers: Headers) -> bool:
         """
         Given the request and response headers, return `True` if an HTTP
         "Not Modified" response could be returned instead.

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -113,8 +113,8 @@ class Jinja2Templates:
 
         self._setup_env_defaults(self.env)
 
+    @staticmethod
     def _create_env(
-        self,
         directory: str
         | PathLike[typing.AnyStr]
         | typing.Sequence[str | PathLike[typing.AnyStr]],
@@ -126,7 +126,8 @@ class Jinja2Templates:
 
         return jinja2.Environment(**env_options)
 
-    def _setup_env_defaults(self, env: jinja2.Environment) -> None:
+    @staticmethod
+    def _setup_env_defaults(env: jinja2.Environment) -> None:
         @pass_context
         def url_for(
             context: dict[str, typing.Any],

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -470,8 +470,9 @@ class TestClient(httpx.Client):
             ) as portal:
                 yield portal
 
+    @staticmethod
     def _choose_redirect_arg(
-        self, follow_redirects: bool | None, allow_redirects: bool | None
+        follow_redirects: bool | None, allow_redirects: bool | None
     ) -> bool | httpx._client.UseClientDefault:
         redirect: bool | httpx._client.UseClientDefault = (
             httpx._client.USE_CLIENT_DEFAULT

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -125,7 +125,8 @@ class WebSocket(HTTPConnection):
             {"type": "websocket.accept", "subprotocol": subprotocol, "headers": headers}
         )
 
-    def _raise_on_disconnect(self, message: Message) -> None:
+    @staticmethod
+    def _raise_on_disconnect(message: Message) -> None:
         if message["type"] == "websocket.disconnect":
             raise WebSocketDisconnect(message["code"], message.get("reason"))
 


### PR DESCRIPTION
refactor: Use @staticmethod decorator to optimize performance by avoiding instantiation of bound methods for each object

- Bound methods incur overhead as they are objects themselves

<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

However, using the @staticmethod decorator does not have obvious preferable use cases. But I find that as long as methods that do not use self in their body create a bound object, that we could avoid by using @staticmethod

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
