### PR TITLE
Support python-multipart 0.0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ source_pkgs = ["starlette", "tests"]
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
-    "pragma: nocover",
     "if typing.TYPE_CHECKING:",
     "@typing.overload",
     "raise NotImplementedError",

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -113,7 +113,7 @@ class Starlette:
         await self.middleware_stack(scope, receive, send)
 
     def on_event(self, event_type: str) -> typing.Callable:  # type: ignore[type-arg]
-        return self.router.on_event(event_type)  # pragma: nocover
+        return self.router.on_event(event_type)  # pragma: no cover
 
     def mount(self, path: str, app: ASGIApp, name: str | None = None) -> None:
         self.router.mount(path, app=app, name=name)  # pragma: no cover

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -11,9 +11,12 @@ from starlette.datastructures import FormData, Headers, UploadFile
 try:
     import multipart
     from multipart.multipart import parse_options_header
-except ModuleNotFoundError:  # pragma: nocover
-    parse_options_header = None
-    multipart = None
+except ModuleNotFoundError:  # pragma: no cover
+    parse_options_header = None  # type: ignore
+    multipart = None  # type: ignore
+
+if typing.TYPE_CHECKING:
+    from multipart.multipart import MultipartCallbacks, QuerystringCallbacks
 
 
 class FormMessage(Enum):
@@ -74,7 +77,7 @@ class FormParser:
 
     async def parse(self) -> FormData:
         # Callbacks dictionary.
