### PR TITLE
Don't print xfail on the test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ module = "starlette.testclient.*"
 implicit_optional = true
 
 [tool.pytest.ini_options]
-addopts = "-rxXs --strict-config --strict-markers"
+addopts = "-rXs --strict-config --strict-markers"
 xfail_strict = true
 filterwarnings = [
     # Turn warnings that aren't filtered into exceptions


### PR DESCRIPTION
It looks like there was a bug before 8.0, on which they were not printed, but then it was fixed, and we see the single test we have xfail being printed (that raises exception) when we ran the test suite.