### PR TITLE
Fix `routing.get_name()` not to assume all routines have `__name__`

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -99,9 +99,7 @@ def websocket_session(
 
 
 def get_name(endpoint: typing.Callable[..., typing.Any]) -> str:
-    if inspect.isroutine(endpoint) or inspect.isclass(endpoint):
-        return endpoint.__name__
-    return endpoint.__class__.__name__
+    return getattr(endpoint, "__name__", endpoint.__class__.__name__)
 
 
 def replace_params(


### PR DESCRIPTION
# Summary

Fix `routing.get_name()` to use the `__name__` attribute only if it is actually present, rather than assuming that all routine and class types have it, and use the fallback to class name otherwise.  This is necessary for `functools.partial()` that doesn't have a `__name__` attribute, but is recognized as a routine starting with Python 3.13.0b3. Since for older versions of Python, it would have used the fallback anyway, this doesn't really change the behavior there.

Fixes #2638

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. ← this is covered by existing tests already
- [ ] I've updated the documentation accordingly. ← I don't think any changes are necessary
