### PR TITLE
tests: adding `# pragma: no branch` in `middleware/test_base` and `test_routing`

### DIFF
--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -288,7 +288,7 @@ async def test_run_background_tasks_even_if_client_disconnects() -> None:
 
     async def send(message: Message) -> None:
         if message["type"] == "http.response.body":
-            if not message.get("more_body", False):
+            if not message.get("more_body", False):  # pragma: no branch
                 response_complete.set()
 
     await app(scope, receive, send)
@@ -402,7 +402,7 @@ async def test_run_context_manager_exit_even_if_client_disconnects() -> None:
 
     async def send(message: Message) -> None:
         if message["type"] == "http.response.body":
-            if not message.get("more_body", False):
+            if not message.get("more_body", False):  # pragma: no branch
                 response_complete.set()
 
     await app(scope, receive, send)
@@ -456,7 +456,7 @@ def test_app_receives_http_disconnect_while_sending_if_discarded(
                 task_status.started()
                 while True:
                     message = await receive()
-                    if message["type"] == "http.disconnect":
+                    if message["type"] == "http.disconnect":  # pragma: no branch
                         task_group.cancel_scope.cancel()
                         break
 
@@ -717,7 +717,7 @@ def test_read_request_stream_in_dispatch_after_app_calls_body(
 async def test_read_request_stream_in_dispatch_wrapping_app_calls_body() -> None:
     async def endpoint(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)
-        async for chunk in request.stream():
+        async for chunk in request.stream():  # pragma: no branch
             assert chunk == b"2"
             break
         await Response()(scope, receive, send)
@@ -730,7 +730,7 @@ async def test_read_request_stream_in_dispatch_wrapping_app_calls_body() -> None
         ) -> Response:
             expected = b"1"
             response: Response | None = None
-            async for chunk in request.stream():
+            async for chunk in request.stream():  # pragma: no branch
                 assert chunk == expected
                 if expected == b"1":
                     response = await call_next(request)
@@ -943,7 +943,7 @@ def test_downstream_middleware_modifies_receive(
         async def wrapped_app(scope: Scope, receive: Receive, send: Send) -> None:
             async def wrapped_receive() -> Message:
                 msg = await receive()
-                if msg["type"] == "http.request":
+                if msg["type"] == "http.request":  # pragma: no branch
                     msg["body"] = msg["body"] * 2
                 return msg
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -883,7 +883,11 @@ class Endpoint:
             id="staticmethod",
         ),
         pytest.param(Endpoint(), "Endpoint", id="object"),
-        pytest.param(lambda request: ..., "<lambda>", id="lambda"),
+        pytest.param(
+            lambda request: ...,  # pragma: no branch
+            "<lambda>",
+            id="lambda",
+        ),
     ],
 )
 def test_route_name(endpoint: typing.Callable[..., Response], expected_name: str) -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -883,11 +883,7 @@ class Endpoint:
             id="staticmethod",
         ),
         pytest.param(Endpoint(), "Endpoint", id="object"),
-        pytest.param(
-            lambda request: ...,  # pragma: no branch
-            "<lambda>",
-            id="lambda",
-        ),
+        pytest.param(lambda request: ..., "<lambda>", id="lambda"),  # pragma: no branch
     ],
 )
 def test_route_name(endpoint: typing.Callable[..., Response], expected_name: str) -> None:


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Related to issue #2452.

Adding `# pragma: no branch` in to all the cases

#### `tests/test_routing.py` [874->exit](https://github.com/encode/starlette/blob/master/tests/test_routing.py#L874)

As we talked, I searched for the cause of missing branch coverage in the `parametrize` line 874, and it turns out that the `lambda` function is what is causing it.

There is [this](https://github.com/nedbat/coveragepy/issues/90#issuecomment-399705237) comment, which is somewhat related, but old. In [this](https://github.com/nedbat/coveragepy/issues/460#issuecomment-399707599) comment (also old), it is mentioned that it was supposed to inform a custom lambda message in the HTML report, but it differs from the message we are encountering here.


![Captura de ecrã 2024-12-20 233703](https://github.com/user-attachments/assets/3f832116-fae5-4ec7-8a2e-0c3357c5d3c0)

#### `tests/middleware/test_base.py` 

- [291->exit](https://github.com/encode/starlette/blob/master/tests/middleware/test_base.py#L291)
- [405->exit](https://github.com/encode/starlette/blob/master/tests/middleware/test_base.py#L405)
- [459->457](https://github.com/encode/starlette/blob/master/tests/middleware/test_base.py#L459)
- [720->723](https://github.com/encode/starlette/blob/master/tests/middleware/test_base.py#L720)
- [733->740](https://github.com/encode/starlette/blob/master/tests/middleware/test_base.py#L733)
- [946->948](https://github.com/encode/starlette/blob/master/tests/middleware/test_base.py#L946)


I believe that in these cases, there are no branch options to be tested, and I am sending this for your confirmation.

One note: the line `459->457` sometimes appears as missing branch coverage in some test runs, while at other times it appears as already covered.


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
