### PR TITLE
Add `max_part_size` parameter to `MultiPartParser`

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -113,12 +113,12 @@ state with `disconnected = await request.is_disconnected()`.
 
 Request files are normally sent as multipart form data (`multipart/form-data`).
 
-Signature: `request.form(max_files=1000, max_fields=1000)`
+Signature: `request.form(max_files=1000, max_fields=1000, max_part_size=1024*1024)`
 
-You can configure the number of maximum fields or files with the parameters `max_files` and `max_fields`:
+You can configure the number of maximum fields or files with the parameters `max_files` and `max_fields`; and part size using `max_part_size`:
 
 ```python
-async with request.form(max_files=1000, max_fields=1000):
+async with request.form(max_files=1000, max_fields=1000, max_part_size=1024*1024):
     ...
 ```
 

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -122,15 +122,15 @@ class FormParser:
 
 
 class MultiPartParser:
-    max_file_size: int = 1024 * 1024  # 1MB
+    max_file_size = 1024 * 1024  # 1MB
 
     def __init__(
         self,
         headers: Headers,
         stream: typing.AsyncGenerator[bytes, None],
         *,
-        max_files: int = 1000,
-        max_fields: int = 1000,
+        max_files: int | float = 1000,
+        max_fields: int | float = 1000,
         max_part_size: int = 1024 * 1024,  # 1MB
     ) -> None:
         assert multipart is not None, "The `python-multipart` library must be installed to use form parsing."

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -122,6 +122,8 @@ class FormParser:
 
 
 class MultiPartParser:
+    max_file_size = 1024 * 1024  # 1MB
+
     def __init__(
         self,
         headers: Headers,
@@ -129,7 +131,6 @@ class MultiPartParser:
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_file_size: int = 1024 * 1024,  # 1MB
         max_part_size: int | float = 1024 * 1024,  # 1MB
     ) -> None:
         assert multipart is not None, "The `python-multipart` library must be installed to use form parsing."
@@ -147,7 +148,6 @@ class MultiPartParser:
         self._file_parts_to_write: list[tuple[MultipartPart, bytes]] = []
         self._file_parts_to_finish: list[MultipartPart] = []
         self._files_to_close_on_error: list[SpooledTemporaryFile[bytes]] = []
-        self.max_file_size = max_file_size
         self.max_part_size = max_part_size
 
     def on_part_begin(self) -> None:

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -122,15 +122,15 @@ class FormParser:
 
 
 class MultiPartParser:
-    max_file_size = 1024 * 1024  # 1MB
+    max_file_size: int = 1024 * 1024  # 1MB
 
     def __init__(
         self,
         headers: Headers,
         stream: typing.AsyncGenerator[bytes, None],
         *,
-        max_files: int | float = 1000,
-        max_fields: int | float = 1000,
+        max_files: int = 1000,
+        max_fields: int = 1000,
         max_part_size: int = 1024 * 1024,  # 1MB
     ) -> None:
         assert multipart is not None, "The `python-multipart` library must be installed to use form parsing."

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -131,7 +131,7 @@ class MultiPartParser:
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int | float = 1024 * 1024,  # 1MB
+        max_part_size: int = 1024 * 1024,  # 1MB
     ) -> None:
         assert multipart is not None, "The `python-multipart` library must be installed to use form parsing."
         self.headers = headers

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -122,9 +122,6 @@ class FormParser:
 
 
 class MultiPartParser:
-    max_file_size = 1024 * 1024  # 1MB
-    max_part_size = 1024 * 1024  # 1MB
-
     def __init__(
         self,
         headers: Headers,
@@ -132,6 +129,8 @@ class MultiPartParser:
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
+        max_file_size: int = 1024 * 1024,  # 1MB
+        max_part_size: int | float = 1024 * 1024,  # 1MB
     ) -> None:
         assert multipart is not None, "The `python-multipart` library must be installed to use form parsing."
         self.headers = headers
@@ -148,6 +147,8 @@ class MultiPartParser:
         self._file_parts_to_write: list[tuple[MultipartPart, bytes]] = []
         self._file_parts_to_finish: list[MultipartPart] = []
         self._files_to_close_on_error: list[SpooledTemporaryFile[bytes]] = []
+        self.max_file_size = max_file_size
+        self.max_part_size = max_part_size
 
     def on_part_begin(self) -> None:
         self._current_part = MultipartPart()

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -254,7 +254,6 @@ class Request(HTTPConnection):
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_file_size: int = 1024 * 1024,
         max_part_size: int | float = 1024 * 1024,
     ) -> FormData:
         if self._form is None:
@@ -271,7 +270,6 @@ class Request(HTTPConnection):
                         self.stream(),
                         max_files=max_files,
                         max_fields=max_fields,
-                        max_file_size=max_file_size,
                         max_part_size=max_part_size,
                     )
                     self._form = await multipart_parser.parse()
@@ -291,13 +289,10 @@ class Request(HTTPConnection):
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_file_size: int = 1024 * 1024,
         max_part_size: int | float = 1024 * 1024,
     ) -> AwaitableOrContextManager[FormData]:
         return AwaitableOrContextManagerWrapper(
-            self._get_form(
-                max_files=max_files, max_fields=max_fields, max_file_size=max_file_size, max_part_size=max_part_size
-            )
+            self._get_form(max_files=max_files, max_fields=max_fields, max_part_size=max_part_size)
         )
 
     async def close(self) -> None:

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -252,8 +252,8 @@ class Request(HTTPConnection):
     async def _get_form(
         self,
         *,
-        max_files: int = 1000,
-        max_fields: int = 1000,
+        max_files: int | float = 1000,
+        max_fields: int | float = 1000,
         max_part_size: int = 1024 * 1024,
     ) -> FormData:
         if self._form is None:
