### PR TITLE
Add tests for request caching (body, JSON, form) and stream consumption guarantees

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -14,6 +14,12 @@ from starlette.types import Message, Receive, Scope, Send
 from tests.types import TestClientFactory
 
 
+@pytest.fixture()
+def scope() -> dict[str, Any]:
+    scope = {"type": "http", "path": "/", "method": "GET", "headers": [(b"content-type", b"application/json")]}
+    return scope
+
+
 class ReceiveTracker:
     def __init__(self) -> None:
         self._count = 0

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -14,6 +14,29 @@ from starlette.types import Message, Receive, Scope, Send
 from tests.types import TestClientFactory
 
 
+class ReceiveTracker:
+    def __init__(self) -> None:
+        self._count = 0
+        self._recieve_content = {"type": "http.request", "body": b'{"abc": 123}', "more_body": False}
+
+    async def __call__(self) -> dict[str, str | bytes | bool]:
+        self._count += 1
+        return self._recieve_content  # type: ignore[return-value]
+
+    @property
+    def call_count(self) -> int:
+        return self._count
+
+
+@pytest.fixture()
+def receive() -> ReceiveTracker:
+    """
+    Wrapper for the `receive` func that adds
+    an additional call_count
+    """
+    return ReceiveTracker()
+
+
 def test_request_url(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -57,12 +57,42 @@ async def test_body_caching(scope: dict[str, Any], receive: ReceiveTracker) -> N
 @pytest.mark.anyio
 async def test_body_to_json_caching(scope: dict[str, Any], receive: ReceiveTracker) -> None:
     request = Request(scope, receive)
-    
+
     json_body1 = await request.json()
     json_body2 = await request.json()
     assert json_body1 == json_body2
 
     assert receive.call_count == 1
+
+
+@pytest.mark.anyio
+async def test_form_caching(scope: dict[str, Any]) -> None:
+    scope_urlencoded = scope.copy()
+    scope_multipart = scope.copy()
+
+    scope_urlencoded["headers"] = [(b"content-type", b"application/x-www-form-urlencoded")]
+    scope_multipart["headers"] = [(b"content-type", b"multipart/form-data; boundary=----x")]
+
+    # Urlencoded
+    receive_url_encoded = ReceiveTracker()
+    receive_url_encoded._recieve_content["body"] = b"abc=123"
+    request_urlencoded = Request(scope_urlencoded, receive_url_encoded)
+    form_urlencoded = await request_urlencoded.form()
+    await request_urlencoded.form()
+    assert receive_url_encoded.call_count == 1
+    assert dict(form_urlencoded) == {"abc": "123"}
+
+    # Multipart
+    receive_multipart = ReceiveTracker()
+    receive_multipart._recieve_content["body"] = (
+        b'------x\r\nContent-Disposition: form-data; name="abc"\r\n\r\n123\r\n------x--\r\n'
+    )
+    request_multipart = Request(scope_multipart, receive_multipart)
+    form_multipart = await request_multipart.form()
+    await request_multipart.form()
+    assert receive_multipart.call_count == 1
+    assert dict(form_multipart) == {"abc": "123"}
+
 
 @pytest.mark.anyio
 async def test_stream_consumed_once(scope: dict[str, Any], receive: ReceiveTracker) -> None:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -43,6 +43,17 @@ def receive() -> ReceiveTracker:
     return ReceiveTracker()
 
 
+@pytest.mark.anyio
+async def test_body_caching(scope: dict[str, Any], receive: ReceiveTracker) -> None:
+    request = Request(scope, receive)
+
+    body1 = await request.body()
+    body2 = await request.body()
+    assert body1 == body2
+
+    assert receive.call_count == 1
+
+
 def test_request_url(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -55,6 +55,16 @@ async def test_body_caching(scope: dict[str, Any], receive: ReceiveTracker) -> N
 
 
 @pytest.mark.anyio
+async def test_body_to_json_caching(scope: dict[str, Any], receive: ReceiveTracker) -> None:
+    request = Request(scope, receive)
+    
+    json_body1 = await request.json()
+    json_body2 = await request.json()
+    assert json_body1 == json_body2
+
+    assert receive.call_count == 1
+
+@pytest.mark.anyio
 async def test_stream_consumed_once(scope: dict[str, Any], receive: ReceiveTracker) -> None:
     _receive = receive
     request = Request(scope, receive)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -54,6 +54,26 @@ async def test_body_caching(scope: dict[str, Any], receive: ReceiveTracker) -> N
     assert receive.call_count == 1
 
 
+@pytest.mark.anyio
+async def test_stream_consumed_once(scope: dict[str, Any], receive: ReceiveTracker) -> None:
+    _receive = receive
+    request = Request(scope, receive)
+
+    async def get_chunks() -> bytes:
+        chunks = b""
+        async for chunk in request.stream():
+            chunks += chunk
+        return chunks
+
+    await get_chunks()
+    with pytest.raises(RuntimeError) as exc:
+        await get_chunks()
+
+    assert "Stream consumed" in str(exc.value)
+
+    assert _receive.call_count == 1
+
+
 def test_request_url(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)


### PR DESCRIPTION
# Summary

<!-- Write a small summary about what is happening here. -->
Adds tests for request body caching behavior in Starlette.

This includes coverage for:
- raw body caching
- JSON-to-body caching (`request.json()`)
- form parsing caching (both `application/x-www-form-urlencoded` and `multipart/form-data`)
- stream gets consumed only once guarantees (`request.stream()`)
 
To improve test clarity and reuse, two fixtures were introduced:
- `scope`: provides a basic HTTP ASGI scope
- `receive` tracker: wraps the ASGI receive callable and tracks the call count to verify that the receive function only gets called once
# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly. (no need to update)