### PR TITLE
docs: fix typo in applications example

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -27,7 +27,7 @@ async def websocket_endpoint(websocket):
     await websocket.send_text('Hello, websocket!')
     await websocket.close()
 
-@asyncontextmanager
+@asynccontextmanager
 async def lifespan(app):
     print('Startup')
     yield


### PR DESCRIPTION
# Summary

Typo found in the "applications" page makes the code example not work.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