-        callbacks = {
+        callbacks: QuerystringCallbacks = {
             "on_field_start": self.on_field_start,
             "on_field_name": self.on_field_name,
             "on_field_data": self.on_field_data,
@@ -220,7 +223,7 @@ class MultiPartParser:
             raise MultiPartException("Missing boundary in multipart.")
 
         # Callbacks dictionary.
-        callbacks = {
+        callbacks: MultipartCallbacks = {
             "on_part_begin": self.on_part_begin,
             "on_part_data": self.on_part_data,
             "on_part_end": self.on_part_end,

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -14,8 +14,8 @@ from starlette.types import Message, Receive, Scope, Send
 
 try:
     from multipart.multipart import parse_options_header
-except ModuleNotFoundError:  # pragma: nocover
-    parse_options_header = None
+except ModuleNotFoundError:  # pragma: no cover
+    parse_options_header = None  # type: ignore
 
 
 if typing.TYPE_CHECKING:

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -767,7 +767,7 @@ class Router:
     def __eq__(self, other: typing.Any) -> bool:
         return isinstance(other, Router) and self.routes == other.routes
 
-    def mount(self, path: str, app: ASGIApp, name: str | None = None) -> None:  # pragma: nocover
+    def mount(self, path: str, app: ASGIApp, name: str | None = None) -> None:  # pragma: no cover
         route = Mount(path, app=app, name=name)
         self.routes.append(route)
 
@@ -782,7 +782,7 @@ class Router:
         methods: list[str] | None = None,
         name: str | None = None,
         include_in_schema: bool = True,
-    ) -> None:  # pragma: nocover
+    ) -> None:  # pragma: no cover
         route = Route(
             path,
             endpoint=endpoint,

--- a/starlette/schemas.py
+++ b/starlette/schemas.py
@@ -10,7 +10,7 @@ from starlette.routing import BaseRoute, Host, Mount, Route
 
 try:
     import yaml
-except ModuleNotFoundError:  # pragma: nocover
+except ModuleNotFoundError:  # pragma: no cover
     yaml = None  # type: ignore[assignment]
 
 

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -19,9 +19,9 @@ try:
     # adding a type ignore for mypy to let us access an attribute that may not exist
     if hasattr(jinja2, "pass_context"):
         pass_context = jinja2.pass_context
-    else:  # pragma: nocover
+    else:  # pragma: no cover
         pass_context = jinja2.contextfunction  # type: ignore[attr-defined]
-except ModuleNotFoundError:  # pragma: nocover
+except ModuleNotFoundError:  # pragma: no cover
     jinja2 = None  # type: ignore[assignment]
 
 

--- a/tests/middleware/test_errors.py
+++ b/tests/middleware/test_errors.py
@@ -77,7 +77,7 @@ def test_debug_not_http(test_client_factory: TestClientFactory) -> None:
     with pytest.raises(RuntimeError):
         client = test_client_factory(app)
         with client.websocket_connect("/"):
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 def test_background_task(test_client_factory: TestClientFactory) -> None:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -211,7 +211,7 @@ def test_invalid_decorator_usage() -> None:
 
         @requires("authenticated")
         def foo() -> None:
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 def test_user_interface(test_client_factory: TestClientFactory) -> None:
@@ -281,11 +281,11 @@ def test_websocket_authentication_required(
     with test_client_factory(app) as client:
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect("/ws"):
-                pass  # pragma: nocover
+                pass  # pragma: no cover
 
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect("/ws", headers={"Authorization": "basic foobar"}):
-                pass  # pragma: nocover
+                pass  # pragma: no cover
 
         with client.websocket_connect("/ws", auth=("tomchristie", "example")) as websocket:
             data = websocket.receive_json()
@@ -293,11 +293,11 @@ def test_websocket_authentication_required(
 
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect("/ws/decorated"):
-                pass  # pragma: nocover
+                pass  # pragma: no cover
 
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect("/ws/decorated", headers={"Authorization": "basic foobar"}):
-                pass  # pragma: nocover
+                pass  # pragma: no cover
 
         with client.websocket_connect("/ws/decorated", auth=("tomchristie", "example")) as websocket:
             data = websocket.receive_json()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -22,8 +22,8 @@ async def test_run_until_first_complete() -> None:
 
     async def task2() -> None:
         await task1_finished.wait()
-        await anyio.sleep(0)  # pragma: nocover
-        task2_finished.set()  # pragma: nocover
+        await anyio.sleep(0)  # pragma: no cover
+        task2_finished.set()  # pragma: no cover
 
     await run_until_first_complete((task1, {}), (task2, {}))
     assert task1_finished.is_set()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -111,7 +111,7 @@ def test_with_headers(client: TestClient) -> None:
 def test_websockets_should_raise(client: TestClient) -> None:
     with pytest.raises(RuntimeError):
         with client.websocket_connect("/runtime_error"):
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 def test_handled_exc_after_response(

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -83,7 +83,7 @@ def test_redirect_response_content_length_header(
 ) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         if scope["path"] == "/":
-            response = Response("hello", media_type="text/plain")  # pragma: nocover
+            response = Response("hello", media_type="text/plain")  # pragma: no cover
         else:
             response = RedirectResponse("/")
         await response(scope, receive, send)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -365,7 +365,7 @@ def test_protocol_switch(test_client_factory: TestClientFactory) -> None:
 
     with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/404"):
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 ok = PlainTextResponse("OK")
@@ -598,7 +598,7 @@ def test_standalone_ws_route_does_not_match(
     client = test_client_factory(app)
     with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/invalid"):
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 def test_lifespan_async(test_client_factory: TestClientFactory) -> None:
@@ -795,7 +795,7 @@ def test_raise_on_startup(test_client_factory: TestClientFactory) -> None:
 
     with pytest.raises(RuntimeError):
         with test_client_factory(app):
-            pass  # pragma: nocover
+            pass  # pragma: no cover
     assert startup_failed
 
 
@@ -808,7 +808,7 @@ def test_raise_on_shutdown(test_client_factory: TestClientFactory) -> None:
 
     with pytest.raises(RuntimeError):
         with test_client_factory(app):
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 def test_partial_async_endpoint(test_client_factory: TestClientFactory) -> None:
@@ -1186,7 +1186,7 @@ def test_decorator_deprecations() -> None:
 
     with pytest.deprecated_call():
 
-        async def startup() -> None: ...  # pragma: nocover
+        async def startup() -> None: ...  # pragma: no cover
 
         router.on_event("startup")(startup)
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -529,7 +529,7 @@ def test_receive_json_invalid_mode(test_client_factory: TestClientFactory) -> No
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
         with client.websocket_connect("/"):
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 def test_receive_text_before_accept(test_client_factory: TestClientFactory) -> None:
@@ -540,7 +540,7 @@ def test_receive_text_before_accept(test_client_factory: TestClientFactory) -> N
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
         with client.websocket_connect("/"):
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 def test_receive_bytes_before_accept(test_client_factory: TestClientFactory) -> None:
@@ -551,7 +551,7 @@ def test_receive_bytes_before_accept(test_client_factory: TestClientFactory) -> 
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
         with client.websocket_connect("/"):
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 def test_receive_json_before_accept(test_client_factory: TestClientFactory) -> None:
@@ -573,7 +573,7 @@ def test_send_before_accept(test_client_factory: TestClientFactory) -> None:
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
         with client.websocket_connect("/"):
-            pass  # pragma: nocover
+            pass  # pragma: no cover
 
 
 def test_send_wrong_message_type(test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
Now `python-multipart` has the `py.typed`, so I had to fix our `formparsers` module.

I've also taken the opportunity to replace `nocover` to `no cover`. Sorry for the noise with it, but it was bothering me for some time.