### PR TITLE
Make `spool_max_size` configurable via `request.form()`

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -131,7 +131,7 @@ MultiPartParser.spool_max_size = 100 * 1024 * 1024  # 100 MB
 MultiPartParser.max_part_size = 10 * 1024 * 1024  # 10 MB
 ```
 
-These defaults apply whenever `request.form()` is called without explicit values, which is useful for frameworks like FastAPI that call `request.form()` internally.
+These defaults apply whenever `request.form()` is called without explicit values.
 
 !!! info
     These limits are for security reasons, allowing an unlimited number of fields or files could lead to a denial of service attack by consuming a lot of CPU and memory parsing too many empty fields.

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -113,12 +113,12 @@ state with `disconnected = await request.is_disconnected()`.
 
 Request files are normally sent as multipart form data (`multipart/form-data`).
 
-Signature: `request.form(max_files=1000, max_fields=1000, max_part_size=1024*1024)`
+Signature: `request.form(max_files=1000, max_fields=1000, max_part_size=1024*1024, spool_max_size=1024*1024)`
 
-You can configure the number of maximum fields or files with the parameters `max_files` and `max_fields`; and part size using `max_part_size`:
+You can configure the number of maximum fields or files with the parameters `max_files` and `max_fields`; part size using `max_part_size`; and the in-memory spool size before uploaded files roll over to disk using `spool_max_size`:
 
 ```python
-async with request.form(max_files=1000, max_fields=1000, max_part_size=1024*1024):
+async with request.form(max_files=1000, max_fields=1000, max_part_size=1024*1024, spool_max_size=1024*1024):
     ...
 ```
 

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -113,7 +113,7 @@ state with `disconnected = await request.is_disconnected()`.
 
 Request files are normally sent as multipart form data (`multipart/form-data`).
 
-Signature: `request.form(max_files=1000, max_fields=1000, max_part_size=1024*1024, spool_max_size=1024*1024)`
+Signature: `request.form(max_files=1000, max_fields=1000, max_part_size=<default>, spool_max_size=<default>)`
 
 You can configure the number of maximum fields or files with the parameters `max_files` and `max_fields`; part size using `max_part_size`; and the in-memory spool size before uploaded files roll over to disk using `spool_max_size`:
 
@@ -122,7 +122,7 @@ async with request.form(max_files=1000, max_fields=1000, max_part_size=1024*1024
     ...
 ```
 
-You can also set `max_part_size` and `spool_max_size` globally via class attributes on `MultiPartParser`:
+The defaults for `max_part_size` and `spool_max_size` are read from class attributes on `MultiPartParser` (both default to 1MB). You can set them globally:
 
 ```python
 from starlette.formparsers import MultiPartParser

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -122,6 +122,17 @@ async with request.form(max_files=1000, max_fields=1000, max_part_size=1024*1024
     ...
 ```
 
+You can also set `max_part_size` and `spool_max_size` globally via class attributes on `MultiPartParser`:
+
+```python
+from starlette.formparsers import MultiPartParser
+
+MultiPartParser.spool_max_size = 100 * 1024 * 1024  # 100 MB
+MultiPartParser.max_part_size = 10 * 1024 * 1024  # 10 MB
+```
+
+These defaults apply whenever `request.form()` is called without explicit values, which is useful for frameworks like FastAPI that call `request.form()` internally.
+
 !!! info
     These limits are for security reasons, allowing an unlimited number of fields or files could lead to a denial of service attack by consuming a lot of CPU and memory parsing too many empty fields.
 

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -113,7 +113,7 @@ state with `disconnected = await request.is_disconnected()`.
 
 Request files are normally sent as multipart form data (`multipart/form-data`).
 
-Signature: `request.form(max_files=1000, max_fields=1000, max_part_size=<default>, spool_max_size=<default>)`
+Signature: `request.form(max_files=1000, max_fields=1000, max_part_size=1024*1024, spool_max_size=1024*1024)`
 
 You can configure the number of maximum fields or files with the parameters `max_files` and `max_fields`; part size using `max_part_size`; and the in-memory spool size before uploaded files roll over to disk using `spool_max_size`:
 

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -122,8 +122,9 @@ class FormParser:
         return FormData(items)
 
 
