### PR TITLE
docs: improve grammar in contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,7 +19,7 @@ Possible bugs may be raised as a "Potential Issue" discussion, feature requests 
 be raised as an "Ideas" discussion. We can then determine if the discussion needs
 to be escalated into an "Issue" or not, or if we'd consider a pull request.
 
-Try to be as descriptive as you can and, in case of a bug report,
+Try to be as descriptive as you can and, in the case of a bug report,
 provide as much information as possible like:
 
 - OS platform

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,7 +19,7 @@ Possible bugs may be raised as a "Potential Issue" discussion, feature requests 
 be raised as an "Ideas" discussion. We can then determine if the discussion needs
 to be escalated into an "Issue" or not, or if we'd consider a pull request.
 
-Try to be more descriptive as you can and in case of a bug report,
+Try to be as descriptive as you can and, in case of a bug report,
 provide as much information as possible like:
 
 - OS platform


### PR DESCRIPTION
# Summary
- Clarify wording in `docs/contributing.md` to improve readability for new contributors.

# Checklist
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

## Validation
- Not run; docs-only wording change.