### PR TITLE
perf: avoid regex re-compile

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -56,8 +56,7 @@ class Response:
             populate_content_length = True
             populate_content_type = True
         else:
-            raw_headers = [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in
-                           headers.items()]
+            raw_headers = [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items()]
             keys = [h[0] for h in raw_headers]
             populate_content_length = b"content-length" not in keys
             populate_content_type = b"content-type" not in keys
@@ -198,8 +197,7 @@ class RedirectResponse(Response):
         headers: typing.Mapping[str, str] | None = None,
         background: BackgroundTask | None = None,
     ) -> None:
-        super().__init__(content=b"", status_code=status_code, headers=headers,
-                         background=background)
+        super().__init__(content=b"", status_code=status_code, headers=headers, background=background)
         self.headers["location"] = quote(str(url), safe=":/%#?=@[]!$&'()*+,;")
 
 
@@ -252,6 +250,7 @@ class StreamingResponse(Response):
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         async with anyio.create_task_group() as task_group:
+
             async def wrap(func: typing.Callable[[], typing.Awaitable[None]]) -> None:
                 await func()
                 task_group.cancel_scope.cancel()
@@ -345,8 +344,7 @@ class FileResponse(Response):
         http_range = headers.get("range")
         http_if_range = headers.get("if-range")
 
-        if http_range is None or (
-            http_if_range is not None and not self._should_use_range(http_if_range, stat_result)):
+        if http_range is None or (http_if_range is not None and not self._should_use_range(http_if_range, stat_result)):
             await self._handle_simple(send, send_header_only)
         else:
             try:
@@ -354,24 +352,20 @@ class FileResponse(Response):
             except MalformedRangeHeader as exc:
                 return await PlainTextResponse(exc.content, status_code=400)(scope, receive, send)
             except RangeNotSatisfiable as exc:
-                response = PlainTextResponse(status_code=416,
-                                             headers={"Content-Range": f"*/{exc.max_size}"})
+                response = PlainTextResponse(status_code=416, headers={"Content-Range": f"*/{exc.max_size}"})
                 return await response(scope, receive, send)
 
             if len(ranges) == 1:
                 start, end = ranges[0]
-                await self._handle_single_range(send, start, end, stat_result.st_size,
-                                                send_header_only)
+                await self._handle_single_range(send, start, end, stat_result.st_size, send_header_only)
             else:
-                await self._handle_multiple_ranges(send, ranges, stat_result.st_size,
-                                                   send_header_only)
+                await self._handle_multiple_ranges(send, ranges, stat_result.st_size, send_header_only)
 
         if self.background is not None:
             await self.background()
 
     async def _handle_simple(self, send: Send, send_header_only: bool) -> None:
-        await send({"type": "http.response.start", "status": self.status_code,
-                    "headers": self.raw_headers})
+        await send({"type": "http.response.start", "status": self.status_code, "headers": self.raw_headers})
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
         else:
@@ -404,8 +398,7 @@ class FileResponse(Response):
                     chunk = await file.read(min(self.chunk_size, end - start))
                     start += len(chunk)
                     more_body = len(chunk) == self.chunk_size and start < end
