### PR TITLE
Security: Session Cookie Header Injection via Unsanitized `domain` Parameter

### DIFF
--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import typing
 from base64 import b64decode, b64encode
 from typing import Literal
@@ -34,6 +35,8 @@ class SessionMiddleware:
         if https_only:  # Secure flag can be used with HTTPS only
             self.security_flags += "; secure"
         if domain is not None:
+            if not re.match(r"^[a-zA-Z0-9._-]+$", domain):
+                raise ValueError("Invalid domain: must contain only alphanumeric characters, dots, hyphens, and underscores")
             self.security_flags += f"; domain={domain}"
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:


### PR DESCRIPTION
## Problem

The `domain` parameter in `SessionMiddleware.__init__` is directly interpolated into the `Set-Cookie` header string without any validation or sanitization. A value like `example.com; Path=/; SameSite=None` could override cookie security attributes. While typically developer-controlled, this violates defense-in-depth principles and could be exploited if the domain value comes from an external configuration source.

**Severity**: `medium`
**File**: `starlette/middleware/sessions.py`

## Solution

Validate the `domain` parameter to ensure it contains only valid domain characters (alphanumeric, hyphens, dots) and does not contain semicolons, spaces, or other characters that could alter cookie attributes. For example: `if domain is not None: assert re.match(r'^[a-zA-Z0-9.-]+$', domain), 'Invalid domain'`

## Changes

- `starlette/middleware/sessions.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
