### PR TITLE
Modify application_state at _raise_on_disconnect

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -110,6 +110,8 @@ class WebSocket(HTTPConnection):
 
     def _raise_on_disconnect(self, message: Message) -> None:
         if message["type"] == "websocket.disconnect":
+            self.application_state = WebSocketState.DISCONNECTED
+
             raise WebSocketDisconnect(message["code"], message.get("reason"))
 
     async def receive_text(self) -> str:


### PR DESCRIPTION
# Summary
In my opinion, even when the websocket is closed by the client, the state should be changed to DISCONNECTED. 
This way, it can be handled more easily by users.

# Checklist
- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.
