### PR TITLE
Make UUID path parameter conversion more flexible

### DIFF
--- a/starlette/convertors.py
+++ b/starlette/convertors.py
@@ -67,7 +67,7 @@ class FloatConvertor(Convertor[float]):
 
 
 class UUIDConvertor(Convertor[uuid.UUID]):
-    regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    regex = "[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}"
 
     def convert(self, value: str) -> uuid.UUID:
         return uuid.UUID(value)

--- a/tests/test_convertors.py
+++ b/tests/test_convertors.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Iterator
+from uuid import UUID
 
 import pytest
 
@@ -66,6 +67,29 @@ def test_default_float_convertor(test_client_factory: TestClientFactory, param: 
         return JSONResponse({"float": param})
 
     app = Router(routes=[Route("/{param:float}", endpoint=float_convertor)])
+
+    client = test_client_factory(app)
+    response = client.get(f"/{param}")
+    assert response.status_code == status_code
+
+
+@pytest.mark.parametrize(
+    "param, status_code",
+    [
+        ("00000000-aaaa-ffff-9999-000000000000", 200),
+        ("00000000aaaaffff9999000000000000", 200),
+        ("00000000-AAAA-FFFF-9999-000000000000", 200),
+        ("00000000AAAAFFFF9999000000000000", 200),
+        ("not-a-uuid", 404),
+    ],
+)
+def test_default_uuid_convertor(test_client_factory: TestClientFactory, param: str, status_code: int) -> None:
+    def uuid_convertor(request: Request) -> JSONResponse:
+        param = request.path_params["param"]
+        assert isinstance(param, UUID)
+        return JSONResponse("ok")
+
+    app = Router(routes=[Route("/{param:uuid}", endpoint=uuid_convertor)])
 
     client = test_client_factory(app)
     response = client.get(f"/{param}")


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Based on @adriangb suggestion made in this [discussion thread](https://github.com/encode/starlette/discussions/2802#discussioncomment-11583842), here is a more flexible conversion of UUID path parameters. 

UUID representation may vary depending on the system from which it is generated. Some systems may return an hex representation with no hyphens, while some others use upper-case letters.

From Python perspective, they are all valid:
![image](https://github.com/user-attachments/assets/75af3f98-c2a5-4d3d-b860-beb06656886b)

Not handling those cases may yield to hard-to-debug 404 errors.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
