### PR TITLE
Send 404 instead of 500 when filename requested is too long on `StaticFiles`

### DIFF
--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -126,7 +126,7 @@ class StaticFiles:
         except PermissionError:
             raise HTTPException(status_code=401)
         except OSError as exc:
-            # If the the user requested a filename that is too long, send back a 404.
+            # Filename is too long, so it can't be a valid static file.
             if exc.errno == errno.ENAMETOOLONG:
                 raise HTTPException(status_code=404)
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -469,6 +469,21 @@ def test_staticfiles_access_file_as_dir_returns_404(
     assert response.text == "Not Found"
 
 
+def test_staticfiles_filename_too_long_returns_404(
+    tmpdir: Path, test_client_factory: TestClientFactory
+) -> None:
+    routes = [Mount("/", app=StaticFiles(directory=tmpdir), name="static")]
+    app = Starlette(routes=routes)
+    client = test_client_factory(app)
+
+    # The exact filename limit is platform specific (mainly filesystem specific), but,
+    # as of 2024, it appears to be not more than 4096 chars on POSIX systems, so this
+    # test should behave consistently with a filename longer than that.
+    response = client.get(f"/{'a' * 5000}.txt")
+    assert response.status_code == 404
+    assert response.text == "Not Found"
+
+
 def test_staticfiles_unhandled_os_error_returns_500(
     tmpdir: Path,
     test_client_factory: TestClientFactory,

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -469,17 +469,15 @@ def test_staticfiles_access_file_as_dir_returns_404(
     assert response.text == "Not Found"
 
 
-def test_staticfiles_filename_too_long_returns_404(
+def test_staticfiles_filename_too_long(
     tmpdir: Path, test_client_factory: TestClientFactory
 ) -> None:
     routes = [Mount("/", app=StaticFiles(directory=tmpdir), name="static")]
     app = Starlette(routes=routes)
     client = test_client_factory(app)
 
-    # The exact filename limit is platform specific (mainly filesystem specific), but,
-    # as of 2024, it appears to be not more than 4096 chars on POSIX systems, so this
-    # test should behave consistently with a filename longer than that.
-    response = client.get(f"/{'a' * 5000}.txt")
+    path_max_size = os.pathconf("/", "PC_PATH_MAX")
+    response = client.get(f"/{'a' * path_max_size}.txt")
     assert response.status_code == 404
     assert response.text == "Not Found"
 


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
If a static file with a really long name is requested, then it causes an `OSError` to be raised saying "Filename too long". This error currently gets propagated, resulting in a 500 response. In such a case, the name is too long for the underlying OS to handle, therefore a file with that name couldn't possibly exist, therefore it would be more appropriate to not propagate the error and to return a 404 response.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

Note: I feel that the existing documentation is adequate, it already states:

> Static files will respond with "404 Not found" or "405 Method not allowed" responses for requests which do not match.