### PR TITLE
Do not process FileNotFoundError in FileResponse, resolves #979

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -341,7 +341,7 @@ class FileResponse(Response):
                 stat_result = await anyio.to_thread.run_sync(os.stat, self.path)
                 self.set_stat_headers(stat_result)
             except FileNotFoundError:
-                raise RuntimeError(f"File at path {self.path} does not exist.")
+                pass
             else:
                 mode = stat_result.st_mode
                 if not stat.S_ISREG(mode):

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -299,9 +299,8 @@ def test_file_response_with_missing_file_raises_error(tmp_path: Path, test_clien
     path = tmp_path / "404.txt"
     app = FileResponse(path=path, filename="404.txt")
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(FileNotFoundError) as exc_info:
         client.get("/")
-    assert "does not exist" in str(exc_info.value)
 
 
 def test_file_response_with_chinese_filename(tmp_path: Path, test_client_factory: TestClientFactory) -> None:

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -299,7 +299,7 @@ def test_file_response_with_missing_file_raises_error(tmp_path: Path, test_clien
     path = tmp_path / "404.txt"
     app = FileResponse(path=path, filename="404.txt")
     client = test_client_factory(app)
-    with pytest.raises(FileNotFoundError) as exc_info:
+    with pytest.raises(FileNotFoundError):
         client.get("/")
 
 


### PR DESCRIPTION
FileNotFoundError can be processed in exception_handlers

<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
Avoid handling FileNotFoundError in FileResponse.
This allows FileNotFoundError to be properly handled using exception_handlers, for example, by returning a 404 error when a file is not found.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
