### PR TITLE
Allow async exception handlers to type-check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "anyio>=3.6.2,<5",
-    "typing_extensions>=3.10.0; python_version < '3.10'",
+    "typing_extensions>=3.10.0; python_version < '3.13'",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "anyio>=3.6.2,<5",
-    "typing_extensions>=3.10.0; python_version < '3.13'",
+    "typing_extensions>=4.10.0; python_version < '3.13'",
 ]
 
 [project.optional-dependencies]

--- a/starlette/_exception_handler.py
+++ b/starlette/_exception_handler.py
@@ -58,7 +58,7 @@ def wrap_app_handling_exceptions(app: ASGIApp, conn: Request | WebSocket) -> ASG
             if is_async_callable(handler):
                 response = await handler(conn, exc)
             else:
-                response = await run_in_threadpool(handler, conn, exc)  # type: ignore
+                response = await run_in_threadpool(handler, conn, exc)
             if response is not None:
                 await response(scope, receive, sender)
 

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -9,10 +9,10 @@ from typing import Any, Callable, Generic, Protocol, TypeVar, overload
 
 from starlette.types import Scope
 
-if sys.version_info >= (3, 10):  # pragma: no cover
-    from typing import TypeGuard
+if sys.version_info >= (3, 13):  # pragma: no cover
+    from typing import TypeIs
 else:  # pragma: no cover
-    from typing_extensions import TypeGuard
+    from typing_extensions import TypeIs
 
 has_exceptiongroups = True
 if sys.version_info < (3, 11):  # pragma: no cover
@@ -26,11 +26,11 @@ AwaitableCallable = Callable[..., Awaitable[T]]
 
 
 @overload
-def is_async_callable(obj: AwaitableCallable[T]) -> TypeGuard[AwaitableCallable[T]]: ...
+def is_async_callable(obj: AwaitableCallable[T]) -> TypeIs[AwaitableCallable[T]]: ...
 
 
 @overload
-def is_async_callable(obj: Any) -> TypeGuard[AwaitableCallable[Any]]: ...
+def is_async_callable(obj: Any) -> TypeIs[AwaitableCallable[Any]]: ...
 
 
 def is_async_callable(obj: Any) -> Any:

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -80,7 +80,7 @@ class Starlette:
     def build_middleware_stack(self) -> ASGIApp:
         debug = self.debug
         error_handler = None
-        exception_handlers: dict[Any, Callable[[Request, Exception], Response]] = {}
+        exception_handlers: dict[Any, ExceptionHandler] = {}
 
         for key, value in self.exception_handlers.items():
             if key in (500, Exception):

--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -4,13 +4,12 @@ import html
 import inspect
 import sys
 import traceback
-from typing import Any, Callable
 
 from starlette._utils import is_async_callable
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, PlainTextResponse, Response
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from starlette.types import ASGIApp, ExceptionHandler, Message, Receive, Scope, Send
 
 STYLES = """
 p {
@@ -140,7 +139,7 @@ class ServerErrorMiddleware:
     def __init__(
         self,
         app: ASGIApp,
-        handler: Callable[[Request, Exception], Any] | None = None,
+        handler: ExceptionHandler | None = None,
         debug: bool = False,
     ) -> None:
         self.app = app

--- a/starlette/middleware/exceptions.py
+++ b/starlette/middleware/exceptions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Callable
+from typing import Any
 
 from starlette._exception_handler import (
     ExceptionHandlers,
@@ -11,7 +11,7 @@ from starlette._exception_handler import (
 from starlette.exceptions import HTTPException, WebSocketException
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, ExceptionHandler, Receive, Scope, Send
 from starlette.websockets import WebSocket
 
 
@@ -19,7 +19,7 @@ class ExceptionMiddleware:
     def __init__(
         self,
         app: ASGIApp,
-        handlers: Mapping[Any, Callable[[Request, Exception], Response]] | None = None,
+        handlers: Mapping[Any, ExceptionHandler] | None = None,
         debug: bool = False,
     ) -> None:
         self.app = app
@@ -36,7 +36,7 @@ class ExceptionMiddleware:
     def add_exception_handler(
         self,
         exc_class_or_status_code: int | type[Exception],
-        handler: Callable[[Request, Exception], Response],
+        handler: ExceptionHandler,
     ) -> None:
         if isinstance(exc_class_or_status_code, int):
             self._status_handlers[exc_class_or_status_code] = handler

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -65,7 +65,7 @@ def request_response(
     and returns an ASGI application.
     """
     f: Callable[[Request], Awaitable[Response]] = (
-        func if is_async_callable(func) else functools.partial(run_in_threadpool, func)  # type:ignore
+        func if is_async_callable(func) else functools.partial(run_in_threadpool, func)
     )
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -48,6 +48,14 @@ async def handler_that_reads_body(request: Request, exc: BadBodyException) -> JS
     return JSONResponse(status_code=422, content={"body": body.decode()})
 
 
+async def async_catch_all_handler(request: Request, exc: Exception) -> JSONResponse:
+    raise NotImplementedError
+
+
+def sync_catch_all_handler(request: Request, exc: Exception) -> JSONResponse:
+    raise NotImplementedError
+
+
 class HandledExcAfterResponse:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         response = PlainTextResponse("OK", status_code=200)
@@ -73,6 +81,9 @@ app = ExceptionMiddleware(
     router,
     handlers={BadBodyException: handler_that_reads_body},  # type: ignore[dict-item]
 )
+
+sync_catch_all = ExceptionMiddleware(router, handlers={Exception: sync_catch_all_handler})
+async_catch_all = ExceptionMiddleware(router, handlers={Exception: async_catch_all_handler})
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

There has been a lot of discussion around the exception handlers' type annotations, e.g., #2403 and #2048, but there is a simple case that isn't currently handled and can be fixed easily.

When building the `ExceptionMiddleware` directly, only sync handlers are accepted, even though the code can perfectly well handle async handlers. I think this was not noticed before because not many users instantiate this middleware directly, and when they do, the errors linked to the exceptions' variance always led to adding `# type: ignore`s, missing this simple error.

The fix is just to reuse the existing `ExceptionHandler` type alias.

I wasn't sure how to add tests for these changes. I added some code in `test_exceptions.py` that is just used to check there is not type error, let me know if there is another preferred approach.

While using the `ExceptionHandler` alias in a few places, it unearthed another error that can be solved by using [`TypeIs`](https://typing.python.org/en/latest/spec/narrowing.html#typeis) instead of [`TypeGuard`](https://typing.python.org/en/latest/spec/narrowing.html#typeguard) in `is_async_callable`. This fixes a few false positives from MyPy, though is not directly related to the initial change in this PR so I totally understand if you prefer I leave it out.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
