### PR TITLE
fix(gzip): Make sure Vary header is always added if a response can be compressed

### DIFF
--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -15,17 +15,24 @@ class GZipMiddleware:
         self.compresslevel = compresslevel
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] == "http":  # pragma: no branch
-            headers = Headers(scope=scope)
-            if "gzip" in headers.get("Accept-Encoding", ""):
-                responder = GZipResponder(self.app, self.minimum_size, compresslevel=self.compresslevel)
-                await responder(scope, receive, send)
-                return
-        await self.app(scope, receive, send)
+        if scope["type"] != "http":  # pragma: no cover
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        responder: ASGIApp
+        if "gzip" in headers.get("Accept-Encoding", ""):
+            responder = GZipResponder(self.app, self.minimum_size, compresslevel=self.compresslevel)
+        else:
+            responder = IdentityResponder(self.app, self.minimum_size)
+
+        await responder(scope, receive, send)
 
 
-class GZipResponder:
-    def __init__(self, app: ASGIApp, minimum_size: int, compresslevel: int = 9) -> None:
+class IdentityResponder:
+    content_encoding: str
+
+    def __init__(self, app: ASGIApp, minimum_size: int) -> None:
         self.app = app
         self.minimum_size = minimum_size
         self.send: Send = unattached_send
@@ -33,15 +40,12 @@ class GZipResponder:
         self.started = False
         self.content_encoding_set = False
         self.content_type_is_excluded = False
-        self.gzip_buffer = io.BytesIO()
-        self.gzip_file = gzip.GzipFile(mode="wb", fileobj=self.gzip_buffer, compresslevel=compresslevel)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         self.send = send
-        with self.gzip_buffer, self.gzip_file:
-            await self.app(scope, receive, self.send_with_gzip)
+        await self.app(scope, receive, self.send_with_compression)
 
-    async def send_with_gzip(self, message: Message) -> None:
+    async def send_with_compression(self, message: Message) -> None:
         message_type = message["type"]
         if message_type == "http.response.start":
             # Don't send the initial message until we've determined how to
@@ -64,48 +68,75 @@ class GZipResponder:
                 await self.send(self.initial_message)
                 await self.send(message)
             elif not more_body:
-                # Standard GZip response.
-                self.gzip_file.write(body)
-                self.gzip_file.close()
-                body = self.gzip_buffer.getvalue()
+                # Standard response.
+                body = self.apply_compression(body, more_body=False)
 
                 headers = MutableHeaders(raw=self.initial_message["headers"])
-                headers["Content-Encoding"] = "gzip"
-                headers["Content-Length"] = str(len(body))
                 headers.add_vary_header("Accept-Encoding")
-                message["body"] = body
+                if body != message["body"]:
+                    headers["Content-Encoding"] = self.content_encoding
+                    headers["Content-Length"] = str(len(body))
+                    message["body"] = body
 
                 await self.send(self.initial_message)
                 await self.send(message)
             else:
-                # Initial body in streaming GZip response.
-                headers = MutableHeaders(raw=self.initial_message["headers"])
-                headers["Content-Encoding"] = "gzip"
-                headers.add_vary_header("Accept-Encoding")
-                del headers["Content-Length"]
+                # Initial body in streaming response.
+                body = self.apply_compression(body, more_body=True)
 
-                self.gzip_file.write(body)
-                message["body"] = self.gzip_buffer.getvalue()
-                self.gzip_buffer.seek(0)
-                self.gzip_buffer.truncate()
+                headers = MutableHeaders(raw=self.initial_message["headers"])
+                headers.add_vary_header("Accept-Encoding")
+                if body != message["body"]:
+                    headers["Content-Encoding"] = self.content_encoding
+                    del headers["Content-Length"]
+                    message["body"] = body
 
                 await self.send(self.initial_message)
                 await self.send(message)
-
         elif message_type == "http.response.body":  # pragma: no branch
-            # Remaining body in streaming GZip response.
+            # Remaining body in streaming response.
             body = message.get("body", b"")
             more_body = message.get("more_body", False)
 
-            self.gzip_file.write(body)
-            if not more_body:
-                self.gzip_file.close()
-
-            message["body"] = self.gzip_buffer.getvalue()
-            self.gzip_buffer.seek(0)
-            self.gzip_buffer.truncate()
+            message["body"] = self.apply_compression(body, more_body=more_body)
 
             await self.send(message)
+
+    def apply_compression(self, body: bytes, *, more_body: bool) -> bytes:
+        """Apply compression on the response body.
+
+        If more_body is False, any compression file should be closed. If it
+        isn't, it won't be closed automatically until all background tasks
+        complete.
+        """
+        return body
+
+
+class GZipResponder(IdentityResponder):
+    content_encoding = "gzip"
+
+    def __init__(self, app: ASGIApp, minimum_size: int, compresslevel: int = 9) -> None:
+        super().__init__(app, minimum_size)
+
+        self.gzip_buffer = io.BytesIO()
+        self.gzip_file = gzip.GzipFile(mode="wb", fileobj=self.gzip_buffer, compresslevel=compresslevel)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        with self.gzip_buffer, self.gzip_file:
+            await super().__call__(scope, receive, send)
+
+    def apply_compression(self, body: bytes, *, more_body: bool) -> bytes:
+        self.gzip_file.write(body)
+        self.gzip_file.flush()
+        body = self.gzip_buffer.getvalue()
+
+        if not more_body:
+            self.gzip_file.close()
+
+        self.gzip_buffer.seek(0)
+        self.gzip_buffer.truncate()
+
+        return body
 
 
 async def unattached_send(message: Message) -> typing.NoReturn:

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -64,7 +64,7 @@ class IdentityResponder:
             body = message.get("body", b"")
             more_body = message.get("more_body", False)
             if len(body) < self.minimum_size and not more_body:
-                # Don't apply GZip to small outgoing responses.
+                # Don't apply compression to small outgoing responses.
                 await self.send(self.initial_message)
                 await self.send(message)
             elif not more_body:
@@ -127,12 +127,10 @@ class GZipResponder(IdentityResponder):
 
     def apply_compression(self, body: bytes, *, more_body: bool) -> bytes:
         self.gzip_file.write(body)
-        self.gzip_file.flush()
-        body = self.gzip_buffer.getvalue()
-
         if not more_body:
             self.gzip_file.close()
 
+        body = self.gzip_buffer.getvalue()
         self.gzip_buffer.seek(0)
         self.gzip_buffer.truncate()
 


### PR DESCRIPTION
Fixes #2863

<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
Since the presense or absense of the `Accept-Encoding` header can change the response body, `Vary` should always be added whether the client requested gzip encoding or not. Otherwise some caching implementations might return a non-compressed response even when a compressed one was requested.

This change may seem a bit complex, but it reworks the `GZipMiddleware` to behave the same no matter what the compression is (or lack of). Basic changes include:

1. Move all gzip compression to a method `apply_compression` and don't update the `content-encoding` or `content-length` headers if the body didn't change.
2. Create a base class `IdentityResponder` from `GZipResponder` which will be used to respond to non-gzip requests. Its `apply_compression` method will return the body unchanged.
3. Coincidentally, it's now easier to implement new compression algorithms like deflate, brotli, or zstd. This PR does not implement those.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
