### PR TITLE
Remove duplicated license in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Environment :: Web Environment",
     "Framework :: AnyIO",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "starlette"
 dynamic = ["version"]
 description = "The little ASGI library that shines."
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {file = "LICENSE.md"}
 requires-python = ">=3.8"
 authors = [{ name = "Tom Christie", email = "tom@tomchristie.com" }]
 classifiers = [


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Resolve the building issue from `pyproject.toml`

```log
22:32:47   | ValueError: invalid pyproject.toml config: `project.license`.
22:32:47   | configuration error: `project.license` must be valid exactly by one definition (2 matches found):
22:32:47   |
22:32:47   |     - keys:
22:32:47   |         'file': {type: string}
22:32:47   |       required: ['file']
22:32:47   |     - keys:
22:32:47   |         'text': {type: string}
22:32:47   |       required: ['text']
22:32:47   |
22:32:47   | WARNING: exit code 1 from a shell command.
22:32:47   NOTE: recipe python3-starlette-0.39.0-r0: task do_compile: Failed
```
Reference: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
