### PR TITLE
Remove `ExceptionMiddleware` import proxy from `starlette.exceptions` module

### DIFF
--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -1,19 +1,11 @@
 from __future__ import annotations
 
 import http
-import typing
-import warnings
-
-__all__ = ("HTTPException", "WebSocketException")
+from collections.abc import Mapping
 
 
 class HTTPException(Exception):
-    def __init__(
-        self,
-        status_code: int,
-        detail: str | None = None,
-        headers: typing.Mapping[str, str] | None = None,
-    ) -> None:
+    def __init__(self, status_code: int, detail: str | None = None, headers: Mapping[str, str] | None = None) -> None:
         if detail is None:
             detail = http.HTTPStatus(status_code).phrase
         self.status_code = status_code
@@ -39,24 +31,3 @@ class WebSocketException(Exception):
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
         return f"{class_name}(code={self.code!r}, reason={self.reason!r})"
-
-
-__deprecated__ = "ExceptionMiddleware"
-
-
-def __getattr__(name: str) -> typing.Any:  # pragma: no cover
-    if name == __deprecated__:
-        from starlette.middleware.exceptions import ExceptionMiddleware
-
-        warnings.warn(
-            f"{__deprecated__} is deprecated on `starlette.exceptions`. "
-            f"Import it from `starlette.middleware.exceptions` instead.",
-            category=DeprecationWarning,
-            stacklevel=3,
-        )
-        return ExceptionMiddleware
-    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
-
-
-def __dir__() -> list[str]:
-    return sorted(list(__all__) + [__deprecated__])  # pragma: no cover

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,3 @@
-import warnings
 from collections.abc import Generator
 
 import pytest
@@ -179,19 +178,6 @@ def test_websocket_repr() -> None:
         repr(CustomWebSocketException(1013, reason="Something custom"))
         == "CustomWebSocketException(code=1013, reason='Something custom')"
     )
-
-
-def test_exception_middleware_deprecation() -> None:
-    # this test should be removed once the deprecation shim is removed
-    with pytest.warns(DeprecationWarning):
-        from starlette.exceptions import ExceptionMiddleware  # noqa: F401
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        import starlette.exceptions
-
-    with pytest.warns(DeprecationWarning):
-        starlette.exceptions.ExceptionMiddleware
 
 
 def test_request_in_app_and_handler_is_the_same_object(client: TestClient) -> None:


### PR DESCRIPTION
This was introduced in **May 19, 2022** on https://github.com/encode/starlette/pull/1617.

Now, **December 28, 2024** we are removing it. It's more than 2 years and a half.