### PR TITLE
Fix issue with middleware args passing

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -10,7 +10,7 @@ else:  # pragma: no cover
     from typing_extensions import ParamSpec
 
 from starlette.datastructures import State, URLPath
-from starlette.middleware import Middleware, _MiddlewareClass
+from starlette.middleware import Middleware, _MiddlewareFactory
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.middleware.exceptions import ExceptionMiddleware
@@ -96,7 +96,7 @@ class Starlette:
 
         app = self.router
         for cls, args, kwargs in reversed(middleware):
-            app = cls(app=app, *args, **kwargs)
+            app = cls(app, *args, **kwargs)
         return app
 
     @property
@@ -123,7 +123,7 @@ class Starlette:
 
     def add_middleware(
         self,
-        middleware_class: type[_MiddlewareClass[P]],
+        middleware_class: _MiddlewareFactory[P],
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> None:

--- a/starlette/middleware/__init__.py
+++ b/starlette/middleware/__init__.py
@@ -36,6 +36,6 @@ class Middleware:
         class_name = self.__class__.__name__
         args_strings = [f"{value!r}" for value in self.args]
         option_strings = [f"{key}={value!r}" for key, value in self.kwargs.items()]
-        cls_name = self.cls.__name__  # type: ignore[attr-defined]
-        args_repr = ", ".join([cls_name] + args_strings + option_strings)
+        name = getattr(self.cls, "__name__", "")
+        args_repr = ", ".join([name] + args_strings + option_strings)
         return f"{class_name}({args_repr})"

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -236,7 +236,7 @@ class Route(BaseRoute):
 
         if middleware is not None:
             for cls, args, kwargs in reversed(middleware):
-                self.app = cls(app=self.app, *args, **kwargs)
+                self.app = cls(self.app, *args, **kwargs)
 
         if methods is None:
             self.methods = None
@@ -328,7 +328,7 @@ class WebSocketRoute(BaseRoute):
 
         if middleware is not None:
             for cls, args, kwargs in reversed(middleware):
-                self.app = cls(app=self.app, *args, **kwargs)
+                self.app = cls(self.app, *args, **kwargs)
 
         self.path_regex, self.path_format, self.param_convertors = compile_path(path)
 
@@ -388,7 +388,7 @@ class Mount(BaseRoute):
         self.app = self._base_app
         if middleware is not None:
             for cls, args, kwargs in reversed(middleware):
-                self.app = cls(app=self.app, *args, **kwargs)
+                self.app = cls(self.app, *args, **kwargs)
         self.name = name
         self.path_regex, self.path_format, self.param_convertors = compile_path(self.path + "/{path:path}")
 

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -10,7 +10,7 @@ from anyio.abc import TaskStatus
 
 from starlette.applications import Starlette
 from starlette.background import BackgroundTask
-from starlette.middleware import Middleware, _MiddlewareClass
+from starlette.middleware import Middleware, _MiddlewareFactory
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import ClientDisconnect, Request
 from starlette.responses import PlainTextResponse, Response, StreamingResponse
@@ -232,7 +232,7 @@ class CustomMiddlewareUsingBaseHTTPMiddleware(BaseHTTPMiddleware):
 )
 def test_contextvars(
     test_client_factory: TestClientFactory,
-    middleware_cls: type[_MiddlewareClass[Any]],
+    middleware_cls: _MiddlewareFactory[Any],
 ) -> None:
     # this has to be an async endpoint because Starlette calls run_in_threadpool
     # on sync endpoints which has it's own set of peculiarities w.r.t propagating


### PR DESCRIPTION
# Summary

A feature introduced in #2381 doesn't allow to pass args inside middleware, here is an example:
```py
from starlette.applications import Starlette
from starlette.types import ASGIApp, Receive, Scope, Send
from starlette.testclient import TestClient


class Middleware:
    def __init__(self, app: ASGIApp, arg: str) -> None:
        self.app = app
        self.arg = arg

    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
        self.app(scope, receive, send)


app = Starlette()
app.add_middleware(Middleware, "foo")

client = TestClient(app)
response = client.get("/")
```
```py
TypeError: Middleware.__init__() got multiple values for argument 'app'
```

Also, make type annotation for middleware less strict, remove restriction for middleware to be class, and make it callable that returns ASGI application, it's a fully backward-compatible change.

```py
from starlette.applications import Starlette
from starlette.responses import JSONResponse
from starlette.types import ASGIApp, Receive, Scope, Send
from starlette.testclient import TestClient


def forbid_http_middleware(app: ASGIApp) -> ASGIApp:
    async def middleware(scope: Scope, receive: Receive, send: Send) -> None:
        if scope["type"] == "http":
            _response = JSONResponse({"detail": "Forbidden"}, status_code=403)
            await _response(scope, receive, send)
        else:
            await app(scope, receive, send)

    return middleware


app = Starlette()
app.add_middleware(forbid_http_middleware)

client = TestClient(app)
response = client.get("/")
```

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
