### PR TITLE
Adapt starlette's logo to the current theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 <p align="center">
-  <a href="https://www.starlette.io/"><img width="420px" src="https://raw.githubusercontent.com/encode/starlette/master/docs/img/starlette.svg" alt='starlette'></a>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/encode/starlette/master/docs/img/starlette_dark.svg" width="420px">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/encode/starlette/master/docs/img/starlette.svg" width="420px">
+    <img alt="starlette-logo" src="https://raw.githubusercontent.com/encode/starlette/master/docs/img/starlette_dark.svg">
+  </picture>
 </p>
+
 <p align="center">
     <em>✨ The little ASGI framework that shines. ✨</em>
 </p>


### PR DESCRIPTION
# Summary

Discussion: [#2797](https://github.com/encode/starlette/discussions/2797)

Made Starlette's logo is adaptive to the current user theme on the readme file.

**Dark** mode:
![image](https://github.com/user-attachments/assets/a15b5246-f3de-41d9-8cfd-ed050d141b8c)

**Light** mode:
![image](https://github.com/user-attachments/assets/40cdb3f9-5ba7-4409-8313-7812ee2cb3bf)


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

# References
* https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to
