### PR TITLE
Add maintainers to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,11 @@ description = "The little ASGI library that shines."
 readme = "README.md"
 license = "BSD-3-Clause"
 requires-python = ">=3.8"
-authors = [{ name = "Tom Christie", email = "tom@tomchristie.com" }]
+authors = [
+    { name = "Tom Christie", email = "tom@tomchristie.com" },
+    { name = "Marcelo Trylesinski", email = "marcelotryle@gmail.com" },
+    { name = "Adrian Garcia Badaracco", email = "1755071+adriangb@users.noreply.github.com" },
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Web Environment",


### PR DESCRIPTION
I've talked to @tomchristie about this, so I'm adding Adrian and myself to the `authors` list.

This PR considers the people that have been maintaining Starlette more actively in the last years.

This is the commit count:

<img width="915" alt="Screenshot 2024-08-06 at 11 33 02" src="https://github.com/user-attachments/assets/9112bd22-3220-43fc-bea6-86c002b79faf">

Besides the commit count, @adriangb has been the most active after me in the issues, discussions, and helping to maintain Starlette in general.