### PR TITLE
Get iscoroutinefunction() from inspect rather than asyncio

### DIFF
--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import asyncio
 import functools
+import inspect
 import sys
 import typing
 from contextlib import contextmanager
@@ -36,7 +36,7 @@ def is_async_callable(obj: typing.Any) -> typing.Any:
     while isinstance(obj, functools.partial):
         obj = obj.func
 
-    return asyncio.iscoroutinefunction(obj) or (callable(obj) and asyncio.iscoroutinefunction(obj.__call__))
+    return inspect.iscoroutinefunction(obj) or (callable(obj) and inspect.iscoroutinefunction(obj.__call__))
 
 
 T_co = typing.TypeVar("T_co", covariant=True)


### PR DESCRIPTION
Python 3.14.0a3 issues a `DeprecationWarning` for
`asyncio.iscoroutinefunction()`, stating that it is deprecated and slated for removal in Python 3.16, and recommending
`inspect.iscoroutinefunction()` instead. This change resolves that `DeprecationWarning`.

<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

Running the tests with Python 3.14.0a3 fails with several errors like:

```
_______________________________________________________________________________ ERROR collecting tests/middleware/test_base.py _______________________________________________________________________________
tests/middleware/test_base.py:77: in <module>
    Route("/", endpoint=homepage),
starlette/routing.py:230: in __init__
    self.app = request_response(endpoint)
starlette/routing.py:66: in request_response
    func if is_async_callable(func) else functools.partial(run_in_threadpool, func)  # type:ignore
starlette/_utils.py:39: in is_async_callable
    return asyncio.iscoroutinefunction(obj) or (callable(obj) and asyncio.iscoroutinefunction(obj.__call__))
/usr/lib64/python3.14/asyncio/coroutines.py:23: in iscoroutinefunction
    warnings._deprecated("asyncio.iscoroutinefunction",
/usr/lib64/python3.14/warnings.py:668: in _deprecated
    warn(msg, DeprecationWarning, stacklevel=3)
E   DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
```

This PR just implements the recommended migration from `asyncio.iscoroutinefunction()` to `inspect.iscoroutinefunction()` in `starlette/_utils.py`. Note that `starlete/routing.py` already uses `inspect.iscoroutinefunction()` even before this PR:

https://github.com/encode/starlette/blob/4d72fd87ea1c358691a19468168f7217d8ca6a87/starlette/routing.py#L55

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!) **I think this is a small enough change for a “drive-by” PR, but this can be moved to a discussion if you think a less trivial approach is needed for some reason.**
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. **N/A – this resolves test errors in Python 3.14.0a3, so no new tests are required.**
- [ ] I've updated the documentation accordingly. **N/A – I don’t think any documentation updates are required.**
