### PR TITLE
Use `asyncio.iscoroutinefunction` for Python 3.12 and older

### DIFF
--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import inspect
 import sys
 from collections.abc import Awaitable, Generator
 from contextlib import AbstractAsyncContextManager, contextmanager
@@ -10,8 +9,11 @@ from typing import Any, Callable, Generic, Protocol, TypeVar, overload
 from starlette.types import Scope
 
 if sys.version_info >= (3, 13):  # pragma: no cover
+    from inspect import iscoroutinefunction
     from typing import TypeIs
 else:  # pragma: no cover
+    from asyncio import iscoroutinefunction
+
     from typing_extensions import TypeIs
 
 has_exceptiongroups = True
@@ -37,7 +39,7 @@ def is_async_callable(obj: Any) -> Any:
     while isinstance(obj, functools.partial):
         obj = obj.func
 
-    return inspect.iscoroutinefunction(obj) or (callable(obj) and inspect.iscoroutinefunction(obj.__call__))
+    return iscoroutinefunction(obj) or (callable(obj) and iscoroutinefunction(obj.__call__))
 
 
 T_co = TypeVar("T_co", covariant=True)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -1,5 +1,6 @@
 import functools
 from typing import Any
+from unittest.mock import create_autospec
 
 import pytest
 
@@ -81,6 +82,13 @@ def test_async_nested_partial() -> None:
     partial = functools.partial(async_func, b=2)
     nested_partial = functools.partial(partial, a=1)
     assert is_async_callable(nested_partial)
+
+
+def test_async_mocked_async_function() -> None:
+    async def async_func() -> None: ...  # pragma: no cover
+
+    mock = create_autospec(async_func)
+    assert is_async_callable(mock)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
inpsect.iscoroutinefunction still has issues with mocked coroutines, for example, until Python 3.13.

Resolves https://github.com/encode/starlette/discussions/2983

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