-class _Unset:  # pragma: no cover
-    ...
+class _Unset:
+    def __repr__(self) -> str:  # pragma: no cover
+        return "<default>"
 
 
 _UNSET = _Unset()

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -123,20 +123,27 @@ class FormParser:
 
 
 class MultiPartParser:
-    spool_max_size = 1024 * 1024  # 1MB
-    """The maximum size of the spooled temporary file used to store file data."""
-    max_part_size = 1024 * 1024  # 1MB
-    """The maximum size of a part in the multipart request."""
-
     def __init__(
         self,
         headers: Headers,
-        stream: AsyncGenerator[bytes, None],
+        stream: AsyncGenerator[bytes],
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
         max_part_size: int = 1024 * 1024,  # 1MB
+        spool_max_size: int = 1024 * 1024,  # 1MB
     ) -> None:
+        """Parse multipart form data from an incoming request.
+
+        Args:
+            headers: The request headers, used to extract the multipart boundary.
+            stream: An async generator yielding request body chunks.
+            max_files: Maximum number of file parts allowed.
+            max_fields: Maximum number of non-file field parts allowed.
+            max_part_size: Maximum size in bytes for a single non-file part.
+            spool_max_size: Maximum size in bytes for the in-memory spool of each uploaded file before it rolls over
+                to disk.
+        """
         assert multipart is not None, "The `python-multipart` library must be installed to use form parsing."
         self.headers = headers
         self.stream = stream
@@ -153,6 +160,7 @@ class MultiPartParser:
         self._file_parts_to_finish: list[MultipartPart] = []
         self._files_to_close_on_error: list[SpooledTemporaryFile[bytes]] = []
         self.max_part_size = max_part_size
+        self.spool_max_size = spool_max_size
 
     def on_part_begin(self) -> None:
         self._current_part = MultipartPart()

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -122,7 +122,34 @@ class FormParser:
         return FormData(items)
 
 
