### PR TITLE
Add `ContentType` generic to `Response`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "anyio>=3.4.0,<5",
-    "typing_extensions>=3.10.0; python_version < '3.10'",
+    "typing_extensions>=4.4.0; python_version < '3.13'",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # Testing
 coverage==7.4.3
 importlib-metadata==7.0.1
-mypy==1.8.0
+mypy==1.9.0
 ruff==0.1.15
 typing_extensions==4.10.0
 types-contextvars==2.4.7.3

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -258,7 +258,7 @@ def test_request_disconnect(
     scope = {"type": "http", "method": "POST", "path": "/"}
     with pytest.raises(ClientDisconnect):
         anyio.run(
-            app,  # type: ignore
+            app,
             scope,
             receiver,
             None,

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -258,7 +258,7 @@ def test_request_disconnect(
     scope = {"type": "http", "method": "POST", "path": "/"}
     with pytest.raises(ClientDisconnect):
         anyio.run(
-            app,
+            app,  # type: ignore
             scope,
             receiver,
             None,


### PR DESCRIPTION
- Retry of https://github.com/encode/starlette/pull/1534.

At the time that PR was implemented the `default=` parameter was not available on `TypeVar`, and mypy didn't support it.

Now it's possible to achieve what that PR intended.