### PR TITLE
Streaming response early disconnect mode

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -215,6 +215,7 @@ class StreamingResponse(Response):
         headers: typing.Mapping[str, str] | None = None,
         media_type: str | None = None,
         background: BackgroundTask | None = None,
+        early_disconnect: bool = True,
     ) -> None:
         if isinstance(content, typing.AsyncIterable):
             self.body_iterator = content
@@ -223,6 +224,7 @@ class StreamingResponse(Response):
         self.status_code = status_code
         self.media_type = self.media_type if media_type is None else media_type
         self.background = background
+        self.early_disconnect = early_disconnect
         self.init_headers(headers)
 
     async def listen_for_disconnect(self, receive: Receive) -> None:
@@ -247,14 +249,17 @@ class StreamingResponse(Response):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        async with anyio.create_task_group() as task_group:
+        if self.early_disconnect:
+            async with anyio.create_task_group() as task_group:
 
-            async def wrap(func: typing.Callable[[], typing.Awaitable[None]]) -> None:
-                await func()
-                task_group.cancel_scope.cancel()
+                async def wrap(func: typing.Callable[[], typing.Awaitable[None]]) -> None:
+                    await func()
+                    task_group.cancel_scope.cancel()
 
-            task_group.start_soon(wrap, partial(self.stream_response, send))
-            await wrap(partial(self.listen_for_disconnect, receive))
+                task_group.start_soon(wrap, partial(self.stream_response, send))
+                await wrap(partial(self.listen_for_disconnect, receive))
+        else:
+            await self.stream_response(send)
 
         if self.background is not None:
             await self.background()

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1006,16 +1006,23 @@ def test_pr_1519_comment_1236166180_example() -> None:
 
 @pytest.mark.anyio
 async def test_multiple_middlewares_stacked_client_disconnected() -> None:
+    ordered_events: list[str] = []
+    unordered_events: list[str] = []
+
     class MyMiddleware(BaseHTTPMiddleware):
-        def __init__(self, app: ASGIApp, version: int, events: list[str]) -> None:
+        def __init__(self, app: ASGIApp, version: int) -> None:
             self.version = version
-            self.events = events
             super().__init__(app)
 
         async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-            self.events.append(f"{self.version}:STARTED")
+            ordered_events.append(f"{self.version}:STARTED")
             res = await call_next(request)
-            self.events.append(f"{self.version}:COMPLETED")
+            ordered_events.append(f"{self.version}:COMPLETED")
+
+            def background() -> None:
+                unordered_events.append(f"{self.version}:BACKGROUND")
+
+            res.background = BackgroundTask(background)
             return res
 
     async def sleepy(request: Request) -> Response:
@@ -1027,11 +1034,9 @@ async def test_multiple_middlewares_stacked_client_disconnected() -> None:
             raise AssertionError("Should have raised ClientDisconnect")
         return Response(b"")
 
-    events: list[str] = []
-
     app = Starlette(
         routes=[Route("/", sleepy)],
-        middleware=[Middleware(MyMiddleware, version=_ + 1, events=events) for _ in range(10)],
+        middleware=[Middleware(MyMiddleware, version=_ + 1) for _ in range(10)],
     )
 
     scope = {
@@ -1051,7 +1056,7 @@ async def test_multiple_middlewares_stacked_client_disconnected() -> None:
 
     await app(scope, receive().__anext__, send)
 
-    assert events == [
+    assert ordered_events == [
         "1:STARTED",
         "2:STARTED",
         "3:STARTED",
@@ -1073,6 +1078,21 @@ async def test_multiple_middlewares_stacked_client_disconnected() -> None:
         "2:COMPLETED",
         "1:COMPLETED",
     ]
+
+    assert sorted(unordered_events) == sorted(
+        [
+            "1:BACKGROUND",
+            "2:BACKGROUND",
+            "3:BACKGROUND",
+            "4:BACKGROUND",
+            "5:BACKGROUND",
+            "6:BACKGROUND",
+            "7:BACKGROUND",
+            "8:BACKGROUND",
+            "9:BACKGROUND",
+            "10:BACKGROUND",
+        ]
+    )
 
     assert sent == [
         {


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Starlette 0.38.4 introduced a bugfix that also introduced a backward incompatible change. This PR keep both the original fix as well as recovers the backward compatibility through parameterization.

## https://github.com/encode/starlette/pull/2620 solved issue

https://github.com/encode/starlette/pull/2620 delivered an important fix for `BaseHTTPMiddleware` which relied on `StreamingResponse` for chained upstream and downstream communication. Unfortunately, `StreamingResponse` optimized for early disconnect which resulted into unexpected termination for some of middleware handlers, in case the communication did not manage to propagate through a longer stack (a stack of 4 was enough to reproduce).

## https://github.com/encode/starlette/pull/2620 created issue

Change https://github.com/encode/starlette/pull/2620 introduced a backward incompatible change for streaming response from `BaseHTTPMiddleware` (background tasks were dropped). This impacted software that relied async post-processing.

## This PR content

This PR extends `StreamingResponse` with `early_disconnect` flag (default `True`) that controls the early disconnect behavior that is undesirable for the middleware case `BaseHTTPMiddleware`. The flag is backward compatible for clients of `StreamingResponse`. The `_StreamingResponse` is reverted back to inherit from `StreamingResponse` but this time suppressing the early disconnect mode. Unit tests extended to cover the case.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] [N/A]  I've updated the documentation accordingly.
