### PR TITLE
Remove itsdangerous dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ Starlette only requires `anyio`, and the following are optional:
 * [`httpx`][httpx] - Required if you want to use the `TestClient`.
 * [`jinja2`][jinja2] - Required if you want to use `Jinja2Templates`.
 * [`python-multipart`][python-multipart] - Required if you want to support form parsing, with `request.form()`.
-* [`itsdangerous`][itsdangerous] - Required for `SessionMiddleware` support.
 * [`pyyaml`][pyyaml] - Required for `SchemaGenerator` support.
 
 You can install all of these with `pip install starlette[full]`.
@@ -135,7 +134,6 @@ in isolation.
 [httpx]: https://www.python-httpx.org/
 [jinja2]: https://jinja.palletsprojects.com/
 [python-multipart]: https://multipart.fastapiexpert.com/
-[itsdangerous]: https://itsdangerous.palletsprojects.com/
 [sqlalchemy]: https://www.sqlalchemy.org
 [pyyaml]: https://pyyaml.org/wiki/PyYAMLDocumentation
 [techempower]: https://www.techempower.com/benchmarks/#hw=ph&test=fortune&l=zijzen-sf

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,7 +109,6 @@ Starlette only requires `anyio`, and the following dependencies are optional:
 * [`httpx`][httpx] - Required if you want to use the `TestClient`.
 * [`jinja2`][jinja2] - Required if you want to use `Jinja2Templates`.
 * [`python-multipart`][python-multipart] - Required if you want to support form parsing, with `request.form()`.
-* [`itsdangerous`][itsdangerous] - Required for `SessionMiddleware` support.
 * [`pyyaml`][pyyaml] - Required for `SchemaGenerator` support.
 
 You can install all of these with `pip install starlette[full]`.
@@ -156,7 +155,6 @@ in isolation.
 [httpx]: https://www.python-httpx.org/
 [jinja2]: https://jinja.palletsprojects.com/
 [python-multipart]: https://multipart.fastapiexpert.com/
