### PR TITLE
Fix StreamingResponse and FileResponse with websocket denial responses

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -23,7 +23,19 @@ from starlette.background import BackgroundTask
 from starlette.concurrency import iterate_in_threadpool
 from starlette.datastructures import URL, Headers, MutableHeaders
 from starlette.requests import ClientDisconnect
-from starlette.types import Receive, Scope, Send
+from starlette.types import Message, Receive, Scope, Send
+
+
+def _wrap_send_for_websocket(send: Send, scope: Scope) -> Send:
+    if scope.get("type") != "websocket":
+        return send
+
+    async def websocket_send(message: Message) -> None:
+        if message["type"].startswith("http.response."):
+            message["type"] = "websocket." + message["type"]
+        await send(message)
+
+    return websocket_send
 
 
 class Response:
@@ -257,6 +269,7 @@ class StreamingResponse(Response):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        send = _wrap_send_for_websocket(send, scope)
         spec_version = tuple(map(int, scope.get("asgi", {}).get("spec_version", "2.0").split(".")))
 
         if spec_version >= (2, 4):
@@ -334,6 +347,7 @@ class FileResponse(Response):
         self.headers.setdefault("etag", etag)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        send = _wrap_send_for_websocket(send, scope)
         send_header_only: bool = scope["method"].upper() == "HEAD"
         send_pathsend: bool = "http.response.pathsend" in scope.get("extensions", {})
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -7,7 +7,7 @@ import pytest
 from anyio.abc import ObjectReceiveStream, ObjectSendStream
 
 from starlette import status
-from starlette.responses import Response
+from starlette.responses import Response, StreamingResponse
 from starlette.testclient import WebSocketDenialResponse
 from starlette.types import Message, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
@@ -612,3 +612,24 @@ def test_receive_wrong_message_type(test_client_factory: TestClientFactory) -> N
     with pytest.raises(RuntimeError):
         with client.websocket_connect("/") as websocket:
             websocket.send({"type": "websocket.connect"})
+
+
+def test_send_denial_streaming_response(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive=receive, send=send)
+        msg = await websocket.receive()
+        assert msg == {"type": "websocket.connect"}
+
+        async def body_iterator():
+            yield b"hello "
+            yield b"world"
+
+        response = StreamingResponse(content=body_iterator(), status_code=403)
+        await websocket.send_denial_response(response)
+
+    client = test_client_factory(app)
+    with pytest.raises(WebSocketDenialResponse) as exc:
+        with client.websocket_connect("/"):
+            pass  # pragma: no cover
+    assert exc.value.status_code == 403
+    assert exc.value.content == b"hello world"


### PR DESCRIPTION
## Summary

`StreamingResponse` and `FileResponse` override `__call__` but hardcode ASGI message types as `http.response.start` / `http.response.body` without adding the `websocket.` prefix that the base `Response` class handles. This causes a `RuntimeError` when passing either of these response types to `WebSocket.send_denial_response()`.

The fix wraps the `send` callable in both `StreamingResponse.__call__` and `FileResponse.__call__` to rewrite message types when the scope is a websocket connection. This keeps the existing method signatures intact and avoids touching the internal helper methods.

Fixes #3048

## Test plan

- Added `test_send_denial_streaming_response` that verifies `StreamingResponse` works with `send_denial_response`
- All existing websocket and response tests pass