### PR TITLE
Resolve the anyio `ResourceWarning` in production code

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -131,8 +131,11 @@ class BaseHTTPMiddleware:
                 return message
 
             async def close_recv_stream_on_response_sent() -> None:
-                await response_sent.wait()
-                recv_stream.close()
+                # The stream must always be closed, even if an exception occurs.
+                try:
+                    await response_sent.wait()
+                finally:
+                    recv_stream.close()
 
             async def send_no_error(message: Message) -> None:
                 try:


### PR DESCRIPTION
> [!Note]
>
> This addresses one of the same issues that #2778 addresses, but changes fewer lines to do so. This may mean it's more correct or less correct, so please review.
>
> This PR intentionally addresses only the warnings encountered by downstream projects using starlette. It does not address the remaining `ResourceWarning`s caused by starlette's own test code.

This resolves the `ResourceWarning`s caused by a failure to close the receive stream opened at line 112.

Identified by setting pytest `filterwarnings` to "all" instead of "error", and running pytest with tracemalloc set:

```
PYTHONTRACEMALLOC=10 pytest
```

Fixes #2772

<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. _Existing tests already triggered the `ResourceWarning`_
- [ ] I've updated the documentation accordingly. _Doesn't appear to be relevant_