-[itsdangerous]: https://itsdangerous.palletsprojects.com/
 [sqlalchemy]: https://www.sqlalchemy.org
 [pyyaml]: https://pyyaml.org/wiki/PyYAMLDocumentation
 [techempower]: https://www.techempower.com/benchmarks/#hw=ph&test=fortune&l=zijzen-sf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
 
 [project.optional-dependencies]
 full = [
-    "itsdangerous",
     "jinja2",
     "python-multipart>=0.0.18",
     "pyyaml",

--- a/starlette/signing.py
+++ b/starlette/signing.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+
+from starlette.datastructures import Secret
+
+
+class TimestampSigner:
+    """
+    Signs and unsigns data with HMAC-SHA256 and timestamp validation.
+
+    Format: <b64(payload+timestamp)><b64(signature)>_
+    """
+
+    def __init__(self, secret: str | Secret) -> None:
+        """
+        Initialize signer with a secret key.
+
+        Args:
+            secret: Secret key for HMAC signing
+        """
+        self._secret = str(secret).encode("utf-8")
+
+    def sign(self, data: bytes) -> bytes:
+        """
+        Sign data with current timestamp.
+
+        Args:
+            data: Raw data to sign
+
+        Returns:
+            Signed token as bytes
+        """
+        timestamp_bytes = int(time.time()).to_bytes(5, "big")
+
+        combined = data + timestamp_bytes
+        combined_encoded = _b64_encode(combined)
+
+        signature = hmac.HMAC(self._secret, combined_encoded, hashlib.sha256).digest()[:16]
+        signature_encoded = _b64_encode(signature)
+
+        return combined_encoded + (signature_encoded + b"_")
+
+    def unsign(self, signed_data: bytes, max_age: int | None = None) -> bytes | None:
+        """
+        Verify and extract data from signed token.
+
+        Args:
+            signed_data: Signed token
+            max_age: Maximum age in seconds (optional)
+
+        Returns:
+            Payload bytes on success, None on failure
+        """
+        # Quick pre-checks
+        if len(signed_data) < 30 or signed_data[-1] != 95:
+            return None
+
+        signature_encoded = signed_data[-23:-1]
+        signature = _b64_decode(signature_encoded)
+        if signature is None or len(signature) != 16:
+            return None
+
+        combined_encoded = signed_data[:-23]
+        expected_signature = hmac.HMAC(self._secret, combined_encoded, hashlib.sha256).digest()[:16]
+        if not hmac.compare_digest(signature, expected_signature):
+            return None
+
+        combined = _b64_decode(combined_encoded)
+        if combined is None:  # pragma: no cover
+            return None
+
+        # Check timestamp age if max_age is set
+        if max_age is not None:
+            timestamp_bytes = combined[-5:]
+            timestamp = int.from_bytes(timestamp_bytes, "big")
+            if time.time() - timestamp > max_age:
+                return None
+
+        data = combined[:-5]
+        return data
+
+
+def _b64_encode(data: bytes) -> bytes:
+    """Encode bytes to base64url format without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+
+def _b64_decode(data: bytes) -> bytes | None:
+    """Decode base64url format, adding padding if needed. Returns None on error."""
+    # Add padding if needed
+    padding = 4 - (len(data) % 4)
+    if padding != 4:
+        data = data + b"=" * padding
+
+    try:
+        return base64.urlsafe_b64decode(data)
+    except Exception:
+        return None

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -1,0 +1,156 @@
+from unittest import mock
+
+from starlette.signing import TimestampSigner, _b64_decode, _b64_encode
+
+
+class TestTimestampSigner:
+    def test_sign_basic(self) -> None:
+        signer = TimestampSigner("secret")
+        signed = signer.sign(b"hello")
+        assert isinstance(signed, bytes)
+        assert len(signed) > 30
+
+    def test_round_trip(self) -> None:
+        signer = TimestampSigner("secret")
+        test_cases = [
+            b"",
+            b"a",
+            b"hello world",
+            b"\x00\x01\x02\xff\xfe\xfd",
+            b"\x00\x00\x00\x00",
+            b"x" * 1000,
+            b'{"user": "alice", "id": 123}',
+            "Hello 世界 🌍".encode(),
+        ]
+        for data in test_cases:
+            signed = signer.sign(data)
+            unsigned = signer.unsign(signed)
+            assert unsigned == data
+
+    def test_output_is_ascii(self) -> None:
+        signer = TimestampSigner("secret")
+        data = "Hello 世界 🌍".encode()
+        signed = signer.sign(data)
+        signed.decode("ascii")
+        assert all(b < 128 for b in signed)
+
+    def test_no_padding_in_output(self) -> None:
+        signer = TimestampSigner("secret")
+        for size in range(10):
+            data = b"x" * size
+            signed = signer.sign(data)
+            assert b"=" not in signed
+
+    def test_no_forbidden_characters(self) -> None:
+        signer = TimestampSigner("secret")
+        forbidden = set(b' ,;"\\')
+        test_data = [
+            b"simple",
+            b'{"user": "alice", "roles": ["admin"]}',
+            b"\x00\xff" * 10,
+            b"x" * 10,
+        ]
+        for data in test_data:
+            signed = signer.sign(data)
+            assert not any(c in forbidden for c in signed)
+            valid_chars = set(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+            assert all(c in valid_chars for c in signed)
+
+
+class TestTimestampValidation:
+    def test_unsign_with_valid_max_age(self) -> None:
+        signer = TimestampSigner("secret")
+        signed = signer.sign(b"data")
+        assert signer.unsign(signed, max_age=10) == b"data"
+        assert signer.unsign(signed, max_age=1000) == b"data"
+
+    def test_unsign_with_expired_max_age(self) -> None:
+        signer = TimestampSigner("secret")
+        with mock.patch("time.time", return_value=1000):
+            signed = signer.sign(b"data")
+
+        with mock.patch("time.time", return_value=1003):
+            assert signer.unsign(signed, max_age=1) is None
+            assert signer.unsign(signed, max_age=0) is None
+
+        assert signer.unsign(signed, max_age=None) == b"data"
+
+
+class TestSecurityAttacks:
+    def test_tampered_signature(self) -> None:
+        signer = TimestampSigner("secret")
+        signed = signer.sign(b"data")
+
+        tampered_byte = bytes([signed[-23] ^ 0xFF])
+        tampered = signed[:-23] + tampered_byte + signed[-22:]
+        assert signer.unsign(tampered) is None
+
+        tampered_byte = bytes([signed[-12] ^ 0xFF])
+        tampered = signed[:-12] + tampered_byte + signed[-11:]
+        assert signer.unsign(tampered) is None
+
+    def test_tampered_payload(self) -> None:
+        signer = TimestampSigner("secret")
+        signed = signer.sign(b"data")
+        tampered = b"XXXX" + signed[4:]
+        assert signer.unsign(tampered) is None
+
+    def test_signature_from_different_payload(self) -> None:
+        signer = TimestampSigner("secret")
+        signed1 = signer.sign(b"data1")
+        signed2 = signer.sign(b"data2")
+
+        combined1 = signed1[:-23]
+        suffix2 = signed2[-23:]
+        mixed = combined1 + suffix2
+        assert signer.unsign(mixed) is None
+
+
+class TestMalformedData:
+    def test_minimum_length_requirement(self) -> None:
+        signer = TimestampSigner("secret")
+        assert signer.unsign(b"") is None
+        assert signer.unsign(b"a") is None
+        assert signer.unsign(b"a" * 20) is None
+        assert signer.unsign(b"a" * 29) is None
+        assert signer.unsign(b"short_") is None
+        assert signer.unsign(b"a" * 29 + b"_") is None
+
+    def test_missing_version_marker(self) -> None:
+        signer = TimestampSigner("secret")
+        signed = signer.sign(b"data")
+
+        without_marker = signed[:-1]
+        assert signer.unsign(without_marker) is None
+
+        wrong_marker = signed[:-1] + b"X"
+        assert signer.unsign(wrong_marker) is None
+
+    def test_invalid_base64_in_combined_data(self) -> None:
+        signer = TimestampSigner("secret")
+        signed = signer.sign(b"data")
+        tampered = b"!!!!!!AAAAA" + signed[-23:]
+        assert signer.unsign(tampered) is None
+
+    def test_invalid_base64_in_signature(self) -> None:
+        signer = TimestampSigner("secret")
+        signed = signer.sign(b"data")
+        tampered = signed[:-23] + b"!" * 22 + b"_"
+        assert signer.unsign(tampered) is None
+
+
+class TestBase64UrlHelpers:
+    def test_encode_basic(self) -> None:
+        assert _b64_encode(b"hello") == b"aGVsbG8"
+        assert _b64_encode(b"") == b""
+
+    def test_decode_invalid_returns_none(self) -> None:
+        assert _b64_decode(b"A") is None
+        assert _b64_decode(b"AAAAA") is None
+
+    def test_round_trip(self) -> None:
+        test_cases = [b"", b"a", b"hello world", b"\x00\x01\x02\xff\xfe\xfd"]
+        for data in test_cases:
+            encoded = _b64_encode(data)
+            decoded = _b64_decode(encoded)
+            assert decoded == data

--- a/uv.lock
+++ b/uv.lock
@@ -461,15 +461,6 @@ wheels = [
 ]
 
 [[package]]
-name = "itsdangerous"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
-]
-
-[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1177,7 +1168,6 @@ dependencies = [
 [package.optional-dependencies]
 full = [
     { name = "httpx" },
-    { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "python-multipart" },
     { name = "pyyaml" },
@@ -1206,7 +1196,6 @@ docs = [
 requires-dist = [
     { name = "anyio", specifier = ">=3.6.2,<5" },
     { name = "httpx", marker = "extra == 'full'", specifier = ">=0.27.0,<0.29.0" },
-    { name = "itsdangerous", marker = "extra == 'full'" },
     { name = "jinja2", marker = "extra == 'full'" },
     { name = "python-multipart", marker = "extra == 'full'", specifier = ">=0.0.18" },
     { name = "pyyaml", marker = "extra == 'full'" },


### PR DESCRIPTION
# Summary

I've always disliked installing itsdangerous dependency just for basic SessionMiddleware functionality. The itsdangerous has lots of features but the amount of functionality needed by starlette is minimal. I decided to prepare starlette-optimized TimestampSigner implementation that has several benefits:

- No dependency, better UX
- Simple, no-fuss implementation
- Uses SHA-256/128 HMAC instead of SHA-1 HMAC
- Smaller signed tokens
- Faster

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

---

I also prepared a small benchmark script:

[benchmark_signing.py](https://github.com/user-attachments/files/23351791/benchmark_signing.py)

`uv run --with itsdangerous python benchmark_signing.py`

```txt
Input: {'user_id': 12345, 'username': 'alice', 'roles': ['admin', 'user']}

itsdangerous:
eyJ1c2VyX2lkIjogMTIzNDUsICJ1c2VybmFtZSI6ICJhbGljZSIsICJyb2xlcyI6IFsiYWRtaW4iLCAidXNlciJdfQ==.aQroow.EK2o0veXJdxMfN724EJaqjwjsQo

starlette.signing:
eyJ1c2VyX2lkIjogMTIzNDUsICJ1c2VybmFtZSI6ICJhbGljZSIsICJyb2xlcyI6IFsiYWRtaW4iLCAidXNlciJdfQBpCuijLtC0_yYQrfToZiZsjFCBzA_

Size: 127b → 119b (6.3% smaller)

Sign:          4.26 μs → 2.58 μs (1.65x faster)
Unsign (valid): 6.61 μs → 3.98 μs (1.66x faster)
Unsign (invalid): 2.47 μs → 0.07 μs (33.60x faster)
```