-                    await send(
-                        {"type": "http.response.body", "body": chunk, "more_body": more_body})
+                    await send({"type": "http.response.body", "body": chunk, "more_body": more_body})
 
     async def _handle_multiple_ranges(
         self,
@@ -428,8 +421,7 @@ class FileResponse(Response):
                 for start, end in ranges:
                     await file.seek(start)
                     chunk = await file.read(min(self.chunk_size, end - start))
-                    await send({"type": "http.response.body", "body": header_generator(start, end),
-                                "more_body": True})
+                    await send({"type": "http.response.body", "body": header_generator(start, end), "more_body": True})
                     await send({"type": "http.response.body", "body": chunk, "more_body": True})
                     await send({"type": "http.response.body", "body": b"\n", "more_body": True})
                 await send(
@@ -444,8 +436,7 @@ class FileResponse(Response):
     def _should_use_range(cls, http_if_range: str, stat_result: os.stat_result) -> bool:
         etag_base = str(stat_result.st_mtime) + "-" + str(stat_result.st_size)
         etag = f'"{md5_hexdigest(etag_base.encode(), usedforsecurity=False)}"'
-        return http_if_range == formatdate(stat_result.st_mtime,
-                                           usegmt=True) or http_if_range == etag
+        return http_if_range == formatdate(stat_result.st_mtime, usegmt=True) or http_if_range == etag
 
     @staticmethod
     def _parse_range_header(http_range: str, file_size: int) -> list[tuple[int, int]]:
@@ -530,8 +521,8 @@ class FileResponse(Response):
             + (end - start)  # Content
             for start, end in ranges
         ) + (
-                             5 + boundary_len  # --boundary--\n
-                         )
+            5 + boundary_len  # --boundary--\n
+        )
         return (
             content_length,
             lambda start, end: (

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -528,7 +528,7 @@ class FileResponse(Response):
             lambda start, end: (
                 f"--{boundary}\n"
                 f"Content-Type: {content_type}\n"
-                f"Content-Range: bytes {start}-{end - 1}/{max_size}\n"
+                f"Content-Range: bytes {start}-{end-1}/{max_size}\n"
                 "\n"
             ).encode("latin-1"),
         )

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -56,7 +56,8 @@ class Response:
             populate_content_length = True
             populate_content_type = True
         else:
-            raw_headers = [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items()]
+            raw_headers = [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in
+                           headers.items()]
             keys = [h[0] for h in raw_headers]
             populate_content_length = b"content-length" not in keys
             populate_content_type = b"content-type" not in keys
@@ -197,7 +198,8 @@ class RedirectResponse(Response):
         headers: typing.Mapping[str, str] | None = None,
         background: BackgroundTask | None = None,
     ) -> None:
-        super().__init__(content=b"", status_code=status_code, headers=headers, background=background)
+        super().__init__(content=b"", status_code=status_code, headers=headers,
+                         background=background)
         self.headers["location"] = quote(str(url), safe=":/%#?=@[]!$&'()*+,;")
 
 
@@ -250,7 +252,6 @@ class StreamingResponse(Response):
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         async with anyio.create_task_group() as task_group:
-
             async def wrap(func: typing.Callable[[], typing.Awaitable[None]]) -> None:
                 await func()
                 task_group.cancel_scope.cancel()
@@ -270,6 +271,9 @@ class MalformedRangeHeader(Exception):
 class RangeNotSatisfiable(Exception):
     def __init__(self, max_size: int) -> None:
         self.max_size = max_size
+
+
+_RANGE_PATTERN = re.compile(r"(\d*)-(\d*)")
 
 
 class FileResponse(Response):
@@ -341,7 +345,8 @@ class FileResponse(Response):
         http_range = headers.get("range")
         http_if_range = headers.get("if-range")
 
-        if http_range is None or (http_if_range is not None and not self._should_use_range(http_if_range, stat_result)):
+        if http_range is None or (
+            http_if_range is not None and not self._should_use_range(http_if_range, stat_result)):
             await self._handle_simple(send, send_header_only)
         else:
             try:
@@ -349,20 +354,24 @@ class FileResponse(Response):
             except MalformedRangeHeader as exc:
                 return await PlainTextResponse(exc.content, status_code=400)(scope, receive, send)
             except RangeNotSatisfiable as exc:
-                response = PlainTextResponse(status_code=416, headers={"Content-Range": f"*/{exc.max_size}"})
+                response = PlainTextResponse(status_code=416,
+                                             headers={"Content-Range": f"*/{exc.max_size}"})
                 return await response(scope, receive, send)
 
             if len(ranges) == 1:
                 start, end = ranges[0]
-                await self._handle_single_range(send, start, end, stat_result.st_size, send_header_only)
+                await self._handle_single_range(send, start, end, stat_result.st_size,
+                                                send_header_only)
             else:
-                await self._handle_multiple_ranges(send, ranges, stat_result.st_size, send_header_only)
+                await self._handle_multiple_ranges(send, ranges, stat_result.st_size,
+                                                   send_header_only)
 
         if self.background is not None:
             await self.background()
 
     async def _handle_simple(self, send: Send, send_header_only: bool) -> None:
-        await send({"type": "http.response.start", "status": self.status_code, "headers": self.raw_headers})
+        await send({"type": "http.response.start", "status": self.status_code,
+                    "headers": self.raw_headers})
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
         else:
