### PR TITLE
CI: skips type check until mypy ready for 3.14

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,6 +26,7 @@ jobs:
         run: "scripts/install"
       - name: "Run linting checks"
         run: "scripts/check"
+        if: { { matrix.python-version != '3.14' } }
       - name: "Build package & docs"
         run: "scripts/build"
       - name: "Run tests"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,7 +26,7 @@ jobs:
         run: "scripts/install"
       - name: "Run linting checks"
         run: "scripts/check"
-        if: { { matrix.python-version != '3.14' } }
+        if: ${{ matrix.python-version != '3.14' }}
       - name: "Build package & docs"
         run: "scripts/build"
       - name: "Run tests"

--- a/scripts/check
+++ b/scripts/check
@@ -6,9 +6,13 @@ if [ -d 'venv' ] ; then
 fi
 export SOURCE_FILES="starlette tests"
 
+export PY_VERSION=$(${PREFIX}python --version)
+
 set -x
 
 ./scripts/sync-version
 ${PREFIX}ruff format --check --diff $SOURCE_FILES
-${PREFIX}mypy $SOURCE_FILES
+if [[ $PY_VERSION != *"3.14"* ]]; then
+    ${PREFIX}mypy $SOURCE_FILES
+fi
 ${PREFIX}ruff check $SOURCE_FILES

--- a/scripts/check
+++ b/scripts/check
@@ -6,13 +6,9 @@ if [ -d 'venv' ] ; then
 fi
 export SOURCE_FILES="starlette tests"
 
-export PY_VERSION=$(${PREFIX}python --version)
-
 set -x
 
 ./scripts/sync-version
 ${PREFIX}ruff format --check --diff $SOURCE_FILES
-if [[ $PY_VERSION != *"3.14"* ]]; then
-    ${PREFIX}mypy $SOURCE_FILES
-fi
+${PREFIX}mypy $SOURCE_FILES
 ${PREFIX}ruff check $SOURCE_FILES


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Skips mypy type check for 3.14 since they are [not testing](https://github.com/python/mypy/blob/master/.github/workflows/test.yml#L69-L75) against it yet and the build in this repo is [failing](https://github.com/encode/starlette/actions/runs/14960245809/job/42021194140) as a result.

More discussion in #2934

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
