### PR TITLE
tests: Add skipped coverages for `websockets.py` and `templating.py` using `branch=true`

### DIFF
--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -98,7 +98,7 @@ class Jinja2Templates:
         self.context_processors = context_processors or []
         if directory is not None:
             self.env = self._create_env(directory, **env_options)
-        elif env is not None:  # pragma: no cover
+        elif env is not None:  # pragma: no branch
             self.env = env
 
         self._setup_env_defaults(self.env)

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -98,8 +98,8 @@ class Jinja2Templates:
         self.context_processors = context_processors or []
         if directory is not None:
             self.env = self._create_env(directory, **env_options)
-        elif env is not None:
-            self.env = env  # pragma: no cover
+        elif env is not None:  # pragma: no cover
+            self.env = env
 
         self._setup_env_defaults(self.env)
 

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -99,7 +99,7 @@ class Jinja2Templates:
         if directory is not None:
             self.env = self._create_env(directory, **env_options)
         elif env is not None:
-            self.env = env
+            self.env = env  # pragma: no cover
 
         self._setup_env_defaults(self.env)
 

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -103,7 +103,7 @@ class WebSocket(HTTPConnection):
     ) -> None:
         headers = headers or []
 
-        if self.client_state == WebSocketState.CONNECTING:
+        if self.client_state == WebSocketState.CONNECTING:  # pragma: no cover
             # If we haven't yet seen the 'connect' message, then wait for it first.
             await self.receive()
         await self.send({"type": "websocket.accept", "subprotocol": subprotocol, "headers": headers})

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -103,7 +103,7 @@ class WebSocket(HTTPConnection):
     ) -> None:
         headers = headers or []
 
-        if self.client_state == WebSocketState.CONNECTING:  # pragma: no cover
+        if self.client_state == WebSocketState.CONNECTING:  # pragma: no branch
             # If we haven't yet seen the 'connect' message, then wait for it first.
             await self.receive()
         await self.send({"type": "websocket.accept", "subprotocol": subprotocol, "headers": headers})

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -611,17 +611,3 @@ def test_receive_wrong_message_type(test_client_factory: TestClientFactory) -> N
     with pytest.raises(RuntimeError):
         with client.websocket_connect("/") as websocket:
             websocket.send({"type": "websocket.connect"})
-
-
-def test_websocket_accept_with_mocked_connected_state(test_client_factory: TestClientFactory) -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        websocket = WebSocket(scope, receive=receive, send=send)
-        websocket.client_state = WebSocketState.CONNECTED
-        await websocket.accept()
-        await websocket.send_json({"url": str(websocket.url)})
-        await websocket.close()
-
-    client = test_client_factory(app)
-    with client.websocket_connect("/123?a=abc") as websocket:
-        data = websocket.receive_json()
-        assert data == {"url": "ws://testserver/123?a=abc"}


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

> **Note** :information_source:  
>  I don't have a lot of experience, and the idea here is to try to help. Sorry if something seems silly or obvious. Any feedback on how I can improve or suggestions for best practices would be appreciated!

# Summary

Regarding the issue #2452

### Changes to `starlette/websockets.py`

This test is designed to skip the `if` statement at [line 106](https://github.com/encode/starlette/blob/master/starlette/websockets.py#L106). Specifically, the `client_state` is set to `CONNECTED` before calling `websocket.accept()`, which ensures that the code bypasses the conditional logic meant for the `CONNECTING` state.

I replicated the first test and mocked the value.

### Changes to `starlette/templating.py`

At [line 97](https://github.com/encode/starlette/blob/master/starlette/templating.py#L97), an assertion ensures that either `directory` or `env` must be provided, but not both `None`. Since it's not possible to skip both conditionals (`if` or `elif`), I added a `# pragma: no cover` comment to prevent code coverage from flagging this as untested.

```py
def __init__(
    self,
    directory: str | PathLike[str] | typing.Sequence[str | PathLike[str]] | None = None,
    *,
    context_processors: list[typing.Callable[[Request], dict[str, typing.Any]]] | None = None,
    env: jinja2.Environment | None = None,
    **env_options: typing.Any,
) -> None:
    if env_options:
        warnings.warn(
            "Extra environment options are deprecated. Use a preconfigured jinja2.Environment instead.",
            DeprecationWarning,
        )
    assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"  
    assert bool(directory) ^ bool(env), "either 'directory' or 'env' arguments must be passed" # <--------------- Line 97
    self.context_processors = context_processors or []
    if directory is not None:   # <-------------------------------------------- Line 99
        self.env = self._create_env(directory, **env_options)
    elif env is not None:       # <-------------------------------------------- Line 101
        self.env = env

    self._setup_env_defaults(self.env)
```

EDIT: Another option could be to separate the conditional blocks as shown below, ensuring that all branches are covered and that `directory` takes precedence over `env` if both are provided, as the current code behaves.

Regarding the precedence of the `directory` over `env`, would it be worth adding this to the [documentation](https://www.starlette.io/templates/#customizing-jinja2-environment)?

```py
    def __init__(
        self,
        directory: str | PathLike[str] | typing.Sequence[str | PathLike[str]] | None = None,
        *,
        context_processors: list[typing.Callable[[Request], dict[str, typing.Any]]] | None = None,
        env: jinja2.Environment | None = None,
        **env_options: typing.Any,
    ) -> None:
        if env_options:
            warnings.warn(
                "Extra environment options are deprecated. Use a preconfigured jinja2.Environment instead.",
                DeprecationWarning,
            )
        assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
        assert bool(directory) ^ bool(env), "either 'directory' or 'env' arguments must be passed"
        self.context_processors = context_processors or []
        if env is not None:
            self.env = env
        if directory is not None:
            self.env = self._create_env(directory, **env_options)

        self._setup_env_defaults(self.env)
```


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
