### PR TITLE
Allow relative directory path when `follow_symlinks=True`

### DIFF
--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -153,6 +153,7 @@ class StaticFiles:
             joined_path = os.path.join(directory, path)
             if self.follow_symlink:
                 full_path = os.path.abspath(joined_path)
+                directory = os.path.abspath(directory)
             else:
                 full_path = os.path.realpath(joined_path)
                 directory = os.path.realpath(directory)

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -595,7 +595,7 @@ def test_staticfiles_self_symlinks(tmp_path: Path, test_client_factory: TestClie
     assert response.text == "<h1>Hello</h1>"
 
 
-def test_staticfiles_relative_directory_symlinks(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
+def test_staticfiles_relative_directory_symlinks(test_client_factory: TestClientFactory) -> None:
     app = StaticFiles(directory="tests/statics", follow_symlink=True)
     client = test_client_factory(app)
     response = client.get("/example.txt")

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -593,3 +593,19 @@ def test_staticfiles_self_symlinks(tmp_path: Path, test_client_factory: TestClie
     assert response.url == "http://testserver/index.html"
     assert response.status_code == 200
     assert response.text == "<h1>Hello</h1>"
+
+
+def test_staticfiles_relative(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
+    app = StaticFiles(directory="tests/statics")
+    client = test_client_factory(app)
+    response = client.get("/example.txt")
+    assert response.status_code == 200
+    assert response.text == "123\n"
+
+
+def test_staticfiles_relative_symlinks(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
+    app = StaticFiles(directory="tests/statics", follow_symlink=True)
+    client = test_client_factory(app)
+    response = client.get("/example.txt")
+    assert response.status_code == 200
+    assert response.text == "123\n"

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -595,15 +595,7 @@ def test_staticfiles_self_symlinks(tmp_path: Path, test_client_factory: TestClie
     assert response.text == "<h1>Hello</h1>"
 
 
-def test_staticfiles_relative(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
-    app = StaticFiles(directory="tests/statics")
-    client = test_client_factory(app)
-    response = client.get("/example.txt")
-    assert response.status_code == 200
-    assert response.text == "123\n"
-
-
-def test_staticfiles_relative_symlinks(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
+def test_staticfiles_relative_directory_symlinks(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
     app = StaticFiles(directory="tests/statics", follow_symlink=True)
     client = test_client_factory(app)
     response = client.get("/example.txt")


### PR DESCRIPTION

# Summary

Fix for StaticFiles(follow_symlinks=True, directory="some relative path") that stopped working with commit eee4cdc.

When using StaticFiles with a relative path (e.g. a static folder included with the source code deployment) and follow_symlinks is set to True, the commit at eee4cdc removed the code that translates the relative folder into an absolute folder, and then the system call os.path.commonpath fails because it expects the arguments to either be all relative or all absolute.

This MR fixes this issue by using the same pattern as the full_path - os.abspath for follow_symlinks=True, and os.realpath when False. 


# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [-] I've updated the documentation accordingly.
