### PR TITLE
Pin httpx in `full` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ full = [
     "jinja2",
     "python-multipart>=0.0.7",
     "pyyaml",
-    "httpx>=0.22.0",
+    "httpx>=0.27.0,<0.29.0",
 ]
 
 [project.urls]

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -77,7 +77,7 @@ def test_wsgi_post(test_client_factory: TestClientFactory) -> None:
     client = test_client_factory(app)
     response = client.post("/", json={"example": 123})
     assert response.status_code == 200
-    assert response.text == '{"example": 123}'
+    assert response.text == '{"example":123}'
 
 
 def test_wsgi_exception(test_client_factory: TestClientFactory) -> None:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -91,7 +91,7 @@ def test_request_body(test_client_factory: TestClientFactory) -> None:
     assert response.json() == {"body": ""}
 
     response = client.post("/", json={"a": "123"})
-    assert response.json() == {"body": '{"a": "123"}'}
+    assert response.json() == {"body": '{"a":"123"}'}
 
     response = client.post("/", data="abc")  # type: ignore
     assert response.json() == {"body": "abc"}
@@ -112,7 +112,7 @@ def test_request_stream(test_client_factory: TestClientFactory) -> None:
     assert response.json() == {"body": ""}
 
     response = client.post("/", json={"a": "123"})
-    assert response.json() == {"body": '{"a": "123"}'}
+    assert response.json() == {"body": '{"a":"123"}'}
 
     response = client.post("/", data="abc")  # type: ignore
     assert response.json() == {"body": "abc"}


### PR DESCRIPTION
As per https://github.com/encode/starlette/pull/2709#issuecomment-2435791452, I'm pinning `httpx` on the `full` extra.

But... This is not enforced if users install `httpx` without `starlette[full]`.

cc @tomchristie 