### PR TITLE
Add HTTP 103 Early Hints support to Request

### DIFF
--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -34,3 +34,41 @@ routes = [
 
 app = Starlette(routes=routes)
 ```
+### `Request.send_early_hints`
+
+Used to initiate HTTP 103 Early Hints for one or more resources. If the
+`http.response.early_hint` ASGI extension is not available this method does
+nothing.
+
+Signature: `send_early_hints(links)`
+
+* `links` - An iterable of `bytes` containing RFC 8288 `Link` header values.
+
+```python
+from starlette.applications import Starlette
+from starlette.responses import HTMLResponse
+from starlette.routing import Route
+
+
+async def homepage(request):
+    """
+    Homepage which uses HTTP 103 Early Hints to advertise resources.
+    """
+    await request.send_early_hints(
+        [
+            b'</static/style.css>; rel=preload; as=style',
+            b'</static/app.js>; rel=modulepreload',
+        ]
+    )
+
+    return HTMLResponse(
+        '<html><head><link rel="stylesheet" href="/static/style.css"/></head></html>'
+    )
+
+
+routes = [
+    Route("/", endpoint=homepage),
+]
+
+app = Starlette(routes=routes)
+```

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
-from collections.abc import AsyncGenerator, Iterator, Mapping
+from collections.abc import AsyncGenerator, Iterable, Iterator, Mapping
 from http import cookies as http_cookies
 from typing import TYPE_CHECKING, Any, Generic, NoReturn, cast
 
@@ -346,3 +346,13 @@ class Request(HTTPConnection[StateT]):
                 for value in self.headers.getlist(name):
                     raw_headers.append((name.encode("latin-1"), value.encode("latin-1")))
             await self._send({"type": "http.response.push", "path": path, "headers": raw_headers})
+
+    async def send_early_hints(self, links: Iterable[bytes]) -> None:
+        if "http.response.early_hint" not in self.scope.get("extensions", {}):
+            return
+        await self._send(
+            {
+                "type": "http.response.early_hint",
+                "links": list(links),
+            }
+        )

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -13,6 +13,8 @@ from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.types import Message, Receive, Scope, Send
 from tests.types import TestClientFactory
 
+EARLY_HINT_LINK = b"</style.css>; rel=preload; as=style"
+
 
 def test_request_url(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
@@ -562,6 +564,45 @@ def test_request_send_push_promise_without_setting_send(
     client = test_client_factory(app)
     response = client.get("/")
     assert response.json() == {"json": "Send channel not available"}
+
+
+@pytest.mark.anyio
+async def test_request_send_early_hints() -> None:
+    sent = []
+
+    async def mock_send(msg):
+        sent.append(msg)
+
+    scope = {"type": "http", "extensions": {"http.response.early_hint": {}}}
+    request = Request(scope, send=mock_send)
+
+    await request.send_early_hints([EARLY_HINT_LINK])
+
+    assert len(sent) == 1
+    assert sent == [{"type": "http.response.early_hint", "links": [EARLY_HINT_LINK]}]
+
+
+@pytest.mark.anyio
+async def test_request_send_early_hints_no_extension() -> None:
+    sent = []
+
+    async def mock_send(msg):
+        sent.append(msg)
+
+    scope = {"type": "http", "extensions": {}}
+    request = Request(scope, send=mock_send)
+
+    await request.send_early_hints([EARLY_HINT_LINK])
+    assert sent == []
+
+
+@pytest.mark.anyio
+async def test_request_send_early_hints_no_send_channel() -> None:
+    scope = {"type": "http", "extensions": {"http.response.early_hint": {}}}
+    request = Request(scope)
+
+    with pytest.raises(RuntimeError):
+        await request.send_early_hints([EARLY_HINT_LINK])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -586,11 +586,8 @@ async def test_request_send_early_hints() -> None:
 async def test_request_send_early_hints_no_extension() -> None:
     sent: list[Message] = []
 
-    async def mock_send(msg: Message) -> None:
-        sent.append(msg)
-
     scope = {"type": "http", "extensions": {}}
-    request = Request(scope, send=mock_send)
+    request = Request(scope)
 
     await request.send_early_hints([EARLY_HINT_LINK])
     assert sent == []

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -568,9 +568,9 @@ def test_request_send_push_promise_without_setting_send(
 
 @pytest.mark.anyio
 async def test_request_send_early_hints() -> None:
-    sent = []
+    sent: list[Message] = []
 
-    async def mock_send(msg):
+    async def mock_send(msg: Message) -> None:
         sent.append(msg)
 
     scope = {"type": "http", "extensions": {"http.response.early_hint": {}}}
@@ -584,9 +584,9 @@ async def test_request_send_early_hints() -> None:
 
 @pytest.mark.anyio
 async def test_request_send_early_hints_no_extension() -> None:
-    sent = []
+    sent: list[Message] = []
 
-    async def mock_send(msg):
+    async def mock_send(msg: Message) -> None:
         sent.append(msg)
 
     scope = {"type": "http", "extensions": {}}


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This PR adds Request.send_early_hints() to support the ASGI http.response.early_hint extension.

The implementation follows the existing Request.send_push_promise() pattern by:

`Checking whether the http.response.early_hint extension is available before sending.`
`Sending an ASGI http.response.early_hint message containing the provided link values.`
`Returning without sending anything when the extension is not supported.`

## Tests

Added tests covering:

- Sending early hints when the extension is available.
- No-op behavior when the extension is unavailable.
- RuntimeError when no send channel is available, matching the existing send_push_promise() behavior.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

