### PR TITLE
Fix documentation on client address type

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -61,7 +61,6 @@ For example: `request.path_params['username']`
 #### Client Address
 
 The client's remote address is exposed as a named two-tuple `request.client` (or `None`).
-`request.client` may be `None` but each item in the tuple will not be `None`.
 
 The hostname or IP address: `request.client.host`
 

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -60,7 +60,7 @@ For example: `request.path_params['username']`
 
 #### Client Address
 
-The client's remote address is exposed as a named two-tuple `request.client`.
+The client's remote address is exposed as a named two-tuple `request.client` (or `None`).
 `request.client` may be `None` but each item in the tuple will not be `None`.
 
 The hostname or IP address: `request.client.host`

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -61,7 +61,7 @@ For example: `request.path_params['username']`
 #### Client Address
 
 The client's remote address is exposed as a named two-tuple `request.client`.
-Either item in the tuple may be `None`.
+`request.client` may be `None` but each item in the tuple will not be `None`.
 
 The hostname or IP address: `request.client.host`
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -145,7 +145,7 @@ class HTTPConnection(typing.Mapping[str, typing.Any]):
 
     @property
     def client(self) -> Address | None:
-        # client is a 2 item tuple of (host, port), None or missing
+        # client is a 2 item tuple of (host, port), None if missing
         host_port = self.scope.get("client")
         if host_port is not None:
             return Address(*host_port)


### PR DESCRIPTION
# Summary

Updates the documentation to match the [ASGI specs](https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope) and the type in the [source code](https://github.com/encode/starlette/blob/f305f003c27b768ae1f5cf417b158791b10b10dc/starlette/requests.py#L147). I also changed the comment in the source code because I think there was a mistake.

This was changed in the PR https://github.com/encode/starlette/pull/1462 but the documentation was not updated.

This was also previously discussed here https://github.com/encode/starlette/discussions/2244.


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
