### PR TITLE
refactoring: `tests/middleware/test_middleware.py`

### DIFF
--- a/starlette/middleware/__init__.py
+++ b/starlette/middleware/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Iterator
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 if sys.version_info >= (3, 10):  # pragma: no cover
     from typing import ParamSpec
@@ -14,6 +14,7 @@ from starlette.types import ASGIApp
 P = ParamSpec("P")
 
 
+@runtime_checkable
 class _MiddlewareFactory(Protocol[P]):
     def __call__(self, app: ASGIApp, /, *args: P.args, **kwargs: P.kwargs) -> ASGIApp: ...  # pragma: no cover
 

--- a/tests/middleware/test_middleware.py
+++ b/tests/middleware/test_middleware.py
@@ -12,11 +12,21 @@ class CustomMiddleware:  # pragma: no cover
         await self.app(scope, receive, send)
 
 
-def test_middleware_repr() -> None:
-    middleware = Middleware(CustomMiddleware, "foo", bar=123)
-    assert repr(middleware) == "Middleware(CustomMiddleware, 'foo', bar=123)"
+class TestMiddleware:
+    custom_middleware = Middleware(CustomMiddleware, "foo", bar=123, baz="custom")
 
+    def test_created_instance(self) -> None:
+        custom_middleware = self.custom_middleware
+        assert isinstance(custom_middleware, Middleware)
+        assert custom_middleware.cls == CustomMiddleware
 
-def test_middleware_iter() -> None:
-    cls, args, kwargs = Middleware(CustomMiddleware, "foo", bar=123)
-    assert (cls, args, kwargs) == (CustomMiddleware, ("foo",), {"bar": 123})
+    def test_repr(self) -> None:
+        custom_middleware = self.custom_middleware
+        assert repr(custom_middleware) == "Middleware(CustomMiddleware, 'foo', bar=123, baz='custom')"
+
+    def test_iter(self) -> None:
+        custom_middleware = self.custom_middleware
+        cls, args, kwargs = custom_middleware
+        assert cls == custom_middleware.cls
+        assert args == ("foo",)
+        assert kwargs == {"bar": 123, "baz": "custom"}

--- a/tests/middleware/test_middleware.py
+++ b/tests/middleware/test_middleware.py
@@ -1,4 +1,4 @@
-from starlette.middleware import Middleware
+from starlette.middleware import Middleware, _MiddlewareFactory
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 
@@ -10,6 +10,10 @@ class CustomMiddleware:  # pragma: no cover
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         await self.app(scope, receive, send)
+
+
+def test_class_matches_middleware_protocol() -> None:
+    assert isinstance(CustomMiddleware, _MiddlewareFactory)
 
 
 class TestMiddleware:

--- a/tests/middleware/test_middleware.py
+++ b/tests/middleware/test_middleware.py
@@ -18,7 +18,7 @@ class TestMiddleware:
     def test_created_instance(self) -> None:
         custom_middleware = self.custom_middleware
         assert isinstance(custom_middleware, Middleware)
-        assert custom_middleware.cls == CustomMiddleware
+        assert custom_middleware.cls == CustomMiddleware  # type: ignore
 
     def test_repr(self) -> None:
         custom_middleware = self.custom_middleware


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This PR 
a) refactors the code of the `tests/middleware/test_middleware.py`. 
b) decorates `_MiddlewareFactory` with `@runtime_checkable` decorator. This enables usage of `isinstance()` with the protocol class.

It offers:
- more readable and more flexible code structure
- the tested middleware object is instantiated once per test class, and then re-used by test methods of the class.
- additional test added `test_created_instance()`, it shows that the created middleware object is an instance of `Middleware` and its `cls` attribute is equal to `CustomMiddleware`.
- additional test added `test_class_matches_middleware_protocol()`, showing that `CustomMiddleware` class is compliant with the `_MiddlewareFactory` protocol class 

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
