### PR TITLE
Add docstrings to middleware classes

### DIFF
--- a/starlette/middleware/authentication.py
+++ b/starlette/middleware/authentication.py
@@ -14,6 +14,12 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 
 class AuthenticationMiddleware:
+    """Middleware that authenticates incoming requests using a pluggable backend.
+
+    On successful authentication, ``scope["auth"]`` and ``scope["user"]``
+    are populated from the backend result.
+    """
+
     def __init__(
         self,
         app: ASGIApp,

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -94,6 +94,13 @@ class _CachedRequest(Request):
 
 
 class BaseHTTPMiddleware:
+    """Base class for implementing HTTP middleware using a request/response interface.
+
+    Subclasses should override the ``dispatch`` method. The ``dispatch``
+    method receives a ``Request`` and a ``call_next`` callable that forwards
+    the request to the downstream application and returns a ``Response``.
+    """
+
     def __init__(self, app: ASGIApp, dispatch: DispatchFunction | None = None) -> None:
         self.app = app
         self.dispatch_func = self.dispatch if dispatch is None else dispatch

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -13,6 +13,12 @@ SAFELISTED_HEADERS = {"Accept", "Accept-Language", "Content-Language", "Content-
 
 
 class CORSMiddleware:
+    """Middleware for handling Cross-Origin Resource Sharing (CORS) headers.
+
+    Allows configuring allowed origins, methods, headers, and other CORS
+    policy settings. Handles both simple requests and preflight requests.
+    """
+
     def __init__(
         self,
         app: ASGIApp,

--- a/starlette/middleware/exceptions.py
+++ b/starlette/middleware/exceptions.py
@@ -16,6 +16,13 @@ from starlette.websockets import WebSocket
 
 
 class ExceptionMiddleware:
+    """Middleware that handles exceptions by dispatching to registered handlers.
+
+    Exception handlers can be registered by exception class or by HTTP
+    status code. This middleware is added as the innermost middleware
+    by ``Starlette`` applications.
+    """
+
     def __init__(
         self,
         app: ASGIApp,

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -9,6 +9,13 @@ DEFAULT_EXCLUDED_CONTENT_TYPES = ("text/event-stream",)
 
 
 class GZipMiddleware:
+    """Middleware that applies GZip compression to responses.
+
+    Responses smaller than ``minimum_size`` bytes will not be compressed.
+    Compression is only applied when the client sends an ``Accept-Encoding``
+    header that includes ``gzip``.
+    """
+
     def __init__(self, app: ASGIApp, minimum_size: int = 500, compresslevel: int = 9) -> None:
         self.app = app
         self.minimum_size = minimum_size
@@ -117,6 +124,8 @@ class IdentityResponder:
 
 
 class GZipResponder(IdentityResponder):
+    """Responder that compresses response bodies using GZip."""
+
     content_encoding = "gzip"
 
     def __init__(self, app: ASGIApp, minimum_size: int, compresslevel: int = 9) -> None:

--- a/starlette/middleware/httpsredirect.py
+++ b/starlette/middleware/httpsredirect.py
@@ -4,6 +4,12 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 
 class HTTPSRedirectMiddleware:
+    """Middleware that redirects all incoming HTTP requests to HTTPS.
+
+    Any incoming requests to ``http`` or ``ws`` will be redirected to
+    the corresponding ``https`` or ``wss`` URL.
+    """
+
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
 

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -14,6 +14,12 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 class SessionMiddleware:
+    """Middleware that provides cookie-based session support.
+
+    Session data is stored as a signed cookie using ``itsdangerous``.
+    The session dictionary is available via ``request.session``.
+    """
+
     def __init__(
         self,
         app: ASGIApp,
@@ -89,6 +95,8 @@ class SessionMiddleware:
 
 
 class Session(dict[str, typing.Any]):
+    """A dictionary-like object that tracks access and modification state."""
+
     accessed: bool = False
     modified: bool = False
 

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -10,6 +10,13 @@ ENFORCE_DOMAIN_WILDCARD = "Domain wildcard patterns must be like '*.example.com'
 
 
 class TrustedHostMiddleware:
+    """Middleware that enforces a list of trusted host/domain names.
+
+    Requests with a ``Host`` header not matching the allowed hosts will
+    receive a 400 response. Supports wildcard domains (e.g. ``*.example.com``)
+    and optional ``www.`` redirect.
+    """
+
     def __init__(
         self,
         app: ASGIApp,

--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -73,6 +73,12 @@ def build_environ(scope: Scope, body: bytes) -> dict[str, Any]:
 
 
 class WSGIMiddleware:
+    """Middleware that wraps a WSGI application to run within an ASGI server.
+
+    .. deprecated::
+        Use `a2wsgi <https://github.com/abersheeran/a2wsgi>`_ instead.
+    """
+
     def __init__(self, app: Callable[..., Any]) -> None:
         self.app = app
 


### PR DESCRIPTION
## Summary

- Add class-level docstrings to all middleware classes that were missing them: `CORSMiddleware`, `SessionMiddleware`, `Session`, `HTTPSRedirectMiddleware`, `TrustedHostMiddleware`, `GZipMiddleware`, `GZipResponder`, `ExceptionMiddleware`, `AuthenticationMiddleware`, `BaseHTTPMiddleware`, and `WSGIMiddleware`.
- `ServerErrorMiddleware` already had a docstring and was left unchanged.
- Docstring style matches the existing conventions in the codebase (e.g. `HTTPConnection`, `URLPath`, `State`).

## Test plan

- No logic changes; only docstrings added.
- Verified `ruff check` passes on all modified files.