### PR TITLE
Mark http_exception as async to prevent thread creation.

### DIFF
--- a/starlette/middleware/exceptions.py
+++ b/starlette/middleware/exceptions.py
@@ -61,7 +61,7 @@ class ExceptionMiddleware:
 
         await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
 
-    def http_exception(self, request: Request, exc: Exception) -> Response:
+    async def http_exception(self, request: Request, exc: Exception) -> Response:
         assert isinstance(exc, HTTPException)
         if exc.status_code in {204, 304}:
             return Response(status_code=exc.status_code, headers=exc.headers)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,8 @@
+import typing
 from collections.abc import Generator
 
 import pytest
+from pytest import MonkeyPatch
 
 from starlette.exceptions import HTTPException, WebSocketException
 from starlette.middleware.exceptions import ExceptionMiddleware
@@ -184,3 +186,22 @@ def test_request_in_app_and_handler_is_the_same_object(client: TestClient) -> No
     response = client.post("/consume_body_in_endpoint_and_handler", content=b"Hello!")
     assert response.status_code == 422
     assert response.json() == {"body": "Hello!"}
+
+
+def test_http_exception_does_not_use_threadpool(client: TestClient, monkeypatch: MonkeyPatch) -> None:
+    """
+    Verify that handling HTTPException does not invoke run_in_threadpool,
+    confirming the handler correctly runs in the main async context.
+    """
+    from starlette import _exception_handler
+
+    # Replace run_in_threadpool with a function that raises an error
+    def mock_run_in_threadpool(*args: typing.Any, **kwargs: typing.Any) -> None:
+        pytest.fail("run_in_threadpool should not be called for HTTP exceptions")  # pragma: no cover
+
+    # Apply the monkeypatch only during this test
+    monkeypatch.setattr(_exception_handler, "run_in_threadpool", mock_run_in_threadpool)
+
+    # This should succeed because http_exception is async and won't use run_in_threadpool
+    response = client.get("/not_acceptable")
+    assert response.status_code == 406


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

In https://github.com/encode/starlette/blob/master/starlette/_exception_handler.py#L61 we check if the exception_handler is an async function and if not we execute it in a different thread. 
This is meant to ensure that long-running sync IO operations don't block the main async eventloop. 
However, in the case of [http_exception](https://github.com/encode/starlette/blob/master/starlette/middleware/exceptions.py#L64), a simple function that does not do any io at all - the aforementioned logic spawns a thread to run the function. 
Marking this function async is a simple way of making sure this function does not accidently cause a thread to be created.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