+class _RemovedAttribute:
+    """Descriptor that raises a helpful error when a removed class attribute is accessed.
+
+    This is a data descriptor: instance access goes through ``__get__``/``__set__``
+    so that ``self.attr = value`` in ``__init__`` stores into the instance ``__dict__``
+    and later reads return that value, while *class-level* access
+    (``MultiPartParser.attr``) raises an ``AttributeError`` with migration guidance.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __set__(self, obj: object, value: int) -> None:
+        obj.__dict__[self.name] = value
+
+    def __get__(self, obj: object | None, objtype: type | None = None) -> int:
+        if obj is not None:
+            return obj.__dict__[self.name]  # type: ignore[no-any-return]
+        raise AttributeError(
+            f"Accessing `{self.name}` as a class variable is no longer supported. "
+            f"Use the `{self.name}` parameter on `MultiPartParser()` or `request.form()` instead."
+        )
+
+
 class MultiPartParser:
+    spool_max_size = _RemovedAttribute("spool_max_size")
+    max_part_size = _RemovedAttribute("max_part_size")
+
     def __init__(
         self,
         headers: Headers,

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -122,12 +122,18 @@ class FormParser:
         return FormData(items)
 
 
-_Unset = type("_Unset", (), {"__repr__": lambda self: "_Unset"})()
+class _Unset:  # pragma: no cover
+    ...
+
+
+_UNSET = _Unset()
 
 
 class MultiPartParser:
     spool_max_size: int = 1024 * 1024  # 1MB
+    """The maximum size of the spooled temporary file used to store file data."""
     max_part_size: int = 1024 * 1024  # 1MB
+    """The maximum size of a part in the multipart request."""
 
     def __init__(
         self,
@@ -136,20 +142,9 @@ class MultiPartParser:
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int = _Unset,
-        spool_max_size: int = _Unset,
+        max_part_size: int | _Unset = _UNSET,
+        spool_max_size: int | _Unset = _UNSET,
     ) -> None:
-        """Parse multipart form data from an incoming request.
-
-        Args:
-            headers: The request headers, used to extract the multipart boundary.
-            stream: An async generator yielding request body chunks.
-            max_files: Maximum number of file parts allowed.
-            max_fields: Maximum number of non-file field parts allowed.
-            max_part_size: Maximum size in bytes for a single non-file part. Falls back to the class attribute.
-            spool_max_size: Maximum size in bytes for the in-memory spool of each uploaded file before it rolls over
-                to disk. Falls back to the class attribute.
-        """
         assert multipart is not None, "The `python-multipart` library must be installed to use form parsing."
         self.headers = headers
         self.stream = stream
@@ -165,8 +160,8 @@ class MultiPartParser:
         self._file_parts_to_write: list[tuple[MultipartPart, bytes]] = []
         self._file_parts_to_finish: list[MultipartPart] = []
         self._files_to_close_on_error: list[SpooledTemporaryFile[bytes]] = []
-        self._max_part_size = max_part_size if max_part_size is not _Unset else type(self).max_part_size
-        self._spool_max_size = spool_max_size if spool_max_size is not _Unset else type(self).spool_max_size
+        self._max_part_size = type(self).max_part_size if isinstance(max_part_size, _Unset) else max_part_size
+        self._spool_max_size = type(self).spool_max_size if isinstance(spool_max_size, _Unset) else spool_max_size
 
     def on_part_begin(self) -> None:
         self._current_part = MultipartPart()

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -124,6 +124,7 @@ class FormParser:
 
 class _Unset:
     def __repr__(self) -> str:  # pragma: no cover
+        # Shown in inspect.signature() output for parameters that fall back to class attributes.
         return "<default>"
 
 
@@ -206,7 +207,7 @@ class MultiPartParser:
         self._current_partial_header_value = b""
 
     def on_headers_finished(self) -> None:
-        disposition, options = parse_options_header(self._current_part.content_disposition)
+        _disposition, options = parse_options_header(self._current_part.content_disposition)
         try:
             self._current_part.field_name = _user_safe_decode(options[b"name"], self._charset)
         except KeyError:

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from enum import Enum
 from tempfile import SpooledTemporaryFile
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import unquote_plus
 
 from starlette.datastructures import FormData, Headers, UploadFile
@@ -130,9 +130,9 @@ _UNSET = _Unset()
 
 
 class MultiPartParser:
-    spool_max_size: int = 1024 * 1024  # 1MB
+    spool_max_size: ClassVar[int] = 1024 * 1024  # 1MB
     """The maximum size of the spooled temporary file used to store file data."""
-    max_part_size: int = 1024 * 1024  # 1MB
+    max_part_size: ClassVar[int] = 1024 * 1024  # 1MB
     """The maximum size of a part in the multipart request."""
 
     def __init__(

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -165,10 +165,8 @@ class MultiPartParser:
         self._file_parts_to_write: list[tuple[MultipartPart, bytes]] = []
         self._file_parts_to_finish: list[MultipartPart] = []
         self._files_to_close_on_error: list[SpooledTemporaryFile[bytes]] = []
-        if max_part_size is not _Unset:
-            self.max_part_size = max_part_size
-        if spool_max_size is not _Unset:
-            self.spool_max_size = spool_max_size
+        self._max_part_size = max_part_size if max_part_size is not _Unset else type(self).max_part_size
+        self._spool_max_size = spool_max_size if spool_max_size is not _Unset else type(self).spool_max_size
 
     def on_part_begin(self) -> None:
         self._current_part = MultipartPart()
@@ -176,8 +174,8 @@ class MultiPartParser:
     def on_part_data(self, data: bytes, start: int, end: int) -> None:
         message_bytes = data[start:end]
         if self._current_part.file is None:
-            if len(self._current_part.data) + len(message_bytes) > self.max_part_size:
-                raise MultiPartException(f"Part exceeded maximum size of {int(self.max_part_size / 1024)}KB.")
+            if len(self._current_part.data) + len(message_bytes) > self._max_part_size:
+                raise MultiPartException(f"Part exceeded maximum size of {int(self._max_part_size / 1024)}KB.")
             self._current_part.data.extend(message_bytes)
         else:
             self._file_parts_to_write.append((self._current_part, message_bytes))
@@ -222,7 +220,7 @@ class MultiPartParser:
             if self._current_files > self.max_files:
                 raise MultiPartException(f"Too many files. Maximum number of files is {self.max_files}.")
             filename = _user_safe_decode(options[b"filename"], self._charset)
-            tempfile = SpooledTemporaryFile(max_size=self.spool_max_size)
+            tempfile = SpooledTemporaryFile(max_size=self._spool_max_size)
             self._files_to_close_on_error.append(tempfile)
             self._current_part.file = UploadFile(
                 file=tempfile,  # type: ignore[arg-type]

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from enum import Enum
 from tempfile import SpooledTemporaryFile
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 from urllib.parse import unquote_plus
 
 from starlette.datastructures import FormData, Headers, UploadFile
@@ -132,9 +132,9 @@ _UNSET = _Unset()
 
 
 class MultiPartParser:
-    spool_max_size: ClassVar[int] = 1024 * 1024  # 1MB
+    spool_max_size: int = 1024 * 1024  # 1MB
     """The maximum size of the spooled temporary file used to store file data."""
-    max_part_size: ClassVar[int] = 1024 * 1024  # 1MB
+    max_part_size: int = 1024 * 1024  # 1MB
     """The maximum size of a part in the multipart request."""
 
     def __init__(
@@ -162,8 +162,10 @@ class MultiPartParser:
         self._file_parts_to_write: list[tuple[MultipartPart, bytes]] = []
         self._file_parts_to_finish: list[MultipartPart] = []
         self._files_to_close_on_error: list[SpooledTemporaryFile[bytes]] = []
-        self._max_part_size = type(self).max_part_size if isinstance(max_part_size, _Unset) else max_part_size
-        self._spool_max_size = type(self).spool_max_size if isinstance(spool_max_size, _Unset) else spool_max_size
+        if not isinstance(max_part_size, _Unset):
+            self.max_part_size = max_part_size
+        if not isinstance(spool_max_size, _Unset):
+            self.spool_max_size = spool_max_size
 
     def on_part_begin(self) -> None:
         self._current_part = MultipartPart()
@@ -171,8 +173,8 @@ class MultiPartParser:
     def on_part_data(self, data: bytes, start: int, end: int) -> None:
         message_bytes = data[start:end]
         if self._current_part.file is None:
-            if len(self._current_part.data) + len(message_bytes) > self._max_part_size:
-                raise MultiPartException(f"Part exceeded maximum size of {int(self._max_part_size / 1024)}KB.")
+            if len(self._current_part.data) + len(message_bytes) > self.max_part_size:
+                raise MultiPartException(f"Part exceeded maximum size of {int(self.max_part_size / 1024)}KB.")
             self._current_part.data.extend(message_bytes)
         else:
             self._file_parts_to_write.append((self._current_part, message_bytes))
@@ -217,7 +219,7 @@ class MultiPartParser:
             if self._current_files > self.max_files:
                 raise MultiPartException(f"Too many files. Maximum number of files is {self.max_files}.")
             filename = _user_safe_decode(options[b"filename"], self._charset)
-            tempfile = SpooledTemporaryFile(max_size=self._spool_max_size)
+            tempfile = SpooledTemporaryFile(max_size=self.spool_max_size)
             self._files_to_close_on_error.append(tempfile)
             self._current_part.file = UploadFile(
                 file=tempfile,  # type: ignore[arg-type]

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -122,33 +122,12 @@ class FormParser:
         return FormData(items)
 
 
-class _RemovedAttribute:
-    """Descriptor that raises a helpful error when a removed class attribute is accessed.
-
-    This is a data descriptor: instance access goes through ``__get__``/``__set__``
-    so that ``self.attr = value`` in ``__init__`` stores into the instance ``__dict__``
-    and later reads return that value, while *class-level* access
-    (``MultiPartParser.attr``) raises an ``AttributeError`` with migration guidance.
-    """
-
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-    def __set__(self, obj: object, value: int) -> None:
-        obj.__dict__[self.name] = value
-
-    def __get__(self, obj: object | None, objtype: type | None = None) -> int:
-        if obj is not None:
-            return obj.__dict__[self.name]  # type: ignore[no-any-return]
-        raise AttributeError(
-            f"Accessing `{self.name}` as a class variable is no longer supported. "
-            f"Use the `{self.name}` parameter on `MultiPartParser()` or `request.form()` instead."
-        )
+_Unset = type("_Unset", (), {"__repr__": lambda self: "_Unset"})()
 
 
 class MultiPartParser:
-    spool_max_size = _RemovedAttribute("spool_max_size")
-    max_part_size = _RemovedAttribute("max_part_size")
+    spool_max_size: int = 1024 * 1024  # 1MB
+    max_part_size: int = 1024 * 1024  # 1MB
 
     def __init__(
         self,
@@ -157,8 +136,8 @@ class MultiPartParser:
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int = 1024 * 1024,  # 1MB
-        spool_max_size: int = 1024 * 1024,  # 1MB
+        max_part_size: int = _Unset,
+        spool_max_size: int = _Unset,
     ) -> None:
         """Parse multipart form data from an incoming request.
 
