### PR TITLE
Remove reference to publish script

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -166,5 +166,3 @@ Once the release PR is merged, create a
 
 Once created this release will be automatically uploaded to PyPI.
 
-If something goes wrong with the PyPI job the release can be published using the
-`scripts/publish` script.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,5 @@
 * `scripts/check` - Run the code linting, checking that it passes.
 * `scripts/coverage` - Check that code coverage is complete.
 * `scripts/build` - Build source and wheel packages.
-* `scripts/publish` - Publish the latest version to PyPI.
 
 Styled after GitHub's ["Scripts to Rule Them All"](https://github.com/github/scripts-to-rule-them-all).


### PR DESCRIPTION
# Summary
- This PR removes reference to publish script given that the publish file has been removed here https://github.com/Kludex/starlette/pull/3016

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
