### PR TITLE
Add `is_disconnected` property to WebSocket

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -32,6 +32,13 @@ class WebSocket(HTTPConnection[StateT]):
         self.client_state = WebSocketState.CONNECTING
         self.application_state = WebSocketState.CONNECTING
 
+    @property
+    def is_disconnected(self) -> bool:
+        return (
+            self.client_state == WebSocketState.DISCONNECTED
+            or self.application_state == WebSocketState.DISCONNECTED
+        )
+
     async def receive(self) -> Message:
         """
         Receive ASGI websocket messages, ensuring valid state transitions.

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -651,3 +651,18 @@ def test_receive_wrong_message_type(test_client_factory: TestClientFactory) -> N
     with pytest.raises(RuntimeError):
         with client.websocket_connect("/") as websocket:
             websocket.send({"type": "websocket.connect"})
+
+
+def test_is_disconnected_property(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive=receive, send=send)
+        assert not websocket.is_disconnected
+        await websocket.accept()
+        assert not websocket.is_disconnected
+        message = await websocket.receive()
+        websocket.client_state = WebSocketState.DISCONNECTED
+        assert websocket.is_disconnected
+
+    client = test_client_factory(app)
+    with client.websocket_connect("/") as websocket:
+        websocket.send_json({"close": True})


### PR DESCRIPTION
## Description

Adds a synchronous `is_disconnected` property to the `WebSocket` class that returns `True` when either the client or application state is `DISCONNECTED`.

Closes #2766

### Motivation
When handling WebSocket connections with multiple coroutines, it's common for more than one coroutine to attempt closing the connection. Without a way to check the connection state synchronously, this leads to `RuntimeError` exceptions.

This property enables clean, exception-free state checking:

```python
if not websocket.is_disconnected:
    await websocket.close()
```

### Implementation
The property simply checks whether either `client_state` or `application_state` equals `WebSocketState.DISCONNECTED` — both of which are already tracked by the existing state machine in `starlette/websockets.py`.

### Changes
- Added `is_disconnected` property to `WebSocket` class
- Added unit test `test_is_disconnected_property`
