### PR TITLE
docs: fix reusable wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Run uvicorn with `--reload` to enable auto-reloading on code changes.
 
 ## Modularity
 
-The modularity that Starlette is designed on promotes building re-usable
+The modularity that Starlette is designed on promotes building reusable
 components that can be shared between any ASGI framework. This should enable
 an ecosystem of shared middleware and mountable applications.
 


### PR DESCRIPTION
# Summary
Fix the spelling of `reusable` in the README's modularity section.

Docs-only typo fix; no tests were added.

# Checklist
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.