### PR TITLE
BackgroundTasks: run all tasks even when one raises (fire-and-forget)

### DIFF
--- a/starlette/background.py
+++ b/starlette/background.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 from typing import Any, ParamSpec
 
 from starlette._utils import is_async_callable
 from starlette.concurrency import run_in_threadpool
+
+logger = logging.getLogger(__name__)
 
 P = ParamSpec("P")
 
@@ -33,4 +36,7 @@ class BackgroundTasks(BackgroundTask):
 
     async def __call__(self) -> None:
         for task in self.tasks:
-            await task()
+            try:
+                await task()
+            except Exception:
+                logger.exception(f"Background task '{task.func.__name__}' failed")

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -65,15 +65,16 @@ def test_multiple_tasks(test_client_factory: TestClientFactory) -> None:
     assert TASK_COUNTER == 1 + 2 + 3
 
 
-def test_multi_tasks_failure_avoids_next_execution(
+def test_multi_tasks_failure_continues_remaining(
     test_client_factory: TestClientFactory,
 ) -> None:
+    """Verify that when one background task raises, remaining tasks still run (fire-and-forget)."""
     TASK_COUNTER = 0
 
     def increment() -> None:
         nonlocal TASK_COUNTER
         TASK_COUNTER += 1
-        if TASK_COUNTER == 1:  # pragma: no branch
+        if TASK_COUNTER == 1:
             raise Exception("task failed")
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
@@ -84,6 +85,6 @@ def test_multi_tasks_failure_avoids_next_execution(
         await response(scope, receive, send)
 
     client = test_client_factory(app)
-    with pytest.raises(Exception):
-        client.get("/")
-    assert TASK_COUNTER == 1
+    response = client.get("/")
+    assert response.text == "tasks initiated"
+    assert TASK_COUNTER == 2


### PR DESCRIPTION
## Summary

Changes `BackgroundTasks.__call__` to catch exceptions per task (fire-and-forget) instead of stopping the entire loop when one task fails. Exceptions are logged via the standard `logging` module and remaining tasks continue executing.

This implements the behavior requested in issue #3195/#3194.

## Root Cause

The previous implementation awaited each task sequentially without exception handling:
```python
async def __call__(self) -> None:
    for task in self.tasks:
        await task()  # raises → loop stops, remaining tasks never run
```

## Fix

Wrap each `await task()` in try/except, log the exception, and continue:
```python
async def __call__(self) -> None:
    for task in self.tasks:
        try:
            await task()
        except Exception:
            logger.exception(f"Background task '{task.func.__name__}' failed")
```

## Test Evidence

```
tests/test_background.py::test_multi_tasks_failure_continues_remaining[asyncio] PASSED
tests/test_background.py::test_multi_tasks_failure_continues_remaining[trio] PASSED
```

Full background test suite (8 tests): **PASSED**
Selected test suite (232 tests): **PASSED, 2 skipped**

## Breaking Change

This changes existing semantics. Previously, if any background task raised an exception, the loop stopped and remaining tasks did not run (fail-fast). Now, exceptions are caught per-task and remaining tasks continue (fire-and-forget).

Existing test `test_multi_tasks_failure_avoids_next_execution` was renamed and updated to `test_multi_tasks_failure_continues_remaining` to reflect the new expected behavior.

## Rollback

`git revert <commit>` restores previous behavior. No database or schema changes.

## Checklist

- [x] Test added/updated for the changed behavior
- [ ] Documentation updated