### PR TITLE
Revert "Add support for ASGI `pathsend` extension"

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -341,8 +341,6 @@ class FileResponse(Response):
         )
         if scope["method"].upper() == "HEAD":
             await send({"type": "http.response.body", "body": b"", "more_body": False})
-        elif "extensions" in scope and "http.response.pathsend" in scope["extensions"]:
-            await send({"type": "http.response.pathsend", "path": str(self.path)})
         else:
             async with await anyio.open_file(self.path, mode="rb") as file:
                 more_body = True

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -350,38 +350,6 @@ def test_file_response_with_method_warns(
         FileResponse(path=tmpdir, filename="example.png", method="GET")
 
 
-@pytest.mark.anyio
-async def test_file_response_with_pathsend(tmpdir: Path) -> None:
-    path = os.path.join(tmpdir, "xyz")
-    content = b"<file content>" * 1000
-    with open(path, "wb") as file:
-        file.write(content)
-
-    app = FileResponse(path=path, filename="example.png")
-
-    async def receive() -> Message:  # type: ignore[empty-body]
-        ...  # pragma: no cover
-
-    async def send(message: Message) -> None:
-        if message["type"] == "http.response.start":
-            assert message["status"] == status.HTTP_200_OK
-            headers = Headers(raw=message["headers"])
-            assert headers["content-type"] == "image/png"
-            assert "content-length" in headers
-            assert "content-disposition" in headers
-            assert "last-modified" in headers
-            assert "etag" in headers
-        elif message["type"] == "http.response.pathsend":
-            assert message["path"] == str(path)
-
-    # Since the TestClient doesn't support `pathsend`, we need to test this directly.
-    await app(
-        {"type": "http", "method": "get", "extensions": {"http.response.pathsend": {}}},
-        receive,
-        send,
-    )
-
-
 def test_set_cookie(
     test_client_factory: TestClientFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
This reverts #2435.
Superseed #2616, as discussed in [comments](https://github.com/encode/starlette/pull/2616#discussion_r1686260072).

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
