### PR TITLE
Handle bracketed IPv6 hosts in TrustedHostMiddleware and TestClient

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from starlette.datastructures import URL, Headers
+from starlette.datastructures import _HOST_RE, URL, Headers
 from starlette.responses import PlainTextResponse, RedirectResponse, Response
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -37,7 +37,11 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = headers.get("host", "").split(":")[0]
+        host_match = _HOST_RE.fullmatch(headers.get("host", ""))
+        if host_match is None:
+            await PlainTextResponse("Invalid host header", status_code=400)(scope, receive, send)
+            return
+        host = host_match.group(1)
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -224,27 +224,21 @@ class _TestClientTransport(httpx.BaseTransport):
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         scheme = request.url.scheme
-        netloc = request.url.netloc.decode(encoding="ascii")
+        host = request.url.raw_host.decode(encoding="ascii")
         path = request.url.path
         raw_path = request.url.raw_path
         query = request.url.query.decode(encoding="ascii")
 
         default_port = {"http": 80, "ws": 80, "https": 443, "wss": 443}[scheme]
-
-        if ":" in netloc:
-            host, port_string = netloc.split(":", 1)
-            port = int(port_string)
-        else:
-            host = netloc
+        port = request.url.port
+        if port is None:
             port = default_port
 
         # Include the 'host' header.
         if "host" in request.headers:
             headers: list[tuple[bytes, bytes]] = []
-        elif port == default_port:  # pragma: no cover
-            headers = [(b"host", host.encode())]
         else:  # pragma: no cover
-            headers = [(b"host", (f"{host}:{port}").encode())]
+            headers = [(b"host", request.url.netloc)]
 
         # Include other request headers.
         headers += [(key.lower().encode(), value.encode()) for key, value in request.headers.multi_items()]

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -48,3 +48,36 @@ def test_www_redirect(test_client_factory: TestClientFactory) -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert response.url == "https://www.example.com/"
+
+
+def test_trusted_host_middleware_ipv6(test_client_factory: TestClientFactory) -> None:
+    # https://github.com/encode/starlette/issues/3357
+    def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("OK", status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]"])],
+    )
+    client = test_client_factory(app)
+
+    for host in ("[::1]", "[::1]:8000"):
+        response = client.get("/", headers={"host": host})
+        assert response.status_code == 200, host
+
+    response = client.get("/", headers={"host": "[2001:db8::1]"})
+    assert response.status_code == 400
+
+    for malformed_host in (
+        "[::1",
+        "[::1]evil.com",
+        "[::1]@attacker",
+        "[::1].",
+        "[::1]:evil",
+        "[::1]evil.example.com",
+    ):
+        response = client.get("/", headers={"host": malformed_host})
+        assert response.status_code == 400, malformed_host
+
+    response = client.get("/", headers={b"host": b"[::1]:\xb2"})
+    assert response.status_code == 400

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -450,6 +450,25 @@ def test_raw_path_with_querystring(test_client_factory: TestClientFactory) -> No
     assert response.content == b"/hello-world"
 
 
+@pytest.mark.parametrize(
+    ("base_url", "server"),
+    [
+        ("http://[::1]", ["::1", 80]),
+        ("http://[::1]:8000", ["::1", 8000]),
+        ("http://[::1]:0", ["::1", 0]),
+    ],
+)
+def test_ipv6_base_url(test_client_factory: TestClientFactory, base_url: str, server: list[str | int]) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert scope["server"] == server
+        response = Response("OK")
+        await response(scope, receive, send)
+
+    client = test_client_factory(app, base_url=base_url)
+    response = client.get("/")
+    assert response.status_code == 200
+
+
 def test_websocket_raw_path_without_params(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         websocket = WebSocket(scope, receive=receive, send=send)


### PR DESCRIPTION
Fixes #3357 (raised in discussion #3321)

## Summary

`TrustedHostMiddleware` strips the port with `host.split(":")[0]`, so an IPv6 host header such as `[::1]:8000` is reduced to `"["` and rejected even when `allowed_hosts=["[::1]"]`.

`TestClient` has the same class of bug: a bracketed IPv6 `base_url`, such as `http://[::1]:8000`, raises `ValueError` when everything after the first colon is interpreted as the port.

## Changes

- **`TrustedHostMiddleware`** reuses Starlette's existing Host-header validation and extracts its captured hostname. Bracketed IPv6 literals retain their brackets for comparison with `allowed_hosts`, while malformed Host headers are rejected.
- **`TestClient`** relies on the URL implementation's `raw_host`, `port`, and canonical `netloc` properties instead of parsing the netloc manually. The ASGI `server` host remains unbracketed, while a synthesized `Host` header remains correctly bracketed.
- Middleware and TestClient regression tests are independent, so failures identify the affected component directly.

## Tests

- 1069 passed, 2 skipped, 2 xfailed
- Ruff check and format checks pass
- mypy passes for all changed files

## Disclosure

Prepared with the assistance of an AI tool (Claude Code); the changes and test results were reviewed and verified.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
