### PR TITLE
docs: fix static directory wording in StaticFiles docs

### DIFF
--- a/docs/staticfiles.md
+++ b/docs/staticfiles.md
@@ -49,7 +49,7 @@ routes=[
 app = Starlette(routes=routes)
 ```
 
-By default `StaticFiles` will look for `statics` directory in each package,
+By default `StaticFiles` will look for a `static` directory in each package,
 you can change the default directory by specifying a tuple of strings.
 
 ```python


### PR DESCRIPTION
## Summary
- fix `statics` -> `static` in the `StaticFiles` docs sentence

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- No CONTRIBUTING or PR template was found in this repository. This PR keeps a single focused docs-only change in one file.

## Validation/testing note
- Not run (docs-only change)
