### PR TITLE
requests.py: remove wrong assert scope["type"] == "http" in Request

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -200,7 +200,6 @@ class Request(HTTPConnection):
 
     def __init__(self, scope: Scope, receive: Receive = empty_receive, send: Send = empty_send):
         super().__init__(scope)
-        assert scope["type"] == "http"
         self._receive = receive
         self._send = send
         self._stream_consumed = False


### PR DESCRIPTION
It differs from parent class.
Parent class HTTPConnection's `__init__` already asserts scope type is `"http"` or `"websocket"`, but derived Request class only checks `"http"`, so it still raises an error in case of `"websocket"`

<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
