### PR TITLE
`GZipResponder` has been rewritten so that it no longer throws not raised exception warning

### DIFF
--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -1,6 +1,17 @@
+import gc
+import gzip
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from io import BytesIO
+from typing import TYPE_CHECKING, Callable
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
-from starlette.middleware.gzip import GZipMiddleware
+from starlette.middleware.gzip import GZipMiddleware, GZipResponder
 from starlette.requests import Request
 from starlette.responses import ContentStream, PlainTextResponse, StreamingResponse
 from starlette.routing import Route
@@ -104,3 +115,49 @@ def test_gzip_ignored_for_responses_with_encoding_set(
     assert response.text == "x" * 4000
     assert response.headers["Content-Encoding"] == "text"
     assert "Content-Length" not in response.headers
+
+
+if TYPE_CHECKING:
+    from sys import UnraisableHookArgs
+else:
+    UnraisableHookArgs = object
+
+
+@contextmanager
+def override_custom_unraisable_exception_hook_and_gc_collect(
+    unraisable_hook: Callable[[UnraisableHookArgs], None],
+) -> Iterator[None]:
+    unraisable_hook_before_test = sys.unraisablehook
+    sys.unraisablehook = unraisable_hook
+    try:
+        yield
+        gc.collect()
+    finally:
+        sys.unraisablehook = unraisable_hook_before_test
+
+
+# https://github.com/python/cpython/blob/247b50dec8af47ed8a80069117e07b7139f9d54f/Doc/whatsnew/3.13.rst#io
+@pytest.mark.skipif(sys.version_info < (3, 13), reason="requires python3.13 or higher")
+def test_gzip_responder_not_writes_not_raised_exception_warning(
+    test_client_factory: TestClientFactory,
+) -> None:
+    # check unraisablehook trgiggers when BytesIO destroyed before GzipFile
+    mock_for_test_bytesio_and_gzip_unraisable = Mock()
+    with override_custom_unraisable_exception_hook_and_gc_collect(
+        unraisable_hook=mock_for_test_bytesio_and_gzip_unraisable
+    ):
+        b = BytesIO()
+        g = gzip.GzipFile(fileobj=b, mode="wb")
+        del b
+        del g
+
+    assert mock_for_test_bytesio_and_gzip_unraisable.called
+
+    mock_for_test_gzip_responder_unraisable = Mock()
+    with override_custom_unraisable_exception_hook_and_gc_collect(
+        unraisable_hook=mock_for_test_gzip_responder_unraisable
+    ):
+        responder = GZipResponder(app=AsyncMock(), minimum_size=500)
+        del responder
+
+    assert not mock_for_test_gzip_responder_unraisable.called


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Hello, thank you to everyone involved for this wonderful project. I'm glad to have the opportunity to contribute in some way.

I'm using `FastAPI` in my web service, and after upgrading to `Python 3.13`, I've noticed a large number of warnings like this:
```
Exception ignored in: <gzip on 0x7efc933315d0>
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/gzip.py", line 359, in close
    fileobj.write(self.compress.flush())
ValueError: I/O operation on closed file.
```

I spent a considerable amount of time trying to understand where this error actually comes from and realized that it's related to `GzipMiddleware`. I saw the issue https://github.com/encode/starlette/issues/2615, but honestly, I didn't understand why it was marked as completed.

This error occurs because the `BytesIO` object is closed before the `GzipFile`. I suggest using these two objects through a context manager, as mentioned in the `CPython` issue https://github.com/python/cpython/issues/122727.

I also spent a lot of time writing a test for this, so let me explain it. I couldn't write the test similarly to other tests in `gzip_middleware`, where requests are made through the test client; for some reason, the issue would not reproduce this way, possibly due to garbage collection peculiarities. However, in the current test, it's evident that the problem reproduces quite easily—one only needs to create a `GzipResponder` object and delete it. The test was written before I fixed the implementation, and I confirmed that it indeed did not work.
<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
