### PR TITLE
Replace `dict` by `Mapping` on `HTTPException.headers`

### DIFF
--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -12,7 +12,7 @@ class HTTPException(Exception):
         self,
         status_code: int,
         detail: str | None = None,
-        headers: dict[str, str] | None = None,
+        headers: typing.Mapping[str, str] | None = None,
     ) -> None:
         if detail is None:
             detail = http.HTTPStatus(status_code).phrase


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

See also: https://github.com/fastapi/fastapi/discussions/12786

HTTP Headers cannot be represented by a `dict`, as they can have duplicate entries. Example: [`Set-Cookie`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie).

As such type of `starlette.exceptions.HTTPException`'s `headers` field should be `typing.Mapping` instead of `dict`, just like `starlette.responses.Response`'s `headers` field:
https://github.com/encode/starlette/blob/c2e3a39b09a613553ee03586589ed9cd0fbf07f3/starlette/responses.py#L27-L38

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
