### PR TITLE
Reraise exception from background task

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -211,9 +211,4 @@ class _StreamingResponse(Response):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
         if self.background:
-            try:
-                await self.background()
-            except Exception:
-                print("hi there")
-                breakpoint()
-                raise
+            await self.background()


### PR DESCRIPTION
- Closes https://github.com/encode/starlette/issues/2625

Currently, the exceptions on the background tasks are swallowed:

```py
from typing import Any

from starlette.applications import Starlette
from starlette.background import BackgroundTask
from starlette.middleware import Middleware
from starlette.middleware.base import BaseHTTPMiddleware
from starlette.requests import Request
from starlette.responses import JSONResponse
from starlette.routing import Route


class CustomHeaderMiddleware(BaseHTTPMiddleware):
    async def dispatch(self, request: Request, call_next: Any):
        response = await call_next(request)
        return response


async def bg_task():
    print("hi there")
    raise ValueError("TEST")


def homepage(request: Request):
    task = BackgroundTask(bg_task)
    message = {"status": "Ok"}
    return JSONResponse(message, background=task)


routes = [Route("/", homepage)]

middleware = [Middleware(CustomHeaderMiddleware)]

app = Starlette(routes=routes, middleware=middleware)
```