### PR TITLE
Support `request.url_for` when only "app" scope is avaialable

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -176,7 +176,7 @@ class HTTPConnection(typing.Mapping[str, typing.Any]):
         return self._state
 
     def url_for(self, name: str, /, **path_params: typing.Any) -> URL:
-        url_path_provider: Starlette | Router | None = self.scope.get("router") or self.scope.get("app")
+        url_path_provider: Router | Starlette | None = self.scope.get("router") or self.scope.get("app")
         if url_path_provider is None:
             raise RuntimeError("The `url_for` method can only be used inside a Starlette application or with a router.")
         url_path = url_path_provider.url_path_for(name, **path_params)

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -19,6 +19,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
 
 if typing.TYPE_CHECKING:
+    from starlette.applications import Starlette
     from starlette.routing import Router
 
 
@@ -175,8 +176,8 @@ class HTTPConnection(typing.Mapping[str, typing.Any]):
         return self._state
 
     def url_for(self, name: str, /, **path_params: typing.Any) -> URL:
-        router: Router = self.scope["router"]
-        url_path = router.url_path_for(name, **path_params)
+        url_pather: Starlette | Router = self.scope.get("app") or self.scope["router"]
+        url_path = url_pather.url_path_for(name, **path_params)
         return url_path.make_absolute_url(base_url=self.base_url)
 
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -176,8 +176,10 @@ class HTTPConnection(typing.Mapping[str, typing.Any]):
         return self._state
 
     def url_for(self, name: str, /, **path_params: typing.Any) -> URL:
-        url_pather: Starlette | Router = self.scope.get("app") or self.scope["router"]
-        url_path = url_pather.url_path_for(name, **path_params)
+        url_path_provider: Starlette | Router | None = self.scope.get("router") or self.scope.get("app")
+        if url_path_provider is None:
+            raise RuntimeError("The `url_for` method can only be used inside a Starlette application or with a router.")
+        url_path = url_path_provider.url_path_for(name, **path_params)
         return url_path.make_absolute_url(base_url=self.base_url)
 
 

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -2,12 +2,7 @@ from __future__ import annotations
 
 import contextvars
 from contextlib import AsyncExitStack
-from typing import (
-    Any,
-    AsyncGenerator,
-    AsyncIterator,
-    Generator,
-)
+from typing import Any, AsyncGenerator, AsyncIterator, Generator
 
 import anyio
 import pytest
@@ -1158,35 +1153,3 @@ async def test_poll_for_disconnect_repeated(send_body: bool) -> None:
         {"type": "http.response.body", "body": b"good!", "more_body": True},
         {"type": "http.response.body", "body": b"", "more_body": False},
     ]
-
-
-def test_request_url_for_before_call_next(
-    test_client_factory: TestClientFactory,
-) -> None:
-    class CallsRequestUrlForMiddleware(BaseHTTPMiddleware):
-        async def dispatch(
-            self,
-            request: Request,
-            call_next: RequestResponseEndpoint,
-        ) -> Response:
-            if request.url == request.url_for("special"):
-                return PlainTextResponse("Special")
-            return await call_next(request)
-
-    def endpoint(request: Request) -> Response:
-        return PlainTextResponse("OK")
-
-    app = Starlette(
-        routes=[
-            Route("/", endpoint, name="index"),
-            Route("/special", endpoint, name="special"),
-        ],
-        middleware=[Middleware(CallsRequestUrlForMiddleware)],
-    )
-
-    client = test_client_factory(app)
-    response = client.get("/")
-    assert response.text == "OK"
-
-    response = client.get("/special")
-    assert response.text == "Special"

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -628,7 +628,7 @@ def test_request_url_starlette_context(test_client_factory: TestClientFactory) -
             url_for = request.url_for("homepage")
             await self.app(scope, receive, send)
 
-    app = Starlette(routes=[Route("/home", homepage)], middleware=[Middleware(CustomMiddleware)])
+    app = Starlette(routes=[Route("/", homepage)], middleware=[Middleware(CustomMiddleware)])
 
     client = test_client_factory(app)
     client.get("/")

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -628,8 +628,8 @@ def test_request_url_starlette_context(test_client_factory: TestClientFactory) -
             url_for = request.url_for("homepage")
             await self.app(scope, receive, send)
 
-    app = Starlette(routes=[Route("/", homepage)], middleware=[Middleware(CustomMiddleware)])
+    app = Starlette(routes=[Route("/home", homepage)], middleware=[Middleware(CustomMiddleware)])
 
     client = test_client_factory(app)
-    client.get("/")
+    client.get("/home")
     assert url_for == URL("http://testserver/home")


### PR DESCRIPTION
# Summary

Resolve the bug (or limitation) in [this related discussion](https://github.com/encode/starlette/discussions/2522) where `Request.url_for()` cannot be called in a middleware inheriting from `BaseHTTPMiddleware` before the `Router`/`call_next` is invoked.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
