### PR TITLE
Make _MiddlewareFactory compatible with Callable

### DIFF
--- a/starlette/middleware/__init__.py
+++ b/starlette/middleware/__init__.py
@@ -14,7 +14,7 @@ P = ParamSpec("P")
 
 
 class _MiddlewareFactory(Protocol[P]):
-    def __call__(self, app: ASGIApp, *args: P.args, **kwargs: P.kwargs) -> ASGIApp: ...  # pragma: no cover
+    def __call__(self, app: ASGIApp, /, *args: P.args, **kwargs: P.kwargs) -> ASGIApp: ...  # pragma: no cover
 
 
 class Middleware:

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncGenerator, AsyncIterator, Generator
+from typing import AsyncGenerator, AsyncIterator, Callable, Generator
 
 import anyio.from_thread
 import pytest
@@ -567,9 +567,12 @@ def test_middleware_factory(test_client_factory: TestClientFactory) -> None:
 
         return _app
 
+    def get_middleware_factory() -> Callable[[ASGIApp, str], ASGIApp]:
+        return _middleware_factory
+
     app = Starlette()
     app.add_middleware(_middleware_factory, arg="foo")
-    app.add_middleware(_middleware_factory, arg="bar")
+    app.add_middleware(get_middleware_factory(), "bar")
 
     with test_client_factory(app):
         pass


### PR DESCRIPTION
# Summary

Make `app` a positional-only argument so that a `Callable[[ASGIApp, ...], ASGIApp]` can be passed in place of `_MiddlewareFactory`.

We can also consider making `_MiddlewareFactory` and moving it into `starlette.types`. This will make it easier to type arguments for `add_middleware()`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
