### PR TITLE
Handle standalone If-None-Match wildcards in StaticFiles

### DIFF
--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -207,6 +207,9 @@ class StaticFiles:
         if if_none_match := request_headers.get("if-none-match"):
             # The "etag" header is added by FileResponse, so it's always present.
             etag = response_headers["etag"]
+            # Per RFC 7232 §3.2, "If-None-Match: *" matches any current representation.
+            if if_none_match.strip() == "*":
+                return True
             return etag in [tag.strip(" W/") for tag in if_none_match.split(",")]
 
         try:

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -208,7 +208,8 @@ class StaticFiles:
             # The "etag" header is added by FileResponse, so it's always present.
             etag = response_headers["etag"]
             # Per RFC 7232 §3.2, "If-None-Match: *" matches any current representation.
-            if if_none_match.strip() == "*":
+            # The wildcard is also honored leniently when sent alongside other tags.
+            if any(tag.strip() == "*" for tag in if_none_match.split(",")):
                 return True
             return etag in [tag.strip(" W/") for tag in if_none_match.split(",")]
 

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -205,12 +205,10 @@ class StaticFiles:
         "Not Modified" response could be returned instead.
         """
         if if_none_match := request_headers.get("if-none-match"):
+            if if_none_match.strip() == "*":
+                return True
             # The "etag" header is added by FileResponse, so it's always present.
             etag = response_headers["etag"]
-            # Per RFC 7232 §3.2, "If-None-Match: *" matches any current representation.
-            # The wildcard is also honored leniently when sent alongside other tags.
-            if any(tag.strip() == "*" for tag in if_none_match.split(",")):
-                return True
             return etag in [tag.strip(" W/") for tag in if_none_match.split(",")]
 
         try:

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -216,6 +216,19 @@ def test_staticfiles_304_with_etag_match(tmpdir: Path, test_client_factory: Test
     assert second_resp.content == b""
 
 
+def test_staticfiles_304_with_if_none_match_wildcard(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
+    path = os.path.join(tmpdir, "example.txt")
+    with open(path, "w") as file:
+        file.write("<file content>")
+
+    app = StaticFiles(directory=tmpdir)
+    client = test_client_factory(app)
+    # Per RFC 7232 §3.2, "If-None-Match: *" should match any current representation.
+    response = client.get("/example.txt", headers={"if-none-match": "*"})
+    assert response.status_code == 304
+    assert response.content == b""
+
+
 def test_staticfiles_200_with_etag_mismatch(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
     path = os.path.join(tmpdir, "example.txt")
     with open(path, "w") as file:

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -227,6 +227,10 @@ def test_staticfiles_304_with_if_none_match_wildcard(tmpdir: Path, test_client_f
     response = client.get("/example.txt", headers={"if-none-match": "*"})
     assert response.status_code == 304
     assert response.content == b""
+    # The wildcard is also honored when sent alongside other entity-tags.
+    response = client.get("/example.txt", headers={"if-none-match": '"bogus-etag", *'})
+    assert response.status_code == 304
+    assert response.content == b""
 
 
 def test_staticfiles_200_with_etag_mismatch(tmpdir: Path, test_client_factory: TestClientFactory) -> None:

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -233,7 +233,7 @@ def test_staticfiles_304_with_if_none_match_wildcard(
     assert response.content == b""
 
 
-@pytest.mark.parametrize("if_none_match", ['"123"', '"foo,*,bar"'])
+@pytest.mark.parametrize("if_none_match", ['"123"', '"*"', '"foo,*,bar"'])
 def test_staticfiles_200_with_etag_mismatch(
     tmp_path: Path,
     test_client_factory: TestClientFactory,

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 import anyio
-import httpx
 import pytest
 
 from starlette.applications import Starlette
@@ -217,28 +216,30 @@ def test_staticfiles_304_with_etag_match(tmpdir: Path, test_client_factory: Test
     assert second_resp.content == b""
 
 
-@pytest.mark.anyio
 @pytest.mark.parametrize("method", ["GET", "HEAD"])
 @pytest.mark.parametrize("if_none_match", ["*", " \t* \t"])
-async def test_staticfiles_304_with_if_none_match_wildcard(tmp_path: Path, method: str, if_none_match: str) -> None:
+def test_staticfiles_304_with_if_none_match_wildcard(
+    tmp_path: Path, test_client_factory: TestClientFactory, method: str, if_none_match: str
+) -> None:
     (tmp_path / "example.txt").write_text("<file content>", encoding="utf-8")
 
     app = StaticFiles(directory=tmp_path)
-    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
-        response = await client.request(method, "/example.txt", headers={"if-none-match": if_none_match})
+    client = test_client_factory(app)
+    response = client.request(method, "/example.txt", headers={"if-none-match": if_none_match})
     assert response.status_code == 304
     assert response.content == b""
 
 
-@pytest.mark.anyio
 @pytest.mark.parametrize("method", ["GET", "HEAD"])
 @pytest.mark.parametrize("if_none_match", ['"123"', '"*"', '"foo,*,bar"', 'W/"foo,*,bar"', '"foo,*,bar", "other"'])
-async def test_staticfiles_200_with_etag_mismatch(tmp_path: Path, method: str, if_none_match: str) -> None:
+def test_staticfiles_200_with_etag_mismatch(
+    tmp_path: Path, test_client_factory: TestClientFactory, method: str, if_none_match: str
+) -> None:
     (tmp_path / "example.txt").write_text("<file content>", encoding="utf-8")
 
     app = StaticFiles(directory=tmp_path)
-    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
-        response = await client.request(method, "/example.txt", headers={"if-none-match": if_none_match})
+    client = test_client_factory(app)
+    response = client.request(method, "/example.txt", headers={"if-none-match": if_none_match})
     assert response.status_code == 200
     assert response.content == (b"<file content>" if method == "GET" else b"")
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -219,29 +219,35 @@ def test_staticfiles_304_with_etag_match(tmpdir: Path, test_client_factory: Test
 @pytest.mark.parametrize("method", ["GET", "HEAD"])
 @pytest.mark.parametrize("if_none_match", ["*", " \t* \t"])
 def test_staticfiles_304_with_if_none_match_wildcard(
-    tmp_path: Path, test_client_factory: TestClientFactory, method: str, if_none_match: str
+    tmp_path: Path,
+    test_client_factory: TestClientFactory,
+    method: str,
+    if_none_match: str,
 ) -> None:
     (tmp_path / "example.txt").write_text("<file content>", encoding="utf-8")
 
     app = StaticFiles(directory=tmp_path)
     client = test_client_factory(app)
     response = client.request(method, "/example.txt", headers={"if-none-match": if_none_match})
+
     assert response.status_code == 304
     assert response.content == b""
 
 
-@pytest.mark.parametrize("method", ["GET", "HEAD"])
-@pytest.mark.parametrize("if_none_match", ['"123"', '"*"', '"foo,*,bar"', 'W/"foo,*,bar"', '"foo,*,bar", "other"'])
+@pytest.mark.parametrize("if_none_match", ['"123"', '"foo,*,bar"'])
 def test_staticfiles_200_with_etag_mismatch(
-    tmp_path: Path, test_client_factory: TestClientFactory, method: str, if_none_match: str
+    tmp_path: Path,
+    test_client_factory: TestClientFactory,
+    if_none_match: str,
 ) -> None:
     (tmp_path / "example.txt").write_text("<file content>", encoding="utf-8")
 
     app = StaticFiles(directory=tmp_path)
     client = test_client_factory(app)
-    response = client.request(method, "/example.txt", headers={"if-none-match": if_none_match})
+    response = client.get("/example.txt", headers={"if-none-match": if_none_match})
+
     assert response.status_code == 200
-    assert response.content == (b"<file content>" if method == "GET" else b"")
+    assert response.content == b"<file content>"
 
 
 def test_staticfiles_200_with_etag_mismatch_and_timestamp_match(

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -229,7 +229,6 @@ def test_staticfiles_304_with_if_none_match_wildcard(
     app = StaticFiles(directory=tmp_path)
     client = test_client_factory(app)
     response = client.request(method, "/example.txt", headers={"if-none-match": if_none_match})
-
     assert response.status_code == 304
     assert response.content == b""
 
@@ -245,7 +244,6 @@ def test_staticfiles_200_with_etag_mismatch(
     app = StaticFiles(directory=tmp_path)
     client = test_client_factory(app)
     response = client.get("/example.txt", headers={"if-none-match": if_none_match})
-
     assert response.status_code == 200
     assert response.content == b"<file content>"
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import anyio
+import httpx
 import pytest
 
 from starlette.applications import Starlette
@@ -216,36 +217,30 @@ def test_staticfiles_304_with_etag_match(tmpdir: Path, test_client_factory: Test
     assert second_resp.content == b""
 
 
-def test_staticfiles_304_with_if_none_match_wildcard(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
-    path = os.path.join(tmpdir, "example.txt")
-    with open(path, "w") as file:
-        file.write("<file content>")
+@pytest.mark.anyio
+@pytest.mark.parametrize("method", ["GET", "HEAD"])
+@pytest.mark.parametrize("if_none_match", ["*", " \t* \t"])
+async def test_staticfiles_304_with_if_none_match_wildcard(tmp_path: Path, method: str, if_none_match: str) -> None:
+    (tmp_path / "example.txt").write_text("<file content>", encoding="utf-8")
 
-    app = StaticFiles(directory=tmpdir)
-    client = test_client_factory(app)
-    # Per RFC 7232 §3.2, "If-None-Match: *" should match any current representation.
-    response = client.get("/example.txt", headers={"if-none-match": "*"})
-    assert response.status_code == 304
-    assert response.content == b""
-    # The wildcard is also honored when sent alongside other entity-tags.
-    response = client.get("/example.txt", headers={"if-none-match": '"bogus-etag", *'})
+    app = StaticFiles(directory=tmp_path)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+        response = await client.request(method, "/example.txt", headers={"if-none-match": if_none_match})
     assert response.status_code == 304
     assert response.content == b""
 
 
-def test_staticfiles_200_with_etag_mismatch(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
-    path = os.path.join(tmpdir, "example.txt")
-    with open(path, "w") as file:
-        file.write("<file content>")
+@pytest.mark.anyio
+@pytest.mark.parametrize("method", ["GET", "HEAD"])
+@pytest.mark.parametrize("if_none_match", ['"123"', '"*"', '"foo,*,bar"', 'W/"foo,*,bar"', '"foo,*,bar", "other"'])
+async def test_staticfiles_200_with_etag_mismatch(tmp_path: Path, method: str, if_none_match: str) -> None:
+    (tmp_path / "example.txt").write_text("<file content>", encoding="utf-8")
 
-    app = StaticFiles(directory=tmpdir)
-    client = test_client_factory(app)
-    first_resp = client.get("/example.txt")
-    assert first_resp.status_code == 200
-    assert first_resp.headers["etag"] != '"123"'
-    second_resp = client.get("/example.txt", headers={"if-none-match": '"123"'})
-    assert second_resp.status_code == 200
-    assert second_resp.content == b"<file content>"
+    app = StaticFiles(directory=tmp_path)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+        response = await client.request(method, "/example.txt", headers={"if-none-match": if_none_match})
+    assert response.status_code == 200
+    assert response.content == (b"<file content>" if method == "GET" else b"")
 
 
 def test_staticfiles_200_with_etag_mismatch_and_timestamp_match(


### PR DESCRIPTION
`StaticFiles` currently returns `200` for an existing file requested with `If-None-Match: *`. Return `304` for `GET` and `HEAD` when the header is a standalone wildcard, allowing surrounding whitespace, as required by [RFC 9110 §13.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2).

Keep quoted ETags such as `"foo,*,bar"` on the normal comparison path. Splitting the header to look for wildcards incorrectly matches these tags; mixed wildcard lists are syntactically invalid under the RFC. The wildcard test covers both methods and surrounding whitespace. The existing mismatch test also covers `"*"` and `"foo,*,bar"`.

Validation: 939 tests passed, 2 skipped, 2 expected failures; 100% coverage. Ruff lint, formatting, and mypy 1.16.1 checks passed.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