@@ -167,9 +146,9 @@ class MultiPartParser:
             stream: An async generator yielding request body chunks.
             max_files: Maximum number of file parts allowed.
             max_fields: Maximum number of non-file field parts allowed.
-            max_part_size: Maximum size in bytes for a single non-file part.
+            max_part_size: Maximum size in bytes for a single non-file part. Falls back to the class attribute.
             spool_max_size: Maximum size in bytes for the in-memory spool of each uploaded file before it rolls over
-                to disk.
+                to disk. Falls back to the class attribute.
         """
         assert multipart is not None, "The `python-multipart` library must be installed to use form parsing."
         self.headers = headers
@@ -186,8 +165,10 @@ class MultiPartParser:
         self._file_parts_to_write: list[tuple[MultipartPart, bytes]] = []
         self._file_parts_to_finish: list[MultipartPart] = []
         self._files_to_close_on_error: list[SpooledTemporaryFile[bytes]] = []
-        self.max_part_size = max_part_size
-        self.spool_max_size = spool_max_size
+        if max_part_size is not _Unset:
+            self.max_part_size = max_part_size
+        if spool_max_size is not _Unset:
+            self.spool_max_size = spool_max_size
 
     def on_part_begin(self) -> None:
         self._current_part = MultipartPart()

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -11,7 +11,7 @@ import anyio
 from starlette._utils import AwaitableOrContextManager, AwaitableOrContextManagerWrapper
 from starlette.datastructures import URL, Address, FormData, Headers, QueryParams, State
 from starlette.exceptions import HTTPException
-from starlette.formparsers import FormParser, MultiPartException, MultiPartParser, _Unset
+from starlette.formparsers import _UNSET, FormParser, MultiPartException, MultiPartParser, _Unset
 from starlette.types import Message, Receive, Scope, Send
 
 if TYPE_CHECKING:
@@ -269,8 +269,8 @@ class Request(HTTPConnection[StateT]):
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int = _Unset,
-        spool_max_size: int = _Unset,
+        max_part_size: int | _Unset = _UNSET,
+        spool_max_size: int | _Unset = _UNSET,
     ) -> FormData:
         if self._form is None:  # pragma: no branch
             assert parse_options_header is not None, (
@@ -306,8 +306,8 @@ class Request(HTTPConnection[StateT]):
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int = _Unset,
-        spool_max_size: int = _Unset,
+        max_part_size: int | _Unset = _UNSET,
+        spool_max_size: int | _Unset = _UNSET,
     ) -> AwaitableOrContextManager[FormData]:
         return AwaitableOrContextManagerWrapper(
             self._get_form(

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -11,7 +11,7 @@ import anyio
 from starlette._utils import AwaitableOrContextManager, AwaitableOrContextManagerWrapper
 from starlette.datastructures import URL, Address, FormData, Headers, QueryParams, State
 from starlette.exceptions import HTTPException
-from starlette.formparsers import FormParser, MultiPartException, MultiPartParser
+from starlette.formparsers import FormParser, MultiPartException, MultiPartParser, _Unset
 from starlette.types import Message, Receive, Scope, Send
 
 if TYPE_CHECKING:
@@ -269,8 +269,8 @@ class Request(HTTPConnection[StateT]):
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int = 1024 * 1024,
-        spool_max_size: int = 1024 * 1024,
+        max_part_size: int = _Unset,
+        spool_max_size: int = _Unset,
     ) -> FormData:
         if self._form is None:  # pragma: no branch
             assert parse_options_header is not None, (
@@ -306,8 +306,8 @@ class Request(HTTPConnection[StateT]):
         *,
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
-        max_part_size: int = 1024 * 1024,
-        spool_max_size: int = 1024 * 1024,
+        max_part_size: int = _Unset,
+        spool_max_size: int = _Unset,
     ) -> AwaitableOrContextManager[FormData]:
         return AwaitableOrContextManagerWrapper(
             self._get_form(

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -270,6 +270,7 @@ class Request(HTTPConnection[StateT]):
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
         max_part_size: int = 1024 * 1024,
+        spool_max_size: int = 1024 * 1024,
     ) -> FormData:
         if self._form is None:  # pragma: no branch
             assert parse_options_header is not None, (
@@ -286,6 +287,7 @@ class Request(HTTPConnection[StateT]):
                         max_files=max_files,
                         max_fields=max_fields,
                         max_part_size=max_part_size,
+                        spool_max_size=spool_max_size,
                     )
                     self._form = await multipart_parser.parse()
                 except MultiPartException as exc:
@@ -305,9 +307,15 @@ class Request(HTTPConnection[StateT]):
         max_files: int | float = 1000,
         max_fields: int | float = 1000,
         max_part_size: int = 1024 * 1024,
+        spool_max_size: int = 1024 * 1024,
     ) -> AwaitableOrContextManager[FormData]:
         return AwaitableOrContextManagerWrapper(
-            self._get_form(max_files=max_files, max_fields=max_fields, max_part_size=max_part_size)
+            self._get_form(
+                max_files=max_files,
+                max_fields=max_fields,
+                max_part_size=max_part_size,
+                spool_max_size=spool_max_size,
+            )
         )
 
     async def close(self) -> None:

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -390,10 +390,26 @@ def test_multipart_request_custom_spool_max_size(
     assert len(ThreadTrackingSpooledTemporaryFile.rollover_threads) == 1
 
 
-@pytest.mark.parametrize("attr", ["spool_max_size", "max_part_size"])
-def test_removed_class_attributes(attr: str) -> None:
-    with pytest.raises(AttributeError, match="no longer supported.*parameter on `MultiPartParser"):
-        getattr(MultiPartParser, attr)
+def test_multipart_request_class_spool_max_size(
+    mock_spooled_temporary_file: None, test_client_factory: TestClientFactory
+) -> None:
+    """Test that setting spool_max_size as a class attribute works as a global default."""
+    original = MultiPartParser.spool_max_size
+    try:
+        MultiPartParser.spool_max_size = 512
+
+        client = test_client_factory(app_monitor_thread)
+        # Data larger than 512 bytes but smaller than 1MB
+        data = BytesIO(b" " * 1024)
+        response = client.post("/", files=[("test_file", data)])
+        assert response.status_code == 200
+
+        app_thread_ident = response.json().get("thread_ident")
+        assert app_thread_ident is not None
+        assert app_thread_ident not in ThreadTrackingSpooledTemporaryFile.rollover_threads
+        assert len(ThreadTrackingSpooledTemporaryFile.rollover_threads) == 1
+    finally:
+        MultiPartParser.spool_max_size = original
 
 
 def test_multipart_request_with_charset_for_filename(tmpdir: Path, test_client_factory: TestClientFactory) -> None:

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -412,6 +412,20 @@ def test_multipart_request_class_spool_max_size(
         MultiPartParser.spool_max_size = original
 
 
+def test_multipart_request_class_max_part_size(test_client_factory: TestClientFactory) -> None:
+    """Test that setting max_part_size as a class attribute works as a global default."""
+    original = MultiPartParser.max_part_size
+    try:
+        MultiPartParser.max_part_size = 512
+
+        client = test_client_factory(Starlette(routes=[Mount("/", app=app)]))
+        response = client.post("/", data={"field": "x" * 513}, files=FORCE_MULTIPART)
+        assert response.status_code == 400
+        assert response.text == "Part exceeded maximum size of 0KB."
+    finally:
+        MultiPartParser.max_part_size = original
+
+
 def test_multipart_request_with_charset_for_filename(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
     client = test_client_factory(app)
     response = client.post(

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -14,7 +14,7 @@ import pytest
 
 from starlette.applications import Starlette
 from starlette.datastructures import UploadFile
-from starlette.formparsers import MultiPartException, MultiPartParser, _user_safe_decode
+from starlette.formparsers import MultiPartException, _user_safe_decode
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Mount

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -350,7 +350,7 @@ def test_multipart_request_large_file_rollover_in_background_thread(
     mock_spooled_temporary_file: None, test_client_factory: TestClientFactory
 ) -> None:
     """Test that Spooled file rollovers happen in background threads."""
-    data = BytesIO(b" " * (1024 * 1024 + 1))
+    data = BytesIO(b" " * (MultiPartParser.spool_max_size + 1))
 
     client = test_client_factory(app_monitor_thread)
     response = client.post("/", files=[("test_large", data)])

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -350,7 +350,7 @@ def test_multipart_request_large_file_rollover_in_background_thread(
     mock_spooled_temporary_file: None, test_client_factory: TestClientFactory
 ) -> None:
     """Test that Spooled file rollovers happen in background threads."""
-    data = BytesIO(b" " * (MultiPartParser.spool_max_size + 1))
+    data = BytesIO(b" " * (1024 * 1024 + 1))
 
     client = test_client_factory(app_monitor_thread)
     response = client.post("/", files=[("test_large", data)])
@@ -361,6 +361,31 @@ def test_multipart_request_large_file_rollover_in_background_thread(
     assert app_thread_ident is not None
 
     # Ensure the app thread was not the same as the rollover one and that a rollover thread exists
+    assert app_thread_ident not in ThreadTrackingSpooledTemporaryFile.rollover_threads
+    assert len(ThreadTrackingSpooledTemporaryFile.rollover_threads) == 1
+
+
+def test_multipart_request_custom_spool_max_size(
+    mock_spooled_temporary_file: None, test_client_factory: TestClientFactory
+) -> None:
+    """Test that a custom spool_max_size triggers rollover at the configured threshold."""
+
+    async def app_with_custom_spool(scope: Scope, receive: Receive, send: Send) -> None:
+        request = Request(scope, receive)
+        await request.form(spool_max_size=512)
+        await request.close()
+        response = JSONResponse({"thread_ident": threading.current_thread().ident})
+        await response(scope, receive, send)
+
+    # Data larger than the custom spool size (512 bytes), but smaller than the default (1MB)
+    data = BytesIO(b" " * 1024)
+
+    client = test_client_factory(app_with_custom_spool)
+    response = client.post("/", files=[("test_file", data)])
+    assert response.status_code == 200
+
+    app_thread_ident = response.json().get("thread_ident")
+    assert app_thread_ident is not None
     assert app_thread_ident not in ThreadTrackingSpooledTemporaryFile.rollover_threads
     assert len(ThreadTrackingSpooledTemporaryFile.rollover_threads) == 1
 

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -14,7 +14,7 @@ import pytest
 
 from starlette.applications import Starlette
 from starlette.datastructures import UploadFile
-from starlette.formparsers import MultiPartException, _user_safe_decode
+from starlette.formparsers import MultiPartException, MultiPartParser, _user_safe_decode
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Mount
@@ -388,6 +388,12 @@ def test_multipart_request_custom_spool_max_size(
     assert app_thread_ident is not None
     assert app_thread_ident not in ThreadTrackingSpooledTemporaryFile.rollover_threads
     assert len(ThreadTrackingSpooledTemporaryFile.rollover_threads) == 1
+
+
+@pytest.mark.parametrize("attr", ["spool_max_size", "max_part_size"])
+def test_removed_class_attributes(attr: str) -> None:
+    with pytest.raises(AttributeError, match="no longer supported.*parameter on `MultiPartParser"):
+        getattr(MultiPartParser, attr)
 
 
 def test_multipart_request_with_charset_for_filename(tmpdir: Path, test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
## Summary

- Remove redundant class-level `spool_max_size` and `max_part_size` attributes from `MultiPartParser` - `max_part_size` was already shadowed by the instance attribute set in `__init__`.
- Expose `spool_max_size` as a constructor parameter on `MultiPartParser`, threaded through `Request.form()` and `Request._get_form()`.
- Add docstring to `MultiPartParser.__init__()`.

---

- Closes https://github.com/Kludex/starlette/pull/2718

## Test plan

- [x] Existing rollover test updated to not reference removed class attribute.
- [x] New `test_multipart_request_custom_spool_max_size` verifies rollover triggers at a custom threshold (512 bytes) with data smaller than the default (1MB).