### PR TITLE
Raise WebSocketDisconnect instead of RuntimeError on send after close

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -95,7 +95,7 @@ class WebSocket(HTTPConnection[StateT]):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            raise WebSocketDisconnect(code=1000)
 
     async def accept(
         self,

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -449,9 +449,24 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect) as exc:
         with client.websocket_connect("/"):
             pass  # pragma: no cover
+    assert exc.value.code == status.WS_1000_NORMAL_CLOSURE
+
+
+def test_send_after_close(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive=receive, send=send)
+        await websocket.accept()
+        await websocket.close()
+        await websocket.send_text("hello")
+
+    client = test_client_factory(app)
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/"):
+            pass  # pragma: no cover
+    assert exc.value.code == status.WS_1000_NORMAL_CLOSURE
 
 
 def test_duplicate_disconnect(test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
## Summary

When a WebSocket connection is already disconnected (application has sent a close message) and another coroutine tries to `send()` or `close()`, the current code raises a generic `RuntimeError('Cannot call "send" once a close message has been sent.')`. This makes it difficult for application code to handle the specific case programmatically, as it requires matching error message strings.

This PR changes the behavior to raise `WebSocketDisconnect(code=1000)` instead, which:
- Is consistent with the existing pattern where `OSError` during send is already converted to `WebSocketDisconnect(code=1006)` (line 89)
- Allows application code to catch the specific exception type
- Is especially useful in concurrent scenarios where multiple coroutines may try to close the same WebSocket

## Changes

- **`starlette/websockets.py`**: Replace `RuntimeError` with `WebSocketDisconnect(code=1000)` in the `send()` method's disconnected state branch
- **`tests/test_websockets.py`**: Update `test_duplicate_close` to expect `WebSocketDisconnect` instead of `RuntimeError`, and add `test_send_after_close` to cover sending text after close

## Context

This was discussed in #2762 where @Kludex concluded:
> "I think it makes more sense to raise WebSocketDisconnect instead of RuntimeError when the application state is disconnected."
> "I believe the exception is the way to go."

Fixes #2766

🤖 Generated with [Claude Code](https://claude.com/claude-code)