### PR TITLE
Add missing compresslevel parameter on docs

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -194,7 +194,7 @@ app = Starlette(routes=routes, middleware=middleware)
 The following arguments are supported:
 
 * `minimum_size` - Do not GZip responses that are smaller than this minimum size in bytes. Defaults to `500`.
-* `compresslevel` - will be used during gzip compression. It is an integer ranging from 1 to 9. Defaults to `9`. Lower value results in faster compression but larger file sizes, while higher value results in slower compression but smaller file sizes.
+* `compresslevel` - Used during GZip compression. It is an integer ranging from 1 to 9. Defaults to `9`. Lower value results in faster compression but larger file sizes, while higher value results in slower compression but smaller file sizes.
 
 The middleware won't GZip responses that already have a `Content-Encoding` set, to prevent them from being encoded twice.
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -185,7 +185,7 @@ from starlette.middleware.gzip import GZipMiddleware
 routes = ...
 
 middleware = [
-    Middleware(GZipMiddleware, minimum_size=1000)
+    Middleware(GZipMiddleware, minimum_size=1000, compresslevel=9)
 ]
 
 app = Starlette(routes=routes, middleware=middleware)
@@ -194,6 +194,7 @@ app = Starlette(routes=routes, middleware=middleware)
 The following arguments are supported:
 
 * `minimum_size` - Do not GZip responses that are smaller than this minimum size in bytes. Defaults to `500`.
+* `compresslevel` - will be used during gzip compression. It is an integer ranging from 1 to 9. Defaults to `9`. Lower value results in faster compression but larger file sizes, while higher value results in slower compression but smaller file sizes.
 
 The middleware won't GZip responses that already have a `Content-Encoding` set, to prevent them from being encoded twice.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

The compresslevel parameter was added in #1128.
But, it was not added to the document, so I added an explanation on docs.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
