### PR TITLE
Expose `url_path_for` on `HTTPConnection`

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -189,7 +189,9 @@ class HTTPConnection(typing.Mapping[str, typing.Any]):
     def url_path_for(self, name: str, /, **path_params: typing.Any) -> URLPath:
         url_path_provider: Router | Starlette | None = self.scope.get("router") or self.scope.get("app")
         if url_path_provider is None:
-            raise RuntimeError("The `url_for` method can only be used inside a Starlette application or with a router.")
+            raise RuntimeError(
+                "The `url_path_for` method can only be used inside a Starlette application or with a router.",
+            )
         return url_path_provider.url_path_for(name, **path_params)
 
 

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -7,7 +7,7 @@ from http import cookies as http_cookies
 import anyio
 
 from starlette._utils import AwaitableOrContextManager, AwaitableOrContextManagerWrapper
-from starlette.datastructures import URL, URLPath, Address, FormData, Headers, QueryParams, State
+from starlette.datastructures import URL, Address, FormData, Headers, QueryParams, State, URLPath
 from starlette.exceptions import HTTPException
 from starlette.formparsers import FormParser, MultiPartException, MultiPartParser
 from starlette.types import Message, Receive, Scope, Send

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -7,7 +7,7 @@ from http import cookies as http_cookies
 import anyio
 
 from starlette._utils import AwaitableOrContextManager, AwaitableOrContextManagerWrapper
-from starlette.datastructures import URL, Address, FormData, Headers, QueryParams, State
+from starlette.datastructures import URL, URLPath, Address, FormData, Headers, QueryParams, State
 from starlette.exceptions import HTTPException
 from starlette.formparsers import FormParser, MultiPartException, MultiPartParser
 from starlette.types import Message, Receive, Scope, Send
@@ -185,6 +185,12 @@ class HTTPConnection(typing.Mapping[str, typing.Any]):
             raise RuntimeError("The `url_for` method can only be used inside a Starlette application or with a router.")
         url_path = url_path_provider.url_path_for(name, **path_params)
         return url_path.make_absolute_url(base_url=self.base_url)
+
+    def url_path_for(self, name: str, /, **path_params: typing.Any) -> URLPath:
+        url_path_provider: Router | Starlette | None = self.scope.get("router") or self.scope.get("app")
+        if url_path_provider is None:
+            raise RuntimeError("The `url_for` method can only be used inside a Starlette application or with a router.")
+        return url_path_provider.url_path_for(name, **path_params)
 
 
 async def empty_receive() -> typing.NoReturn:

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -187,12 +187,7 @@ class HTTPConnection(typing.Mapping[str, typing.Any]):
         return url_path.make_absolute_url(base_url=self.base_url)
 
     def url_path_for(self, name: str, /, **path_params: typing.Any) -> URLPath:
-        url_path_provider: Router | Starlette | None = self.scope.get("router") or self.scope.get("app")
-        if url_path_provider is None:
-            raise RuntimeError(
-                "The `url_path_for` method can only be used inside a Starlette application or with a router.",
-            )
-        return url_path_provider.url_path_for(name, **path_params)
+        return URLPath(self.url_for(name, **path_params).path)
 
 
 async def empty_receive() -> typing.NoReturn:

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -5,7 +5,7 @@ import warnings
 from os import PathLike
 
 from starlette.background import BackgroundTask
-from starlette.datastructures import URL
+from starlette.datastructures import URL, URLPath
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
 from starlette.types import Receive, Scope, Send
@@ -125,7 +125,18 @@ class Jinja2Templates:
             request: Request = context["request"]
             return request.url_for(name, **path_params)
 
+        @pass_context
+        def url_path_for(
+            context: dict[str, typing.Any],
+            name: str,
+            /,
+            **path_params: typing.Any,
+        ) -> URLPath:
+            request: Request = context["request"]
+            return request.url_path_for(name, **path_params)
+
         env.globals.setdefault("url_for", url_for)
+        env.globals.setdefault("url_path_for", url_path_for)
 
     def get_template(self, name: str) -> jinja2.Template:
         return self.env.get_template(name)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -7,7 +7,7 @@ from typing import Any
 import anyio
 import pytest
 
-from starlette.datastructures import URL, URLPath, Address, State
+from starlette.datastructures import URL, Address, State, URLPath
 from starlette.requests import ClientDisconnect, Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.types import Message, Receive, Scope, Send

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -644,7 +644,7 @@ def test_request_url_path_outside_starlette_context(test_client_factory: TestCli
     client = test_client_factory(app)
     with pytest.raises(
         RuntimeError,
-        match="The `url_path_for` method can only be used inside a Starlette application or with a router.",
+        match="The `url_for` method can only be used inside a Starlette application or with a router.",
     ):
         client.get("/")
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -22,6 +22,7 @@ def test_templates(tmpdir: Path, test_client_factory: TestClientFactory) -> None
     path = os.path.join(tmpdir, "index.html")
     with open(path, "w") as file:
         file.write("<html>Hello, <a href='{{ url_for('homepage') }}'>world</a></html>")
+        file.write("<html>Hello, <a href='{{ url_path_for('homepage') }}'>world</a></html>")
 
     async def homepage(request: Request) -> Response:
         return templates.TemplateResponse(request, "index.html")
@@ -31,7 +32,10 @@ def test_templates(tmpdir: Path, test_client_factory: TestClientFactory) -> None
 
     client = test_client_factory(app)
     response = client.get("/")
-    assert response.text == "<html>Hello, <a href='http://testserver/'>world</a></html>"
+    assert (
+        response.text
+        == "<html>Hello, <a href='http://testserver/'>world</a></html><html>Hello, <a href='/'>world</a></html>"
+    )
     assert response.template.name == "index.html"  # type: ignore
     assert set(response.context.keys()) == {"request"}  # type: ignore
 


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Based on the conclusion of #604 which can be found [here](https://github.com/encode/starlette/issues/604#issuecomment-578895744) the consensus seems to be that trying to munge host headers when located behind a reverse proxy isn't the best approach and that instead absolute paths should be used in redirects. The same, I imagine, should apply in tempates.

This is currently possible but would be made easier/neater if the `url_path_for` method which exists on `Starlette` was exposed on the `HTTPConnection` and therefore the `Request`. Additionally, adding a `url_path_for` `jinja` function would allow for this to be achieved in templates much easier.

I leave this PR here for review with the knowledge that if this approach is approved of docs will also need to be added.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
