### PR TITLE
flush() after writing to gzip_file

### DIFF
--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -81,6 +81,7 @@ class GZipResponder:
                 del headers["Content-Length"]
 
                 self.gzip_file.write(body)
+                self.gzip_file.flush()
                 message["body"] = self.gzip_buffer.getvalue()
                 self.gzip_buffer.seek(0)
                 self.gzip_buffer.truncate()
@@ -94,6 +95,7 @@ class GZipResponder:
             more_body = message.get("more_body", False)
 
             self.gzip_file.write(body)
+            self.gzip_file.flush()
             if not more_body:
                 self.gzip_file.close()
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -95,8 +95,9 @@ class GZipResponder:
             more_body = message.get("more_body", False)
 
             self.gzip_file.write(body)
-            self.gzip_file.flush()
-            if not more_body:
+            if more_body:
+                self.gzip_file.flush()
+            else:
                 self.gzip_file.close()
 
             message["body"] = self.gzip_buffer.getvalue()


### PR DESCRIPTION
# Summary
In order to better support streaming responses where the chunks are smaller than the file buffer size, we flush after writing.

Without the explicit flush, the writes are buffered and the subsequent reads see an empty self.gzip_buffer until the file automatically flushes due to either (1) the 32KiB write buffer[^1] fills or (2) the file is closed because the streaming response is complete.

Without flushing, the GZipMiddleware doesn't work as expected for streaming responses, especially not for Server-Sent Events which are expected to be delivered immediately to clients. The code as written appears to intend to flush immediately rather than buffering, as it does immediately call `await self.send(message)`, but in practice that `message` is often empty.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

[^1]: https://github.com/python/cpython/blob/main/Lib/gzip.py#L26