### PR TITLE
test(status): cover remaining deprecated HTTP status aliases

### DIFF
--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -14,6 +14,15 @@ import pytest
             "HTTP_414_REQUEST_URI_TOO_LONG",
             "'HTTP_414_REQUEST_URI_TOO_LONG' is deprecated. Use 'HTTP_414_URI_TOO_LONG' instead.",
         ),
+        (
+            "HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE",
+            "'HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE' is deprecated."
+            " Use 'HTTP_416_RANGE_NOT_SATISFIABLE' instead.",
+        ),
+        (
+            "HTTP_422_UNPROCESSABLE_ENTITY",
+            "'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead.",
+        ),
     ),
 )
 def test_deprecated_types(constant: str, msg: str) -> None:


### PR DESCRIPTION

**Repo:** encode/starlette (⭐ 10000)
**Type:** test
**Files changed:** 1
**Lines:** +9/-0

## What
Extends `tests/test_status.py::test_deprecated_types` to also assert the
`DeprecationWarning` emitted for `HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE`
and `HTTP_422_UNPROCESSABLE_ENTITY`, matching the four entries already
listed in `starlette.status.__deprecated__`.

## Why
`starlette/status.py` declares four deprecated aliases (413, 414, 416, 422),
but the existing parametrized test only covered the first two. The
416/422 alias paths in `__getattr__` were therefore untested, leaving the
deprecation message wording for those constants unverified — a regression
in either the alias name or the message text would slip through CI.

## Testing
`python -m pytest tests/test_status.py -q` — 5 passed (was 3).

## Risk
Low — test-only change, no production code touched.
