### PR TITLE
fix: cors middleware mirrors origin in case no initial cookie is present

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -152,9 +152,9 @@ class CORSMiddleware:
         headers = MutableHeaders(scope=message)
         headers.update(self.simple_headers)
         origin = request_headers["Origin"]
-        has_cookie = "cookie" in request_headers
+        has_cookie = "cookie" in request_headers or "set-cookie" in headers
 
-        # If request includes any cookie headers, then we must respond
+        # If request or response includes any cookie headers, then we must respond
         # with the specific origin instead of '*'.
         if self.allow_all_origins and has_cookie:
             self.allow_explicit_origin(headers, origin)


### PR DESCRIPTION
# Summary

Whenever a CORS request doesn't contain a cookie in the header, but we try to set one (set-cookie in the response header), the origin of the request is not mirrored in the response, leading to CORS errors.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
