### PR TITLE
docs: add docstrings to background and concurrency modules

### DIFF
--- a/starlette/background.py
+++ b/starlette/background.py
@@ -10,6 +10,13 @@ P = ParamSpec("P")
 
 
 class BackgroundTask:
+    """A task to run in the background after a response has been sent.
+
+    Accepts a callable along with any positional and keyword arguments.
+    If the callable is a coroutine function it is awaited directly; otherwise
+    it is executed in a thread pool via `run_in_threadpool`.
+    """
+
     def __init__(self, func: Callable[P, Any], *args: P.args, **kwargs: P.kwargs) -> None:
         self.func = func
         self.args = args
@@ -24,10 +31,16 @@ class BackgroundTask:
 
 
 class BackgroundTasks(BackgroundTask):
+    """A collection of background tasks that are run sequentially after a response.
+
+    Tasks are executed in the order they were added.
+    """
+
     def __init__(self, tasks: Sequence[BackgroundTask] | None = None):
         self.tasks = list(tasks) if tasks else []
 
     def add_task(self, func: Callable[P, Any], *args: P.args, **kwargs: P.kwargs) -> None:
+        """Add a new background task to the collection."""
         task = BackgroundTask(func, *args, **kwargs)
         self.tasks.append(task)
 

--- a/starlette/concurrency.py
+++ b/starlette/concurrency.py
@@ -28,6 +28,7 @@ async def run_until_first_complete(*args: tuple[Callable, dict]) -> None:  # typ
 
 
 async def run_in_threadpool(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    """Run a synchronous callable in a worker thread, returning its result."""
     func = functools.partial(func, *args, **kwargs)
     return await anyio.to_thread.run_sync(func)
 
@@ -49,6 +50,11 @@ def _next(iterator: Iterator[T]) -> T:
 async def iterate_in_threadpool(
     iterator: Iterable[T],
 ) -> AsyncIterator[T]:
+    """Adapt a synchronous iterable into an async iterator using a thread pool.
+
+    Each call to `next()` on the underlying iterator is offloaded to a worker
+    thread so that blocking iteration does not stall the event loop.
+    """
     as_iterator = iter(iterator)
     while True:
         try:


### PR DESCRIPTION
# Summary

Add docstrings to the public classes and functions in `starlette/background.py` and `starlette/concurrency.py`. These modules are part of the core public API and were missing any inline documentation.

Changes:
- `BackgroundTask` — class docstring describing purpose and async/sync dispatch behaviour
- `BackgroundTasks` — class docstring describing sequential execution semantics
- `BackgroundTasks.add_task` — one-line method docstring
- `run_in_threadpool` — one-line function docstring
- `iterate_in_threadpool` — multi-line docstring describing the thread-pool wrapping behaviour

No logic, behaviour, or test changes.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.