### PR TITLE
feat: add `TestClient.query()` helper for the HTTP QUERY method

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -629,6 +629,41 @@ class TestClient(httpx.Client):
             extensions=extensions,
         )
 
+    def query(
+        self,
+        url: httpx._types.URLTypes,
+        *,
+        content: httpx._types.RequestContent | None = None,
+        data: _RequestData | None = None,
+        files: httpx._types.RequestFiles | None = None,
+        json: Any = None,
+        params: httpx._types.QueryParamTypes | None = None,
+        headers: httpx._types.HeaderTypes | None = None,
+        cookies: httpx._types.CookieTypes | None = None,
+        auth: httpx._types.AuthTypes | httpx._client.UseClientDefault = httpx._client.USE_CLIENT_DEFAULT,
+        follow_redirects: bool | httpx._client.UseClientDefault = httpx._client.USE_CLIENT_DEFAULT,
+        timeout: httpx._types.TimeoutTypes | httpx._client.UseClientDefault = httpx._client.USE_CLIENT_DEFAULT,
+        extensions: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        # The HTTP QUERY method is a safe, idempotent method that carries a
+        # request body. httpx has no dedicated helper for it, so dispatch
+        # through the generic ``request`` API.
+        return self.request(
+            "QUERY",
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            follow_redirects=follow_redirects,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
     def delete(  # type: ignore[override]
         self,
         url: httpx._types.URLTypes,

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -431,3 +431,26 @@ def test_timeout_deprecation() -> None:
     ):
         client = TestClient(mock_service)
         client.get("/", timeout=1)
+
+
+async def query_search_endpoint(request: Request) -> JSONResponse:
+    body = await request.json()
+    return JSONResponse({"method": request.method, "term": body["term"]})
+
+
+def test_query_method(test_client_factory: TestClientFactory) -> None:
+    app = Starlette(routes=[Route("/search", endpoint=query_search_endpoint, methods=["QUERY"])])
+    client = test_client_factory(app)
+
+    response = client.query("/search", json={"term": "fastapi"})
+    assert response.status_code == 200
+    assert response.json() == {"method": "QUERY", "term": "fastapi"}
+
+
+def test_query_method_not_allowed(test_client_factory: TestClientFactory) -> None:
+    app = Starlette(routes=[Route("/search", endpoint=query_search_endpoint, methods=["QUERY"])])
+    client = test_client_factory(app)
+
+    response = client.get("/search")
+    assert response.status_code == 405
+    assert "QUERY" in response.headers["allow"]


### PR DESCRIPTION
## Summary

Add a `query()` convenience method to `TestClient`, mirroring the existing body-carrying helpers (`post`, `put`, `patch`). `QUERY` is a *new* HTTP method standardized in [RFC 10008 - "The HTTP QUERY Method"](https://datatracker.ietf.org/doc/rfc10008/) (June 2026): a safe, idempotent method that carries a request body. `httpx` exposes no dedicated helper for it, so `query()` dispatches through the generic `request()` API with method `"QUERY"`.

## Why

Starlette already routes the `QUERY` method (the router has no method whitelist), so this is purely an ergonomic test-client addition - `client.query("/path", json=...)` instead of `client.request("QUERY", "/path", json=...)`. It complements first-class `QUERY` support being added in FastAPI.

## Tests

- `test_query_method`: a `QUERY` request with a JSON body is routed and the body is read back.
- `test_query_method_not_allowed`: a non-`QUERY` request to a `QUERY`-only route returns `405` with `QUERY` in the `Allow` header.

Both run on the asyncio and trio backends. `ruff check`/`format` pass and the full `tests/test_testclient.py` suite is green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

