### PR TITLE
tests: branch coverage in `_utils.py`, `middleware/gzip.py`, `routing.py` and `requests.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ filterwarnings = [
 
 [tool.coverage.run]
 source_pkgs = ["starlette", "tests"]
+branch = true
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ filterwarnings = [
 
 [tool.coverage.run]
 source_pkgs = ["starlette", "tests"]
-branch = true
 
 [tool.coverage.report]
 exclude_lines = [

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -75,9 +75,9 @@ def collapse_excgroups() -> typing.Generator[None, None, None]:
     try:
         yield
     except BaseException as exc:
-        if has_exceptiongroups:
+        if has_exceptiongroups:  # pragma: no cover
             while isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
-                exc = exc.exceptions[0]  # pragma: no cover
+                exc = exc.exceptions[0]
 
         raise exc
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -13,7 +13,7 @@ class GZipMiddleware:
         self.compresslevel = compresslevel
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] == "http":
+        if scope["type"] == "http":  # pragma: no branch
             headers = Headers(scope=scope)
             if "gzip" in headers.get("Accept-Encoding", ""):
                 responder = GZipResponder(self.app, self.minimum_size, compresslevel=self.compresslevel)
@@ -88,7 +88,7 @@ class GZipResponder:
                 await self.send(self.initial_message)
                 await self.send(message)
 
-        elif message_type == "http.response.body":
+        elif message_type == "http.response.body":  # pragma: no branch
             # Remaining body in streaming GZip response.
             body = message.get("body", b"")
             more_body = message.get("more_body", False)

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -230,7 +230,7 @@ class Request(HTTPConnection):
                     self._stream_consumed = True
                 if body:
                     yield body
-            elif message["type"] == "http.disconnect":
+            elif message["type"] == "http.disconnect":  # pragma: no branch
                 self._is_disconnected = True
                 raise ClientDisconnect()
         yield b""
@@ -250,7 +250,7 @@ class Request(HTTPConnection):
         return self._json
 
     async def _get_form(self, *, max_files: int | float = 1000, max_fields: int | float = 1000) -> FormData:
-        if self._form is None:
+        if self._form is None:  # pragma: no branch
             assert (
                 parse_options_header is not None
             ), "The `python-multipart` library must be installed to use form parsing."

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -196,7 +196,7 @@ class BaseRoute:
             if scope["type"] == "http":
                 response = PlainTextResponse("Not Found", status_code=404)
                 await response(scope, receive, send)
-            elif scope["type"] == "websocket":
+            elif scope["type"] == "websocket":  # pragma: no branch
                 websocket_close = WebSocketClose()
                 await websocket_close(scope, receive, send)
             return
@@ -398,7 +398,7 @@ class Mount(BaseRoute):
 
     def matches(self, scope: Scope) -> tuple[Match, Scope]:
         path_params: dict[str, typing.Any]
-        if scope["type"] in ("http", "websocket"):
+        if scope["type"] in ("http", "websocket"):  # pragma: no branch
             root_path = scope.get("root_path", "")
             route_path = get_route_path(scope)
             match = self.path_regex.match(route_path)
@@ -481,7 +481,7 @@ class Host(BaseRoute):
         return getattr(self.app, "routes", [])
 
     def matches(self, scope: Scope) -> tuple[Match, Scope]:
-        if scope["type"] in ("http", "websocket"):
+        if scope["type"] in ("http", "websocket"):  # pragma:no branch
             headers = Headers(scope=scope)
             host = headers.get("host", "").split(":")[0]
             match = self.host_regex.match(host)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -565,6 +565,22 @@ def test_url_for_with_double_mount() -> None:
     assert url == "/mount/static/123"
 
 
+def test_url_for_with_root_path_ending_with_slash(test_client_factory: TestClientFactory) -> None:
+    def homepage(request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "index": str(request.url_for("homepage")),
+            }
+        )
+
+    app = Starlette(routes=[Route("/", homepage, name="homepage")])
+    client = test_client_factory(app, base_url="https://www.example.org/", root_path="/sub_path/")
+    response = client.get("/sub_path/")
+    assert response.json() == {
+        "index": "https://www.example.org/sub_path/",
+    }
+
+
 def test_standalone_route_matches(
     test_client_factory: TestClientFactory,
 ) -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -567,18 +567,12 @@ def test_url_for_with_double_mount() -> None:
 
 def test_url_for_with_root_path_ending_with_slash(test_client_factory: TestClientFactory) -> None:
     def homepage(request: Request) -> JSONResponse:
-        return JSONResponse(
-            {
-                "index": str(request.url_for("homepage")),
-            }
-        )
+        return JSONResponse({"index": str(request.url_for("homepage"))})
 
     app = Starlette(routes=[Route("/", homepage, name="homepage")])
     client = test_client_factory(app, base_url="https://www.example.org/", root_path="/sub_path/")
     response = client.get("/sub_path/")
-    assert response.json() == {
-        "index": "https://www.example.org/sub_path/",
-    }
+    assert response.json() == {"index": "https://www.example.org/sub_path/"}
 
 
 def test_standalone_route_matches(


### PR DESCRIPTION
# Summary


Related to Issue #2452

This PR covers all 9 missing cases.

#### `starlette/_utils.py` [78–82](https://github.com/encode/starlette/blob/master/starlette/_utils.py#L78-L82)

Extend the `# pragma: no cover` to include the condition.

#### `starlette/middleware/gzip.py` [16–22](https://github.com/encode/starlette/blob/master/starlette/middleware/gzip.py#L16-L22), [91–end](https://github.com/encode/starlette/blob/master/starlette/middleware/gzip.py#L91)

Related to conditional cases with scope type and message type.
Added `# pragma: no branch` to all cases.

#### `starlette/routing.py` [199–202](https://github.com/encode/starlette/blob/master/starlette/routing.py#L199-L202), [401–430](https://github.com/encode/starlette/blob/master/starlette/routing.py#L401-L430), [484–496](https://github.com/encode/starlette/blob/master/starlette/routing.py#L484-L496)

Related to conditional cases where the scope type is not 'http' or 'websocket'.
Added `# pragma: no branch` to all cases.

#### `starlette/requests.py` [114–116](https://github.com/encode/starlette/blob/master/starlette/requests.py#L114-L116), [233–225](https://github.com/encode/starlette/blob/master/starlette/requests.py#L233-L225), [253–278](https://github.com/encode/starlette/blob/master/starlette/requests.py#L253-L278)

Although it's from `requests.py`, the test related to lines 114–116 was added in `test_routing.py`.
For the other two cases, `# pragma: no branch` was added.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
