### PR TITLE
Update SessionMiddleware and TrustedHostMiddleware Documentation

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -104,6 +104,7 @@ The following arguments are supported:
 * `session_cookie` - Defaults to "session".
 * `max_age` - Session expiry time in seconds. Defaults to 2 weeks. If set to `None` then the cookie will last as long as the browser session.
 * `same_site` - SameSite flag prevents the browser from sending session cookie along with cross-site requests. Defaults to `'lax'`.
+* `path` - The path set for the session cookie. Defaults to `'/'`.
 * `https_only` - Indicate that Secure flag should be set (can be used with HTTPS only). Defaults to `False`.
 * `domain` - Domain of the cookie used to share cookie between subdomains or cross-domains. The browser defaults the domain to the same host that set the cookie, excluding subdomains [refrence](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#domain_attribute).
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -168,6 +168,7 @@ The following arguments are supported:
 * `allowed_hosts` - A list of domain names that should be allowed as hostnames. Wildcard
 domains such as `*.example.com` are supported for matching subdomains. To allow any
 hostname either use `allowed_hosts=["*"]` or omit the middleware.
+* `www_redirect` - If set to True, requests to non-www versions of the allowed hosts will be redirected to their www counterparts. Defaults to `True`.
 
 If an incoming request does not validate correctly then a 400 response will be sent.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
This PR updates the documentation for `SessionMiddleware` and `TrustedHostMiddleware` to reflect the current code more accurately.

## Changes
1. SessionMiddleware:

- Added documentation for the path parameter which specifies the path set for the session cookie. It defaults to "/".

2. TrustedHostMiddleware:
- Added documentation for the www_redirect parameter. When set to True, this option redirects requests to non-www versions of allowed hosts to their www counterparts. This parameter defaults to True.


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
