### PR TITLE
Use `localhost` instead of `http://localhost` in `TestClient(client=...)` example

### DIFF
--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -86,7 +86,7 @@ By default, the TestClient will set the client host to `"testserver"` and the po
 You can change the client address by setting the `client` attribute of the `TestClient` instance:
 
 ```python
-client = TestClient(app, client=('http://localhost', 8000))
+client = TestClient(app, client=('localhost', 8000))
 ```
 
 ### Selecting the Async backend


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

With https://github.com/encode/starlette/pull/2810, it is possible to override the client host (i.e. the remote address; see https://www.starlette.io/requests/#client-address).

The default value for `TestClient` is `testclient`, but an IP address in most circumstances.

The documentation example for overriding the client host uses a full URI, which makes no sense: it's the remote address.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
