### PR TITLE
Close unclosed `MemoryObjectReceiveStream` in `TestClient`

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -784,7 +784,7 @@ class TestClient(httpx.Client):
                 self.task.result()
             return message
 
-        async with self.stream_send:
+        async with self.stream_send, self.stream_receive:
             await self.stream_receive.send({"type": "lifespan.shutdown"})
             message = await receive()
             assert message["type"] in (


### PR DESCRIPTION
# Summary

`TestClient` isn't closing `stream_receive: StreamObjectStream` correctly during shutdown. This has been confirmed by multiple people as part of discussion [#2603](https://github.com/encode/starlette/discussions/2603). [@markwaddle](https://github.com/markwaddle) has identified that the issue is due to `stream_receive` not being disposed of correctly in the shutdown function. Adding `stream_receive` to the shutdown function's context manager resolved the issue as confirmed by myself and others in the discussion.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
