### PR TITLE
Fix typo in docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -138,7 +138,7 @@ Run uvicorn with `--reload` to enable auto-reloading on code changes.
 
 ## Modularity
 
-The modularity that Starlette is designed on promotes building re-usable
+The modularity that Starlette is designed on promotes building reusable
 components that can be shared between any ASGI framework. This should enable
 an ecosystem of shared middleware and mountable applications.
 


### PR DESCRIPTION
# Summary

Fix "re-usable" -> "reusable" in the docs landing page.

# Related issue

N/A, trivial typo fix.

# Guideline alignment

Typos are explicitly exempt from the prior-discussion expectation in the Starlette PR template.

# Validation/testing

Not run; docs-only wording change.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.