### PR TITLE
Add proper synchronisation to WebSocketTestSession

### DIFF
--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -66,9 +66,7 @@ class Jinja2Templates:
     @typing.overload
     def __init__(
         self,
-        directory: str
-        | PathLike[str]
-        | typing.Sequence[str | PathLike[str]],
+        directory: str | PathLike[str] | typing.Sequence[str | PathLike[str]],
         *,
         context_processors: list[typing.Callable[[Request], dict[str, typing.Any]]]
         | None = None,
@@ -117,9 +115,7 @@ class Jinja2Templates:
 
     def _create_env(
         self,
-        directory: str
-        | PathLike[str]
-        | typing.Sequence[str | PathLike[str]],
+        directory: str | PathLike[str] | typing.Sequence[str | PathLike[str]],
         **env_options: typing.Any,
     ) -> jinja2.Environment:
         loader = jinja2.FileSystemLoader(directory)

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -67,8 +67,8 @@ class Jinja2Templates:
     def __init__(
         self,
         directory: str
-        | PathLike[typing.AnyStr]
-        | typing.Sequence[str | PathLike[typing.AnyStr]],
+        | PathLike[str]
+        | typing.Sequence[str | PathLike[str]],
         *,
         context_processors: list[typing.Callable[[Request], dict[str, typing.Any]]]
         | None = None,
@@ -89,8 +89,8 @@ class Jinja2Templates:
     def __init__(
         self,
         directory: str
-        | PathLike[typing.AnyStr]
-        | typing.Sequence[str | PathLike[typing.AnyStr]]
+        | PathLike[str]
+        | typing.Sequence[str | PathLike[str]]
         | None = None,
         *,
         context_processors: list[typing.Callable[[Request], dict[str, typing.Any]]]
@@ -118,8 +118,8 @@ class Jinja2Templates:
     def _create_env(
         self,
         directory: str
-        | PathLike[typing.AnyStr]
-        | typing.Sequence[str | PathLike[typing.AnyStr]],
+        | PathLike[str]
+        | typing.Sequence[str | PathLike[str]],
         **env_options: typing.Any,
     ) -> jinja2.Environment:
         loader = jinja2.FileSystemLoader(directory)


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

We've been using Starlette's `WebSocketTestSession` in order to test some sockets on our FastAPI application, and it has worked very well. On our Windows development machines, these tests are practically instant (<0.3s), but we quickly found out that the tests could take up to 10-15 minutes on our Linux CI/CD server.

The extreme variability tipped me of that this could be a scheduling issue related to `async`  code which led me to pinpoint the cause of this issue to Starlette's `WebSocketTestSession`, specifically the looping `anyio.sleep(0)` in `_asgi_receive` . Depending on event loop implementation it is not guaranteed to actually yield to another task in a timely manner:  hence our tests would remain stuck on it for minutes at a time.

My solution uses `anyio.Event`s in order to alleviate this problem and implement proper synchronisation on the `_receive_queue`.

Implementing the changes described in this PR resulted in our test suite times going from 10-15 minutes to <0.5s.
This does not change `WebSocketTestSession`'s interface in any way: behaviorally, everything remains the same, up to and including allowing the use of `send` even before entering the context with `with ws_session:`.

Edit: Discussion #2570  is directly relevant to this PR.
# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
