### PR TITLE
Yield message is a http response start type on BaseHTTPMiddleware

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -163,6 +163,10 @@ class BaseHTTPMiddleware:
 
             async def body_stream() -> BodyStreamGenerator:
                 async for message in recv_stream:
+                    if message["type"] == "http.response.start":
+                        yield message
+                        continue
+                        
                     if message["type"] == "http.response.pathsend":
                         yield message
                         break


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

I've been working with MCP servers using SSE transport methods. It turns out that the first message of a stream is of the `http.response.start` type, which raises an assertion since the current code expects an `http.response.body`. This PR adds a condition to handle that case: instead of raising an assertion, it yields the same message.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [] I've updated the documentation accordingly.
