### PR TITLE
fix: make MultiPartParser read default max_part_size from the class attr

### DIFF
--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -134,7 +134,7 @@ class MultiPartParser:
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int = 1024 * 1024,  # 1MB
+        max_part_size: int | None = None,
     ) -> None:
         assert multipart is not None, "The `python-multipart` library must be installed to use form parsing."
         self.headers = headers
@@ -151,7 +151,8 @@ class MultiPartParser:
         self._file_parts_to_write: list[tuple[MultipartPart, bytes]] = []
         self._file_parts_to_finish: list[MultipartPart] = []
         self._files_to_close_on_error: list[SpooledTemporaryFile[bytes]] = []
-        self.max_part_size = max_part_size
+        if max_part_size is not None:
+            self.max_part_size = max_part_size
 
     def on_part_begin(self) -> None:
         self._current_part = MultipartPart()

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -254,7 +254,7 @@ class Request(HTTPConnection):
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int = 1024 * 1024,
+        max_part_size: int | None = None,
     ) -> FormData:
         if self._form is None:  # pragma: no branch
             assert parse_options_header is not None, (
@@ -289,7 +289,7 @@ class Request(HTTPConnection):
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int = 1024 * 1024,
+        max_part_size: int | None = None,
     ) -> AwaitableOrContextManager[FormData]:
         return AwaitableOrContextManagerWrapper(
             self._get_form(max_files=max_files, max_fields=max_fields, max_part_size=max_part_size)

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -104,7 +104,7 @@ async def app_read_body(scope: Scope, receive: Receive, send: Send) -> None:
     await response(scope, receive, send)
 
 
-def make_app_max_parts(max_files: int = 1000, max_fields: int = 1000, max_part_size: int = 1024 * 1024) -> ASGIApp:
+def make_app_max_parts(max_files: int = 1000, max_fields: int = 1000, max_part_size: int | None = None) -> ASGIApp:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)
         data = await request.form(max_files=max_files, max_fields=max_fields, max_part_size=max_part_size)


### PR DESCRIPTION
# Summary

 In FastAPI, the only way to change the maximum part size in a multipart request [is to override](https://github.com/fastapi/fastapi/discussions/12961) `MultiPartParser.max_part_size` globally. That has stopped working since the changes introduced by  [this commit](https://github.com/encode/starlette/pull/2815). I think the change in this PR is benign to keep. Even without considering compatibility with FastAPI, I think falling back to the class attribute to read the default value is a good idea but I don't mind if you think that problem should be addressed separately by FastAPI.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