@@ -395,7 +404,8 @@ class FileResponse(Response):
                     chunk = await file.read(min(self.chunk_size, end - start))
                     start += len(chunk)
                     more_body = len(chunk) == self.chunk_size and start < end
-                    await send({"type": "http.response.body", "body": chunk, "more_body": more_body})
+                    await send(
+                        {"type": "http.response.body", "body": chunk, "more_body": more_body})
 
     async def _handle_multiple_ranges(
         self,
@@ -418,7 +428,8 @@ class FileResponse(Response):
                 for start, end in ranges:
                     await file.seek(start)
                     chunk = await file.read(min(self.chunk_size, end - start))
-                    await send({"type": "http.response.body", "body": header_generator(start, end), "more_body": True})
+                    await send({"type": "http.response.body", "body": header_generator(start, end),
+                                "more_body": True})
                     await send({"type": "http.response.body", "body": chunk, "more_body": True})
                     await send({"type": "http.response.body", "body": b"\n", "more_body": True})
                 await send(
@@ -433,7 +444,8 @@ class FileResponse(Response):
     def _should_use_range(cls, http_if_range: str, stat_result: os.stat_result) -> bool:
         etag_base = str(stat_result.st_mtime) + "-" + str(stat_result.st_size)
         etag = f'"{md5_hexdigest(etag_base.encode(), usedforsecurity=False)}"'
-        return http_if_range == formatdate(stat_result.st_mtime, usegmt=True) or http_if_range == etag
+        return http_if_range == formatdate(stat_result.st_mtime,
+                                           usegmt=True) or http_if_range == etag
 
     @staticmethod
     def _parse_range_header(http_range: str, file_size: int) -> list[tuple[int, int]]:
@@ -453,7 +465,7 @@ class FileResponse(Response):
                 int(_[0]) if _[0] else file_size - int(_[1]),
                 int(_[1]) + 1 if _[0] and _[1] and int(_[1]) < file_size else file_size,
             )
-            for _ in re.findall(r"(\d*)-(\d*)", range_)
+            for _ in _RANGE_PATTERN.findall(range_)
             if _ != ("", "")
         ]
 
@@ -518,14 +530,14 @@ class FileResponse(Response):
             + (end - start)  # Content
             for start, end in ranges
         ) + (
-            5 + boundary_len  # --boundary--\n
-        )
+                             5 + boundary_len  # --boundary--\n
+                         )
         return (
             content_length,
             lambda start, end: (
                 f"--{boundary}\n"
                 f"Content-Type: {content_type}\n"
-                f"Content-Range: bytes {start}-{end-1}/{max_size}\n"
+                f"Content-Range: bytes {start}-{end - 1}/{max_size}\n"
                 "\n"
             ).encode("latin-1"),
         )

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -29,6 +29,9 @@ class EndpointInfo(typing.NamedTuple):
     func: typing.Callable[..., typing.Any]
 
 
+_remove_converter_pattern = re.compile(r":\w+}")
+
+
 class BaseSchemaGenerator:
     def get_schema(self, routes: list[BaseRoute]) -> dict[str, typing.Any]:
         raise NotImplementedError()  # pragma: no cover
@@ -89,7 +92,7 @@ class BaseSchemaGenerator:
             Route("/users/{id:int}", endpoint=get_user, methods=["GET"])
         Should be represented as `/users/{id}` in the OpenAPI schema.
         """
-        return re.sub(r":\w+}", "}", path)
+        return _remove_converter_pattern.sub("}", path)
 
     def parse_docstring(self, func_or_method: typing.Callable[..., typing.Any]) -> dict[str, typing.Any]:
         """


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

found `re.findall` and `re.sub` usage in starlette module, we should always pre-compile regex pattern if it's possible.

Althrough `re` has a built-in cache, but it has size limit and for project using many regex it still may be invalidated and pattern get unnecessary re-compile.


There is still one case in https://github.com/encode/starlette/blob/1131b3cbcd6f9e2aa3500fd4d7bf3cd200fa2532/starlette/_utils.py#L88

It's not a simple case so I didn't touch it.
<!-- Write a small summary about what is happening here. -->

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
