### PR TITLE
tests: branches coverage in `responses.py`, `staticfiles.py`, `templating.py`, `middleware/wsgi.py` and `endpoints.py`

### DIFF
--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -74,7 +74,7 @@ class WebSocketEndpoint:
                 if message["type"] == "websocket.receive":
                     data = await self.decode(websocket, message)
                     await self.on_receive(websocket, data)
-                elif message["type"] == "websocket.disconnect":
+                elif message["type"] == "websocket.disconnect":  # pragma: no branch
                     close_code = int(message.get("code") or status.WS_1000_NORMAL_CLOSURE)
                     break
         except Exception as exc:

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -121,7 +121,7 @@ class WSGIResponder:
         exc_info: typing.Any = None,
     ) -> None:
         self.exc_info = exc_info
-        if not self.response_started:
+        if not self.response_started:  # pragma: no branch
             self.response_started = True
             status_code_string, _ = status.split(" ", 1)
             status_code = int(status_code_string)

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -43,7 +43,7 @@ class _TemplateResponse(HTMLResponse):
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         request = self.context.get("request", {})
         extensions = request.get("extensions", {})
-        if "http.response.debug" in extensions:
+        if "http.response.debug" in extensions:  # pragma: no branch
             await send(
                 {
                     "type": "http.response.debug",

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -43,7 +43,7 @@ class _TemplateResponse(HTMLResponse):
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         request = self.context.get("request", {})
         extensions = request.get("extensions", {})
-        if "http.response.debug" in extensions:  # pragma: no branch
+        if "http.response.debug" in extensions:
             await send(
                 {
                     "type": "http.response.debug",

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -393,6 +393,18 @@ def test_set_cookie_path_none(test_client_factory: TestClientFactory) -> None:
     assert response.headers["set-cookie"] == "mycookie=myvalue; SameSite=lax"
 
 
+def test_set_cookie_samesite_none(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        response = Response("Hello, world!", media_type="text/plain")
+        response.set_cookie("mycookie", "myvalue", samesite=None)
+        await response(scope, receive, send)
+
+    client = test_client_factory(app)
+    response = client.get("/")
+    assert response.text == "Hello, world!"
+    assert response.headers["set-cookie"] == "mycookie=myvalue; Path=/"
+
+
 @pytest.mark.parametrize(
     "expires",
     [

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -216,6 +216,20 @@ def test_staticfiles_304_with_etag_match(tmpdir: Path, test_client_factory: Test
     assert second_resp.content == b""
 
 
+def test_staticfiles_200_with_etag_mismatch(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
+    path = os.path.join(tmpdir, "example.txt")
+    with open(path, "w") as file:
+        file.write("<file content>")
+
+    app = StaticFiles(directory=tmpdir)
+    client = test_client_factory(app)
+    first_resp = client.get("/example.txt")
+    assert first_resp.status_code == 200
+    second_resp = client.get("/example.txt", headers={"if-none-match": '"123"'})
+    assert second_resp.status_code == 200
+    assert second_resp.content == b"<file content>"
+
+
 def test_staticfiles_304_with_last_modified_compare_last_req(
     tmpdir: Path, test_client_factory: TestClientFactory
 ) -> None:

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -225,6 +225,7 @@ def test_staticfiles_200_with_etag_mismatch(tmpdir: Path, test_client_factory: T
     client = test_client_factory(app)
     first_resp = client.get("/example.txt")
     assert first_resp.status_code == 200
+    assert first_resp.headers["etag"] != '"123"'
     second_resp = client.get("/example.txt", headers={"if-none-match": '"123"'})
     assert second_resp.status_code == 200
     assert second_resp.content == b"<file content>"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -15,7 +15,6 @@ from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import Route
 from starlette.templating import Jinja2Templates
-from starlette.types import Message, Receive, Scope, Send
 from tests.types import TestClientFactory
 
 
@@ -309,36 +308,3 @@ def test_templates_when_first_argument_is_request(tmpdir: Path, test_client_fact
     assert response.headers["x-key"] == "value"
     assert response.headers["content-type"] == "text/plain; charset=utf-8"
     spy.assert_called()
-
-
-@pytest.mark.anyio
-async def test_branch_coverage_http_response_debug_not_in_message(tmpdir: Path) -> None:
-    path = os.path.join(tmpdir, "index.html")
-    with open(path, "w") as file:
-        file.write("<html>Hello</html>")
-
-    templates = Jinja2Templates(directory=str(tmpdir))
-
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        assert scope["type"] == "http"
-        request = Request(scope, receive)
-        response = templates.TemplateResponse(request, "index.html")
-        await response(scope, receive, send)
-
-    async def receive() -> Message:
-        raise NotImplementedError("Should not be called!")
-
-    async def send(message: Message) -> None:
-        if message["type"] == "http.response.start":
-            assert message["status"] == 200
-        if message["type"] == "http.response.body":
-            assert message["body"] == b"<html>Hello</html>"
-        assert "http.response.debug" not in message["type"]
-
-    scope = {
-        "type": "http",
-        "method": "GET",
-        "path": "/",
-    }
-
-    await app(scope, receive, send)


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Related to issue #2452.

### `responses.py` - [117→124](https://github.com/encode/starlette/blob/master/starlette/responses.py#L117-L124)
Test with `samesite = None` added.

### `staticfiles.py` - [207→212](https://github.com/encode/starlette/blob/master/starlette/staticfiles.py#L207-L212)
Test with `etag` not matching the `headers["if-none-match"]`.

### `templating.py` - [46→56](https://github.com/encode/starlette/blob/master/starlette/templating.py#L46-L56)
It seems that `TestClient` adds `{'http.response.debug': {}}` to the scope on every HTTP request ([line 310](https://github.com/encode/starlette/blob/master/starlette/testclient.py#L310)), making the statement always `True`.  
Added `pragma: no branch` and needs confirmation.

### `middleware/wsgi.py` - [124→exit](https://github.com/encode/starlette/blob/master/starlette/middleware/wsgi.py#L124-L139)
`self.response_started` is initialized as `False` in `WSGIResponder` and is only used in `WSGIMiddleware` ([line 79](https://github.com/encode/starlette/blob/master/starlette/middleware/wsgi.py#L79)). Removing the `if` statement does not affect the tests.  
Added `pragma: no branch` and needs confirmation.

### `endpoints.py` - [77→72](https://github.com/encode/starlette/blob/master/starlette/endpoints.py#L77-L72)
It seems there are only two possible options inside the `while` loop.
Added `pragma: no branch` and needs confirmation.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
