### PR TITLE
Fixes #3357 Allow IPv6 trusted hosts

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 
 from starlette.datastructures import URL, Headers
@@ -7,6 +8,8 @@ from starlette.responses import PlainTextResponse, RedirectResponse, Response
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 ENFORCE_DOMAIN_WILDCARD = "Domain wildcard patterns must be like '*.example.com'."
+
+host_validation_re = re.compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9.:]+])(?::([0-9]+))?$")
 
 
 class TrustedHostMiddleware:
@@ -37,10 +40,12 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = headers.get("host", "").split(":")[0]
+        host = headers.get("host", "")
+        host = split_domain(host)
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:
+            pattern = pattern.lower()
             if host == pattern or (pattern.startswith("*") and host.endswith(pattern[1:])):
                 is_valid_host = True
                 break
@@ -58,3 +63,11 @@ class TrustedHostMiddleware:
             else:
                 response = PlainTextResponse("Invalid host header", status_code=400)
             await response(scope, receive, send)
+
+
+def split_domain(host: str) -> str:
+    if match := host_validation_re.fullmatch(host.lower()):
+        domain, _ = match.groups(default="")
+        # Remove a trailing dot (if present) from the domain.
+        return domain.removesuffix(".")
+    return ""

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -5,6 +5,7 @@ import inspect
 import io
 import json
 import math
+import re
 import sys
 import warnings
 from collections.abc import Awaitable, Callable, Generator, Iterable, Mapping, MutableMapping, Sequence
@@ -231,8 +232,8 @@ class _TestClientTransport(httpx.BaseTransport):
 
         default_port = {"http": 80, "ws": 80, "https": 443, "wss": 443}[scheme]
 
-        if ":" in netloc:
-            host, port_string = netloc.split(":", 1)
+        if re.search(r":\d+$", netloc):
+            host, port_string = netloc.rsplit(":", 1)
             port = int(port_string)
         else:
             host = netloc

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -13,7 +13,7 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
 
     app = Starlette(
         routes=[Route("/", endpoint=homepage)],
-        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["testserver", "*.testserver"])],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["testserver", "*.testserver", "[::1]"])],
     )
 
     client = test_client_factory(app)
@@ -24,7 +24,15 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
     response = client.get("/")
     assert response.status_code == 200
 
+    client = test_client_factory(app, base_url="http://[::1]")
+    response = client.get("/")
+    assert response.status_code == 200
+
     client = test_client_factory(app, base_url="http://invalidhost")
+    response = client.get("/")
+    assert response.status_code == 400
+
+    client = test_client_factory(app, base_url="http://")
     response = client.get("/")
     assert response.status_code == 400
 


### PR DESCRIPTION
Fixes #3357

# Summary

Improved parsing of domain names from the `HOST` header from how Django does it. See https://github.com/django/django/blob/318a316a4c86a65bede68144f9546a6056d91379/django/http/request.py#L849-L860

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

