### PR TITLE
perf: stop use re on get_route_path

### DIFF
--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import re
 import sys
 import typing
 from contextlib import contextmanager
@@ -84,6 +83,18 @@ def collapse_excgroups() -> typing.Generator[None, None, None]:
 
 
 def get_route_path(scope: Scope) -> str:
+    path: str = scope["path"]
     root_path = scope.get("root_path", "")
-    route_path = re.sub(r"^" + root_path + r"(?=/|$)", "", scope["path"])
-    return route_path
+    if not root_path:
+        return path
+
+    if not path.startswith(root_path):
+        return path
+
+    if path == root_path:
+        return ""
+
+    if path[len(root_path)] == "/":
+        return path[len(root_path) :]
+
+    return path

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -89,6 +89,7 @@ def test_async_nested_partial() -> None:
         ({"path": "/foo-123/bar", "root_path": "/foo"}, "/foo-123/bar"),
         ({"path": "/foo/bar", "root_path": "/foo"}, "/bar"),
         ({"path": "/foo", "root_path": "/foo"}, ""),
+        ({"path": "/foo/bar", "root_path": "/bar"}, "/foo/bar"),
     ],
 )
 def test_get_route_path(scope: Scope, expected_result: str) -> None:


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
```text
platform win32 -- Python 3.10.11, pytest-8.3.2, pluggy-1.5.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: C:\Users\Trim21\proj\starlette
configfile: pyproject.toml
plugins: anyio-4.6.0, benchmark-4.0.0
collected 9 items                                                                                                                                                                                                              

bench.py .........                                                                                                                                                                                                       [100%]


----------------------------------------------------------------------------------------------------- benchmark: 6 tests -----------------------------------------------------------------------------------------------------  
Name (time in ns)                                 Min                    Max                Mean              StdDev              Median                 IQR              Outliers  OPS (Mops/s)            Rounds  Iterations  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  
test_benchmark_new_same                      155.0000 (1.0)         896.0004 (1.0)      168.0182 (1.0)       16.1868 (1.0)      165.0001 (1.0)        2.0006 (34.37)     3410;6140        5.9517 (1.0)       59881         100  
test_benchmark_new_prefix_non_path_match     191.6633 (1.24)      8,683.3315 (9.69)     217.1695 (1.29)      45.3998 (2.80)     208.3349 (1.26)       8.3334 (143.17)    6589;9667        4.6047 (0.77)     196080          12  
test_benchmark_new_path_match                236.8408 (1.53)      3,373.6823 (3.77)     264.6139 (1.57)      42.3720 (2.62)     257.8936 (1.56)      10.5264 (180.84)  10082;11053        3.7791 (0.63)     192309          19  
test_benchmark_old_prefix_non_path_match     749.9960 (4.84)      8,500.0065 (9.49)     820.3344 (4.88)     138.4135 (8.55)     799.9964 (4.85)      16.6668 (286.33)   9095;10933        1.2190 (0.20)     192309           6  
test_benchmark_old_path_match                799.9479 (5.16)     48,399.9611 (54.02)    962.8631 (5.73)     314.3289 (19.42)    900.0069 (5.45)     100.0008 (>1000.0)   3969;5611        1.0386 (0.17)     181819           1  
test_benchmark_old_same                      799.9479 (5.16)      9,899.9590 (11.05)    898.1221 (5.35)     183.1213 (11.31)    900.0069 (5.45)       0.0582 (1.0)        197;2092        1.1134 (0.19)       7988           1  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```