### PR TITLE
✨ Add `max_body_size` parameter to `Request.stream()` and related methods

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -226,6 +226,14 @@ class Request(HTTPConnection[StateT]):
         return self._receive
 
     async def stream(self, max_body_size: int | None = None) -> AsyncGenerator[bytes, None]:
+        if max_body_size is not None:
+            content_length = self.headers.get("content-length")
+            if content_length is not None:
+                try:
+                    if int(content_length) > max_body_size:
+                        raise HTTPException(status_code=413, detail="Content Too Large")
+                except ValueError:
+                    pass
         if hasattr(self, "_body"):
             if max_body_size is not None and len(self._body) > max_body_size:
                 raise HTTPException(status_code=413, detail="Content Too Large")

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -262,7 +262,7 @@ class Request(HTTPConnection[StateT]):
         return self._body
 
     async def json(self, max_body_size: int | None = None) -> Any:
-        if not hasattr(self, "_json"):  # pragma: no branch
+        if not hasattr(self, "_json"):
             body = await self.body(max_body_size=max_body_size)
             self._json = json.loads(body)
         elif max_body_size is not None:

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -315,7 +315,9 @@ class Request(HTTPConnection[StateT]):
         max_body_size: int | None = None,
     ) -> AwaitableOrContextManager[FormData]:
         return AwaitableOrContextManagerWrapper(
-            self._get_form(max_files=max_files, max_fields=max_fields, max_part_size=max_part_size, max_body_size=max_body_size)
+            self._get_form(
+                max_files=max_files, max_fields=max_fields, max_part_size=max_part_size, max_body_size=max_body_size
+            )
         )
 
     async def close(self) -> None:


### PR DESCRIPTION
✨ Add `max_body_size` parameter to `Request.stream()` and related methods

https://github.com/Kludex/starlette/pull/3151 might be a better approach, implementing things as suggested by @Kludex 

<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

When a body size is too large, raise an exception of "413 Content Too Large".

This is done in `Request.stream()`, so it errors out before consuming the data (and storing stuff in memory).

It also errors out even when the data is already cached for consistency, e.g. `Request.body()` cached the data once with a large body and `Request.body(max_body_size=5)` is called right after.

This would hopefully fix / related to https://github.com/Kludex/starlette/issues/2155

Having it in this place in the `Request` (instead of a middleware) would let me use it in FastAPI how I need it, would allow me to set parameters in the app, router, and path operation levels.

## Questions

I don't know if Starlette would like to have other parameters, e.g. at the app level, or some middleware that sets a parameter, and then it could be read by the request from the ASGI scope.

## AI disclaimer

I used AI to help write the code and tests, then I manually reviewed carefully all the code and adjusted, reverted (and unreverted :sweat_smile: ) some changes.

The original prompt:

```
Implement a `max_body_size` in `Request.stream`

If the stream is beyond the size in bytes, raise an HTTPException

Pass the same `max_body_size` to `Request.body`, `Request.form` and `Request.json`

Implement tests for it

Use the venv in .venv
```

Using Claude Opus 4.5 (and 4.6).

There were some manual adjustments and additional prompts, etc.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
    - I will update the docs after we confirm this makes sense, and/or add any other configs needed.