### PR TITLE
Revert bump on `python-multipart`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 full = [
     "itsdangerous",
     "jinja2",
-    "python-multipart>=0.0.13",
+    "python-multipart>=0.0.7",
     "pyyaml",
     "httpx>=0.22.0",
 ]

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -13,10 +13,10 @@ if typing.TYPE_CHECKING:
     from multipart.multipart import MultipartCallbacks, QuerystringCallbacks, parse_options_header
 else:
     try:
-        try:  # pragma: no cover
+        try:
             import python_multipart as multipart
             from python_multipart.multipart import parse_options_header
-        except ModuleNotFoundError:
+        except ModuleNotFoundError:  # pragma: no cover
             import multipart
             from multipart.multipart import parse_options_header
     except ModuleNotFoundError:  # pragma: no cover

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -8,15 +8,20 @@ from urllib.parse import unquote_plus
 
 from starlette.datastructures import FormData, Headers, UploadFile
 
-try:
-    import python_multipart as multipart
-    from python_multipart.multipart import parse_options_header
-except ModuleNotFoundError:  # pragma: no cover
-    parse_options_header = None  # type: ignore
-    multipart = None  # type: ignore
-
 if typing.TYPE_CHECKING:
-    from python_multipart.multipart import MultipartCallbacks, QuerystringCallbacks
+    import multipart
+    from multipart.multipart import MultipartCallbacks, QuerystringCallbacks, parse_options_header
+else:
+    try:
+        try:  # pragma: no cover
+            import python_multipart as multipart
+            from python_multipart.multipart import parse_options_header
+        except ModuleNotFoundError:
+            import multipart
+            from multipart.multipart import parse_options_header
+    except ModuleNotFoundError:  # pragma: no cover
+        multipart = None
+        parse_options_header = None
 
 
 class FormMessage(Enum):

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -21,7 +21,7 @@ else:
     try:
         try:
             from python_multipart.multipart import parse_options_header
-        except ModuleNotFoundError:
+        except ModuleNotFoundError:  # pragma: no cover
             from multipart.multipart import parse_options_header
     except ModuleNotFoundError:  # pragma: no cover
         parse_options_header = None

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -12,15 +12,19 @@ from starlette.exceptions import HTTPException
 from starlette.formparsers import FormParser, MultiPartException, MultiPartParser
 from starlette.types import Message, Receive, Scope, Send
 
-try:
-    from python_multipart.multipart import parse_options_header
-except ModuleNotFoundError:  # pragma: no cover
-    parse_options_header = None  # type: ignore
-
-
 if typing.TYPE_CHECKING:
+    from multipart.multipart import parse_options_header
+
     from starlette.applications import Starlette
     from starlette.routing import Router
+else:
+    try:
+        try:
+            from python_multipart.multipart import parse_options_header
+        except ModuleNotFoundError:
+            from multipart.multipart import parse_options_header
+    except ModuleNotFoundError:  # pragma: no cover
+        parse_options_header = None
 
 
 SERVER_PUSH_HEADERS_TO_COPY = {


### PR DESCRIPTION
This PR reverts the bump I did on https://github.com/encode/starlette/pull/2734.

With this, I don't bother Starlette/FastAPI users.