### PR TITLE
Raise WebSocketDisconnect instead of RuntimeError on send after close

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -95,7 +95,7 @@ class WebSocket(HTTPConnection[StateT]):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            raise WebSocketDisconnect(code=1000)
 
     async def accept(
         self,

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -449,9 +449,24 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect) as exc:
         with client.websocket_connect("/"):
             pass  # pragma: no cover
+    assert exc.value.code == status.WS_1000_NORMAL_CLOSURE
+
+
+def test_send_after_close(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive=receive, send=send)
+        await websocket.accept()
+        await websocket.close()
+        await websocket.send_text("hello")
+
+    client = test_client_factory(app)
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/"):
+            pass  # pragma: no cover
+    assert exc.value.code == status.WS_1000_NORMAL_CLOSURE
 
 
 def test_duplicate_disconnect(test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
## Summary

When application code calls `send()` on a WebSocket that has already been closed, the current behavior raises a `RuntimeError` with the message _"Cannot call 'send' once a close message has been sent."_

This is inconsistent with other WebSocket error handling in Starlette — for example, `OSError` during send is already caught and re-raised as `WebSocketDisconnect(code=1006)` (line 89). The inconsistency forces application code to catch both `RuntimeError` and `WebSocketDisconnect` separately to handle all post-close scenarios.

**This PR changes the `else` branch in `WebSocket.send()` (line 98) to raise `WebSocketDisconnect(code=1000)` instead of `RuntimeError`.**

This means application code can use a single `except WebSocketDisconnect` handler for all WebSocket lifecycle errors, which is particularly useful in concurrent patterns where a close can race with pending sends.

## Changes

- `starlette/websockets.py`: Replace `RuntimeError` with `WebSocketDisconnect(code=1000)` in the `DISCONNECTED` state branch of `send()`
- `tests/test_websockets.py`: Update `test_duplicate_close` to expect `WebSocketDisconnect` with code 1000; add `test_send_after_close` covering the `send_text()` after `close()` scenario

## Test plan

- [x] `test_duplicate_close` — verifies double-close raises `WebSocketDisconnect(code=1000)`
- [x] `test_send_after_close` — verifies `send_text()` after `close()` raises `WebSocketDisconnect(code=1000)`
- [x] Existing test suite passes (no other tests depend on the `RuntimeError` from this code path)

Fixes #2766

🤖 Generated with [Claude Code](https://claude.com/claude-code)