### PR TITLE
test: add test for unknown status

### DIFF
--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -21,3 +21,11 @@ def test_deprecated_types(constant: str, msg: str) -> None:
         getattr(importlib.import_module("starlette.status"), constant)
         assert len(record) == 1
         assert msg in str(record.list[0])
+
+
+def test_unknown_status() -> None:
+    with pytest.raises(
+        AttributeError,
+        match="module 'starlette.status' has no attribute 'HTTP_999_UNKNOWN_STATUS_CODE'",
+    ):
+        getattr(importlib.import_module("starlette.status"), "HTTP_999_UNKNOWN_STATUS_CODE")


### PR DESCRIPTION
# Summary

This PR adds a test to ensure that accessing an unknown status code in starlette.status raises AttributeError.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.