### PR TITLE
Add `pragma: no branch` in `middleware/exceptions.py`

### DIFF
--- a/starlette/middleware/exceptions.py
+++ b/starlette/middleware/exceptions.py
@@ -28,7 +28,7 @@ class ExceptionMiddleware:
             HTTPException: self.http_exception,
             WebSocketException: self.websocket_exception,
         }
-        if handlers is not None:
+        if handlers is not None:  # pragma: no branch
             for key, value in handlers.items():
                 self.add_exception_handler(key, value)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -33,20 +33,6 @@ def with_headers(request: Request) -> None:
     raise HTTPException(status_code=200, headers={"x-potato": "always"})
 
 
-class BadBodyException(HTTPException):
-    pass
-
-
-async def read_body_and_raise_exc(request: Request) -> None:
-    await request.body()
-    raise BadBodyException(422)
-
-
-async def handler_that_reads_body(request: Request, exc: BadBodyException) -> JSONResponse:
-    body = await request.body()
-    return JSONResponse(status_code=422, content={"body": body.decode()})
-
-
 class HandledExcAfterResponse:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         response = PlainTextResponse("OK", status_code=200)
@@ -63,15 +49,11 @@ router = Router(
         Route("/with_headers", endpoint=with_headers),
         Route("/handled_exc_after_response", endpoint=HandledExcAfterResponse()),
         WebSocketRoute("/runtime_error", endpoint=raise_runtime_error),
-        Route("/consume_body_in_endpoint_and_handler", endpoint=read_body_and_raise_exc, methods=["POST"]),
     ]
 )
 
 
-app = ExceptionMiddleware(
-    router,
-    handlers={BadBodyException: handler_that_reads_body},  # type: ignore[dict-item]
-)
+app = ExceptionMiddleware(router, handlers=None)
 
 
 @pytest.fixture
@@ -194,7 +176,31 @@ def test_exception_middleware_deprecation() -> None:
         starlette.exceptions.ExceptionMiddleware
 
 
-def test_request_in_app_and_handler_is_the_same_object(client: TestClient) -> None:
-    response = client.post("/consume_body_in_endpoint_and_handler", content=b"Hello!")
+class BadBodyException(HTTPException):
+    pass
+
+
+async def read_body_and_raise_exc(request: Request) -> None:
+    await request.body()
+    raise BadBodyException(422)
+
+
+async def handler_that_reads_body(request: Request, exc: BadBodyException) -> JSONResponse:
+    body = await request.body()
+    return JSONResponse(status_code=422, content={"body": body.decode()})
+
+
+def test_request_in_app_and_handler_is_the_same_object(test_client_factory: TestClientFactory) -> None:
+    app = ExceptionMiddleware(
+        Router(
+            routes=[
+                Route("/consume_body_in_endpoint_and_handler", endpoint=read_body_and_raise_exc, methods=["POST"]),
+            ]
+        ),
+        handlers={BadBodyException: handler_that_reads_body},  # type: ignore[dict-item]
+    )
+    with test_client_factory(app) as client:
+        response = client.post("/consume_body_in_endpoint_and_handler", content=b"Hello!")
+
     assert response.status_code == 422
     assert response.json() == {"body": "Hello!"}

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -33,6 +33,20 @@ def with_headers(request: Request) -> None:
     raise HTTPException(status_code=200, headers={"x-potato": "always"})
 
 
+class BadBodyException(HTTPException):
+    pass
+
+
+async def read_body_and_raise_exc(request: Request) -> None:
+    await request.body()
+    raise BadBodyException(422)
+
+
+async def handler_that_reads_body(request: Request, exc: BadBodyException) -> JSONResponse:
+    body = await request.body()
+    return JSONResponse(status_code=422, content={"body": body.decode()})
+
+
 class HandledExcAfterResponse:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         response = PlainTextResponse("OK", status_code=200)
@@ -49,11 +63,15 @@ router = Router(
         Route("/with_headers", endpoint=with_headers),
         Route("/handled_exc_after_response", endpoint=HandledExcAfterResponse()),
         WebSocketRoute("/runtime_error", endpoint=raise_runtime_error),
+        Route("/consume_body_in_endpoint_and_handler", endpoint=read_body_and_raise_exc, methods=["POST"]),
     ]
 )
 
 
-app = ExceptionMiddleware(router, handlers=None)
+app = ExceptionMiddleware(
+    router,
+    handlers={BadBodyException: handler_that_reads_body},  # type: ignore[dict-item]
+)
 
 
 @pytest.fixture
@@ -176,31 +194,7 @@ def test_exception_middleware_deprecation() -> None:
         starlette.exceptions.ExceptionMiddleware
 
 
-class BadBodyException(HTTPException):
-    pass
-
-
-async def read_body_and_raise_exc(request: Request) -> None:
-    await request.body()
-    raise BadBodyException(422)
-
-
-async def handler_that_reads_body(request: Request, exc: BadBodyException) -> JSONResponse:
-    body = await request.body()
-    return JSONResponse(status_code=422, content={"body": body.decode()})
-
-
-def test_request_in_app_and_handler_is_the_same_object(test_client_factory: TestClientFactory) -> None:
-    app = ExceptionMiddleware(
-        Router(
-            routes=[
-                Route("/consume_body_in_endpoint_and_handler", endpoint=read_body_and_raise_exc, methods=["POST"]),
-            ]
-        ),
-        handlers={BadBodyException: handler_that_reads_body},  # type: ignore[dict-item]
-    )
-    with test_client_factory(app) as client:
-        response = client.post("/consume_body_in_endpoint_and_handler", content=b"Hello!")
-
+def test_request_in_app_and_handler_is_the_same_object(client: TestClient) -> None:
+    response = client.post("/consume_body_in_endpoint_and_handler", content=b"Hello!")
     assert response.status_code == 422
     assert response.json() == {"body": "Hello!"}


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Trying to help with issue #2452 

Changing the tests to cover the cases where `handlers=None` in `ExceptionMiddleware` to handle the cases where the `if` statement in [line 31](https://github.com/encode/starlette/blob/master/starlette/middleware/exceptions.py#L31) is skipped.

Isolates the tests that have a route with an exception handler (`BadBodyException`) from the ones that do not have one in [test_exceptions.py](https://github.com/encode/starlette/blob/master/tests/test_exceptions.py), so it can deal with both cases separately.

NOTE: When an app is instantiated directly by Starlette, it passes by default to ExceptionMiddleware an empty dictionary, which makes `if handlers is not None` always evaluate to `True` and the for loop iterates over an empty dict. Another option could be to change [line 31](https://github.com/encode/starlette/blob/master/starlette/middleware/exceptions.py#L31) to `if handlers:` and keep the tests as they are.


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
