### PR TITLE
fix: pathsend handling in middlewares

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -170,6 +170,10 @@ class BaseHTTPMiddleware:
             async def body_stream() -> typing.AsyncGenerator[bytes, None]:
                 async with recv_stream:
                     async for message in recv_stream:
+                        if message["type"] == "http.response.pathsend":
+                            # with pathsend we don't need to stream anything
+                            yield message
+                            break
                         assert message["type"] == "http.response.body"
                         body = message.get("body", b"")
                         if body:

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -15,6 +15,9 @@ RequestResponseEndpoint = typing.Callable[[Request], typing.Awaitable[Response]]
 DispatchFunction = typing.Callable[
     [Request, RequestResponseEndpoint], typing.Awaitable[Response]
 ]
+BodyStreamGenerator = typing.AsyncGenerator[
+    typing.Union[bytes, typing.MutableMapping[str, typing.Any]], None
+]
 T = typing.TypeVar("T")
 
 
@@ -167,7 +170,7 @@ class BaseHTTPMiddleware:
 
             assert message["type"] == "http.response.start"
 
-            async def body_stream() -> typing.AsyncGenerator[bytes, None]:
+            async def body_stream() -> BodyStreamGenerator:
                 async with recv_stream:
                     async for message in recv_stream:
                         if message["type"] == "http.response.pathsend":

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -92,7 +92,6 @@ class GZipResponder:
 
                 await self.send(self.initial_message)
                 await self.send(message)
-
         elif message_type == "http.response.body":
             # Remaining body in streaming GZip response.
             body = message.get("body", b"")
@@ -106,6 +105,10 @@ class GZipResponder:
             self.gzip_buffer.seek(0)
             self.gzip_buffer.truncate()
 
+            await self.send(message)
+        elif message_type == "http.response.pathsend":
+            # Don't apply GZip to pathsend responses
+            await self.send(self.initial_message)
             await self.send(message)
 
 

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -207,7 +207,7 @@ class RedirectResponse(Response):
         self.headers["location"] = quote(str(url), safe=":/%#?=@[]!$&'()*+,;")
 
 
-Content = typing.Union[str, bytes, memoryview]
+Content = typing.Union[str, bytes, memoryview, typing.MutableMapping[str, typing.Any]]
 SyncContentStream = typing.Iterable[Content]
 AsyncContentStream = typing.AsyncIterable[Content]
 ContentStream = typing.Union[AsyncContentStream, SyncContentStream]
@@ -254,7 +254,7 @@ class StreamingResponse(Response):
                 should_close_body = False
                 await send(chunk)
                 break
-            if not isinstance(chunk, (bytes, memoryview)):
+            if isinstance(chunk, str):
                 chunk = chunk.encode(self.charset)
             await send({"type": "http.response.body", "body": chunk, "more_body": True})
 

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -253,7 +253,7 @@ class StreamingResponse(Response):
                 # We got an ASGI message which is not response body (eg: pathsend)
                 should_close_body = False
                 await send(chunk)
-                break
+                continue
             if isinstance(chunk, str):
                 chunk = chunk.encode(self.charset)
             await send({"type": "http.response.body", "body": chunk, "more_body": True})

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextvars
 from contextlib import AsyncExitStack
+from pathlib import Path
 from typing import (
     Any,
     AsyncGenerator,
@@ -18,7 +19,12 @@ from starlette.background import BackgroundTask
 from starlette.middleware import Middleware, _MiddlewareClass
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse, Response, StreamingResponse
+from starlette.responses import (
+    FileResponse,
+    PlainTextResponse,
+    Response,
+    StreamingResponse,
+)
 from starlette.routing import Route, WebSocketRoute
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -1035,3 +1041,54 @@ def test_pr_1519_comment_1236166180_example() -> None:
     resp.raise_for_status()
 
     assert bodies == [b"Hello, World!-foo"]
+
+
+@pytest.mark.anyio
+async def test_asgi_pathsend_events(tmpdir: Path) -> None:
+    path = tmpdir / "example.txt"
+    with path.open("w") as file:
+        file.write("<file content>")
+
+    request_body_sent = False
+    response_complete = anyio.Event()
+    events: list[Message] = []
+
+    async def endpoint_with_pathsend(_: Request) -> FileResponse:
+        return FileResponse(path)
+
+    async def passthrough(
+        request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        return await call_next(request)
+
+    app = Starlette(
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=passthrough)],
+        routes=[Route("/", endpoint_with_pathsend)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+        "extensions": {"http.response.pathsend": {}},
+    }
+
+    async def receive() -> Message:
+        nonlocal request_body_sent
+        if not request_body_sent:
+            request_body_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await response_complete.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        events.append(message)
+        if message["type"] == "http.response.pathsend":
+            response_complete.set()
+
+    await app(scope, receive, send)
+
+    assert len(events) == 2
+    assert events[0]["type"] == "http.response.start"
+    assert events[1]["type"] == "http.response.pathsend"

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -1,13 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
 from typing import Callable
+
+import pytest
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
-from starlette.responses import ContentStream, PlainTextResponse, StreamingResponse
+from starlette.responses import (
+    ContentStream,
+    FileResponse,
+    PlainTextResponse,
+    StreamingResponse,
+)
 from starlette.routing import Route
 from starlette.testclient import TestClient
-from starlette.types import ASGIApp
+from starlette.types import ASGIApp, Message
 
 TestClientFactory = Callable[[ASGIApp], TestClient]
 
@@ -111,3 +121,42 @@ def test_gzip_ignored_for_responses_with_encoding_set(
     assert response.text == "x" * 4000
     assert response.headers["Content-Encoding"] == "text"
     assert "Content-Length" not in response.headers
+
+
+@pytest.mark.anyio
+async def test_gzip_ignored_for_pathsend_responses(tmpdir: Path) -> None:
+    path = tmpdir / "example.txt"
+    with path.open("w") as file:
+        file.write("<file content>")
+
+    events: list[Message] = []
+
+    async def endpoint_with_pathsend(request: Request) -> FileResponse:
+        _ = await request.body()
+        return FileResponse(path)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=endpoint_with_pathsend)],
+        middleware=[Middleware(GZipMiddleware)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+        "headers": [(b"accept-encoding", b"gzip, text")],
+        "extensions": {"http.response.pathsend": {}},
+    }
+
+    async def receive() -> Message:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: Message) -> None:
+        events.append(message)
+
+    await app(scope, receive, send)
+
+    assert len(events) == 2
+    assert events[0]["type"] == "http.response.start"
+    assert events[1]["type"] == "http.response.pathsend"


### PR DESCRIPTION
# Summary

Closes #2613 

It seems that when I introduced support for pathsend in #2435 I didn't check the included middlewares to also support the relevant ASGI messages. Affected Starlette versions 0.36.0 and onwards when running on a server supporting pathsend.

<s>Note: this is still in draft since I'd like to plan some tests for the involved code; also the proposed solution isn't necessarily the best one, probably someone like @Kludex might review this and give his feedbacks before proceeding further.</s>
Update: I added tests just to verify the code. In case you're unhappy with the implementation, we can refactor that and keep the tests.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
