### PR TITLE
Add options to support SPAs in StaticFiles

### DIFF
--- a/docs/staticfiles.md
+++ b/docs/staticfiles.md
@@ -3,13 +3,14 @@ Starlette also includes a `StaticFiles` class for serving files in a given direc
 
 ### StaticFiles
 
-Signature: `StaticFiles(directory=None, packages=None, html=False, check_dir=True, follow_symlink=False)`
+Signature: `StaticFiles(directory=None, packages=None, html=False, check_dir=True, follow_symlink=False, fallback_file=None)`
 
 * `directory` - A string or [os.PathLike][pathlike] denoting a directory path.
 * `packages` - A list of strings or list of tuples of strings of python packages.
 * `html` - Run in HTML mode. Automatically loads `index.html` for directories if such file exist.
 * `check_dir` - Ensure that the directory exists upon instantiation. Defaults to `True`.
 * `follow_symlink` - A boolean indicating if symbolic links for files and directories should be followed. Defaults to `False`.
+* `fallback_file` - If the requested path doesn't exist return this file instead.
 
 You can combine this ASGI application with Starlette's routing to provide
 comprehensive static file serving.
@@ -62,5 +63,17 @@ routes=[
 You may prefer to include static files directly inside the "static" directory
 rather than using Python packaging to include static files, but it can be useful
 for bundling up reusable components.
+
+If you are mounting a static SPA that uses client side routing (such as
+react-router) the `fallback_file` option may be useful to you.
+
+```python
+routes = [
+    ...
+    Mount('/app', app=StaticFiles(directory='myapp', fallback_file='index.html')
+]
+
+app = Starlette(routes=routes)
+```
 
 [pathlike]: https://docs.python.org/3/library/os.html#os.PathLike


### PR DESCRIPTION
# Summary

There are two changes supporting one aim, if you don't consider that to be atomic I can open two PRs.

1. Support loading files from packages that might not be present at instantiation and are built asynchronously from webpack and it's contemporaries. 
2. The `fallback_file` option which is used in client side routing. These tools expect that any path that doesn't resolve to a file in the build directory will return the main SPA file (typically `index.html`).

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

Fixes https://github.com/encode/starlette/discussions/1821

An example of someone in the wild wanting this kind of functionality: https://stackoverflow.com/questions/63069190. I think the examples you find around the web to be insufficient in the case where `index.html` is part of your static bundle that might live in a package.