@@ -287,8 +287,8 @@ class Request(HTTPConnection):
     def form(
         self,
         *,
-        max_files: int = 1000,
-        max_fields: int = 1000,
+        max_files: int | float = 1000,
+        max_fields: int | float = 1000,
         max_part_size: int = 1024 * 1024,
     ) -> AwaitableOrContextManager[FormData]:
         return AwaitableOrContextManagerWrapper(

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -252,8 +252,8 @@ class Request(HTTPConnection):
     async def _get_form(
         self,
         *,
-        max_files: int | float = 1000,
-        max_fields: int | float = 1000,
+        max_files: int = 1000,
+        max_fields: int = 1000,
         max_part_size: int = 1024 * 1024,
     ) -> FormData:
         if self._form is None:
@@ -287,8 +287,8 @@ class Request(HTTPConnection):
     def form(
         self,
         *,
-        max_files: int | float = 1000,
-        max_fields: int | float = 1000,
+        max_files: int = 1000,
+        max_fields: int = 1000,
         max_part_size: int = 1024 * 1024,
     ) -> AwaitableOrContextManager[FormData]:
         return AwaitableOrContextManagerWrapper(

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -249,7 +249,14 @@ class Request(HTTPConnection):
             self._json = json.loads(body)
         return self._json
 
-    async def _get_form(self, *, max_files: int | float = 1000, max_fields: int | float = 1000) -> FormData:
+    async def _get_form(
+        self,
+        *,
+        max_files: int | float = 1000,
+        max_fields: int | float = 1000,
+        max_file_size: int = 1024 * 1024,
+        max_part_size: int | float = 1024 * 1024,
+    ) -> FormData:
         if self._form is None:
             assert (
                 parse_options_header is not None
@@ -264,6 +271,8 @@ class Request(HTTPConnection):
                         self.stream(),
                         max_files=max_files,
                         max_fields=max_fields,
+                        max_file_size=max_file_size,
+                        max_part_size=max_part_size,
                     )
                     self._form = await multipart_parser.parse()
                 except MultiPartException as exc:
@@ -278,9 +287,18 @@ class Request(HTTPConnection):
         return self._form
 
     def form(
-        self, *, max_files: int | float = 1000, max_fields: int | float = 1000
+        self,
+        *,
+        max_files: int | float = 1000,
+        max_fields: int | float = 1000,
+        max_file_size: int = 1024 * 1024,
+        max_part_size: int | float = 1024 * 1024,
     ) -> AwaitableOrContextManager[FormData]:
-        return AwaitableOrContextManagerWrapper(self._get_form(max_files=max_files, max_fields=max_fields))
+        return AwaitableOrContextManagerWrapper(
+            self._get_form(
+                max_files=max_files, max_fields=max_fields, max_file_size=max_file_size, max_part_size=max_part_size
+            )
+        )
 
     async def close(self) -> None:
         if self._form is not None:  # pragma: no branch

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -254,7 +254,7 @@ class Request(HTTPConnection):
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int | float = 1024 * 1024,
+        max_part_size: int = 1024 * 1024,
     ) -> FormData:
         if self._form is None:
             assert (
@@ -289,7 +289,7 @@ class Request(HTTPConnection):
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int | float = 1024 * 1024,
+        max_part_size: int = 1024 * 1024,
     ) -> AwaitableOrContextManager[FormData]:
         return AwaitableOrContextManagerWrapper(
             self._get_form(max_files=max_files, max_fields=max_fields, max_part_size=max_part_size)

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -736,6 +736,6 @@ def test_max_part_size_exceeds_custom_limit(
     }
 
     with expectation:
-        response = client.post("/", data=multipart_data, headers=headers)  # type: ignore
+        response = client.post("/", content=multipart_data, headers=headers)
         assert response.status_code == 400
         assert response.text == "Part exceeded maximum size of 10KB."

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -109,9 +109,7 @@ def make_app_max_parts(
 ) -> ASGIApp:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)
-        data = await request.form(
-            max_files=max_files, max_fields=max_fields, max_file_size=max_file_size, max_part_size=max_part_size
-        )
+        data = await request.form(max_files=max_files, max_fields=max_fields, max_part_size=max_part_size)
         output: dict[str, typing.Any] = {}
         for key, value in data.items():
             if isinstance(value, UploadFile):

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -105,7 +105,7 @@ async def app_read_body(scope: Scope, receive: Receive, send: Send) -> None:
 
 
 def make_app_max_parts(
-    max_files: int = 1000, max_fields: int = 1000, max_file_size: int = 1024 * 1024, max_part_size: int = 1024 * 1024
+    max_files: int = 1000, max_fields: int = 1000, max_part_size: int = 1024 * 1024
 ) -> ASGIApp:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -104,9 +104,7 @@ async def app_read_body(scope: Scope, receive: Receive, send: Send) -> None:
     await response(scope, receive, send)
 
 
-def make_app_max_parts(
-    max_files: int = 1000, max_fields: int = 1000, max_part_size: int = 1024 * 1024
-) -> ASGIApp:
+def make_app_max_parts(max_files: int = 1000, max_fields: int = 1000, max_part_size: int = 1024 * 1024) -> ASGIApp:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)
         data = await request.form(max_files=max_files, max_fields=max_fields, max_part_size=max_part_size)


### PR DESCRIPTION
Fixes #2785 

Also addresses issue discussed in [FastAPI Repo](https://github.com/fastapi/fastapi/discussions/12961#discussioncomment-11336476).