### PR TITLE
Fix TrustedHostMiddleware raising RuntimeError on invalid WebSocket hosts

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -57,4 +57,11 @@ class TrustedHostMiddleware:
                 response = RedirectResponse(url=str(redirect_url))
             else:
                 response = PlainTextResponse("Invalid host header", status_code=400)
-            await response(scope, receive, send)
+
+            if scope["type"] == "websocket":
+                if "websocket.http.response" in scope.get("extensions", {}):
+                    await response(scope, receive, send)
+                else:
+                    await send({"type": "websocket.close", "code": 1008})
+            else:
+                await response(scope, receive, send)

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -7,7 +7,7 @@ from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 from starlette.testclient import WebSocketDenialResponse
-from starlette.types import Scope, Receive, Send
+from starlette.types import Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect
 from tests.types import TestClientFactory
 
@@ -72,7 +72,7 @@ def test_trusted_host_middleware_websocket(test_client_factory: TestClientFactor
     # 2. Invalid host, raises WebSocketDenialResponse because test client supports websocket.http.response extension
     with pytest.raises(WebSocketDenialResponse) as exc_info:
         with client.websocket_connect("ws://invalidhost/"):
-            pass
+            pass  # pragma: no cover
     assert exc_info.value.status_code == 400
     assert exc_info.value.content == b"Invalid host header"
 
@@ -87,12 +87,17 @@ def test_trusted_host_middleware_websocket_without_denial_extension(test_client_
     app = TrustedHostMiddleware(app, allowed_hosts=["testserver"])
 
     async def mock_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
-        if "extensions" in scope:
-            scope["extensions"].pop("websocket.http.response", None)
+        scope.setdefault("extensions", {}).pop("websocket.http.response", None)
         await app(scope, receive, send)
 
     client = test_client_factory(mock_asgi_app)
+
+    # 1. Valid host
+    with client.websocket_connect("/") as websocket:
+        assert websocket.receive_text() == "OK"
+
+    # 2. Invalid host
     with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect("ws://invalidhost/"):
-            pass
+            pass  # pragma: no cover
     assert exc_info.value.code == 1008

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -4,7 +4,11 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
+from starlette.types import Scope, Receive, Send
+from starlette.websockets import WebSocket, WebSocketDisconnect
+from starlette.testclient import WebSocketDenialResponse
 from tests.types import TestClientFactory
+import pytest
 
 
 def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None:
@@ -48,3 +52,46 @@ def test_www_redirect(test_client_factory: TestClientFactory) -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert response.url == "https://www.example.com/"
+
+
+def test_trusted_host_middleware_websocket(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive, send)
+        await websocket.accept()
+        await websocket.send_text("OK")
+        await websocket.close()
+
+    app = TrustedHostMiddleware(app, allowed_hosts=["testserver"])
+    client = test_client_factory(app)
+
+    # 1. Valid host
+    with client.websocket_connect("/") as websocket:
+        assert websocket.receive_text() == "OK"
+
+    # 2. Invalid host, raises WebSocketDenialResponse because test client supports websocket.http.response extension
+    with pytest.raises(WebSocketDenialResponse) as exc_info:
+        with client.websocket_connect("ws://invalidhost/"):
+            pass
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.content == b"Invalid host header"
+
+
+def test_trusted_host_middleware_websocket_without_denial_extension(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive, send)
+        await websocket.accept()
+        await websocket.send_text("OK")
+        await websocket.close()
+
+    app = TrustedHostMiddleware(app, allowed_hosts=["testserver"])
+
+    async def mock_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
+        if "extensions" in scope:
+            scope["extensions"].pop("websocket.http.response", None)
+        await app(scope, receive, send)
+
+    client = test_client_factory(mock_asgi_app)
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("ws://invalidhost/"):
+            pass
+    assert exc_info.value.code == 1008

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -1,14 +1,15 @@
+import pytest
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
+from starlette.testclient import WebSocketDenialResponse
 from starlette.types import Scope, Receive, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect
-from starlette.testclient import WebSocketDenialResponse
 from tests.types import TestClientFactory
-import pytest
 
 
 def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
Fixes #2420

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

