### PR TITLE
Raise WebSocketDisconnect after duplicate close

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -95,7 +95,7 @@ class WebSocket(HTTPConnection[StateT]):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            raise WebSocketDisconnect()
 
     async def accept(
         self,

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -488,7 +488,7 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/"):
             pass  # pragma: no cover
 


### PR DESCRIPTION
# Summary

Fixes #2766.

`WebSocket.send()` now raises `WebSocketDisconnect` when the application-side websocket state is already disconnected. This matches the existing disconnect exception used elsewhere in the websocket API and leaves the receive-after-disconnect path unchanged.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

No documentation update was needed because this keeps the existing websocket exception type consistent rather than adding a new API.

Verification:

- `.venv-codex/bin/python -m pytest tests/test_websockets.py::test_duplicate_close tests/test_websockets.py::test_duplicate_disconnect -q`
- `.venv-codex/bin/python -m pytest tests/test_websockets.py -q`
- `.venv-codex/bin/python -m ruff format --check --diff starlette tests`
- `.venv-codex/bin/python -m ruff check starlette tests`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

