### PR TITLE
Feature: relative url in URL datastructure

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -107,7 +107,7 @@ class URL:
     def is_secure(self) -> bool:
         return self.scheme in ("https", "wss")
 
-    def relative_url(self):
+    def relative_url(self) -> URL:
         """
         Get a URL that only includes url path, query string and fragment.
         """

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -107,6 +107,20 @@ class URL:
     def is_secure(self) -> bool:
         return self.scheme in ("https", "wss")
 
+    def relative_url(self) -> str:
+        """
+        Get the relative URL string, including only url path, query string and fragment.
+        """
+        url_str = self.path
+
+        if self.query:
+            url_str += "?" + self.query
+
+        if self.fragment:
+            url_str += "#" + self.fragment
+
+        return url_str
+
     def replace(self, **kwargs: typing.Any) -> URL:
         if "username" in kwargs or "password" in kwargs or "hostname" in kwargs or "port" in kwargs:
             hostname = kwargs.pop("hostname", None)

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -107,19 +107,11 @@ class URL:
     def is_secure(self) -> bool:
         return self.scheme in ("https", "wss")
 
-    def relative_url(self) -> str:
+    def relative_url(self):
         """
-        Get the relative URL string, including only url path, query string and fragment.
+        Get a URL that only includes url path, query string and fragment.
         """
-        url_str = self.path
-
-        if self.query:
-            url_str += "?" + self.query
-
-        if self.fragment:
-            url_str += "#" + self.fragment
-
-        return url_str
+        return self.__class__(path=self.path, query=self.query, fragment=self.fragment)
 
     def replace(self, **kwargs: typing.Any) -> URL:
         if "username" in kwargs or "password" in kwargs or "hostname" in kwargs or "port" in kwargs:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -90,6 +90,17 @@ def test_hidden_password() -> None:
     assert repr(u) == "URL('https://username:********@example.org/path/to/somewhere')"
 
 
+def test_relative_url() -> None:
+    u = URL("https://example.org/path/to/somewhere")
+    assert u.relative_url() == URL("/path/to/somewhere")
+
+    u = URL("https://username:password@example.org/path/to/somewhere?abc=123")
+    assert u.relative_url() == URL("/path/to/somewhere?abc=123")
+
+    u = URL("https://[fe::2]:12345/path/to/somewhere?abc=123#anchor")
+    assert u.relative_url() == URL("/path/to/somewhere?abc=123#anchor")
+
+
 def test_csv() -> None:
     csv = CommaSeparatedStrings('"localhost", "127.0.0.1", 0.0.0.0')
     assert list(csv) == ["localhost", "127.0.0.1", "0.0.0.0"]


### PR DESCRIPTION
# Summary

In some of my FastAPI applications I have found the need for a relative URL function that gives you a URL that is only the path, query and fragment. I figured others might find it useful. Having it as a method on the class directly is useful in situations like Jinja templates so you dont have to pass in a helper function.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have not updated the documentation as the URL data structure is not documented on the website.
