### PR TITLE
Fail fast on invalid Jinja2Template instantiation parameters

### DIFF
--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -104,7 +104,9 @@ class Jinja2Templates:
                 DeprecationWarning,
             )
         assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
-        assert directory or env, "either 'directory' or 'env' arguments must be passed"
+        assert bool(directory) ^ bool(
+            env
+        ), "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []
         if directory is not None:
             self.env = self._create_env(directory, **env_options)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -143,6 +143,13 @@ def test_templates_require_directory_or_environment() -> None:
         Jinja2Templates()  # type: ignore[call-overload]
 
 
+def test_templates_require_directory_or_enviroment_not_both() -> None:
+    with pytest.raises(
+        AssertionError, match="either 'directory' or 'env' arguments must be passed"
+    ):
+        Jinja2Templates(directory="dir", env=jinja2.Environment())
+
+
 def test_templates_with_directory(tmpdir: Path) -> None:
     path = os.path.join(tmpdir, "index.html")
     with open(path, "w") as file:


### PR DESCRIPTION
# Summary
Calling `Jinja2Template()` with both `directory` and `env` shouldn't be allowed. When both parameters were used, the passed `env` was silently ignored in favor of creating a new one with the provided `directory` and the deprecated `env_options`.


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
