### PR TITLE
Deprecate HTTP_306_RESERVED status code

### DIFF
--- a/starlette/status.py
+++ b/starlette/status.py
@@ -31,7 +31,6 @@ __all__ = [
     "HTTP_303_SEE_OTHER",
     "HTTP_304_NOT_MODIFIED",
     "HTTP_305_USE_PROXY",
-    "HTTP_306_RESERVED",
     "HTTP_307_TEMPORARY_REDIRECT",
     "HTTP_308_PERMANENT_REDIRECT",
     "HTTP_400_BAD_REQUEST",
@@ -111,7 +110,6 @@ HTTP_302_FOUND = 302
 HTTP_303_SEE_OTHER = 303
 HTTP_304_NOT_MODIFIED = 304
 HTTP_305_USE_PROXY = 305
-HTTP_306_RESERVED = 306
 HTTP_307_TEMPORARY_REDIRECT = 307
 HTTP_308_PERMANENT_REDIRECT = 308
 HTTP_400_BAD_REQUEST = 400
@@ -178,6 +176,7 @@ WS_1014_BAD_GATEWAY = 1014
 WS_1015_TLS_HANDSHAKE = 1015
 
 __deprecated__ = {
+    "HTTP_306_RESERVED": 306,
     "HTTP_413_REQUEST_ENTITY_TOO_LARGE": 413,
     "HTTP_414_REQUEST_URI_TOO_LONG": 414,
     "HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE": 416,
@@ -195,11 +194,12 @@ def __getattr__(name: str) -> int:
 
     deprecated = __deprecated__.get(name)
     if deprecated:
-        warnings.warn(
-            f"'{name}' is deprecated. Use '{deprecation_changes[name]}' instead.",
-            category=DeprecationWarning,
-            stacklevel=3,
-        )
+        replacement = deprecation_changes.get(name)
+        if replacement:
+            msg = f"'{name}' is deprecated. Use '{replacement}' instead."
+        else:
+            msg = f"'{name}' is deprecated and will be removed in a future version."
+        warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
         return deprecated
 
     raise AttributeError(f"module 'starlette.status' has no attribute '{name}'")

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -7,6 +7,10 @@ import pytest
     "constant,msg",
     (
         (
+            "HTTP_306_RESERVED",
+            "'HTTP_306_RESERVED' is deprecated and will be removed in a future version.",
+        ),
+        (
             "HTTP_413_REQUEST_ENTITY_TOO_LARGE",
             "'HTTP_413_REQUEST_ENTITY_TOO_LARGE' is deprecated. Use 'HTTP_413_CONTENT_TOO_LARGE' instead.",
         ),


### PR DESCRIPTION
Closes #3192.

Status code 306 is listed as **(Unused)** in the [IANA HTTP Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml) and [RFC 9110 Section 15.4.7](https://www.rfc-editor.org/rfc/rfc9110#section-15.4.7) states it is no longer used and the code is reserved.

This PR moves `HTTP_306_RESERVED` from `__all__` into the existing `__deprecated__` dict so that existing code continues to work but receives a `DeprecationWarning`. The `__getattr__` logic was updated to handle deprecated constants that have no replacement (as opposed to the existing renamed constants like `HTTP_413_REQUEST_ENTITY_TOO_LARGE` → `HTTP_413_CONTENT_TOO_LARGE`).

**Changes:**
- Removed `HTTP_306_RESERVED` from `__all__` and its direct assignment
- Added `HTTP_306_RESERVED` to the `__deprecated__` dict
- Updated `__getattr__` to support deprecated constants without a replacement name
- Added test case for the new deprecation warning