### PR TITLE
Fix TrustedHostMiddleware IPv6 host header parsing

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -37,7 +37,12 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = headers.get("host", "").split(":")[0]
+        host_header = headers.get("host", "")
+        if host_header.startswith("["):
+            # IPv6 address: "[::1]" or "[::1]:port"
+            host = host_header.split("]")[0] + "]"
+        else:
+            host = host_header.split(":")[0]
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -35,6 +35,27 @@ def test_default_allowed_hosts() -> None:
     assert middleware.allowed_hosts == ["*"]
 
 
+def test_trusted_host_middleware_ipv6(test_client_factory: TestClientFactory) -> None:
+    def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("OK", status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]"])],
+    )
+
+    client = test_client_factory(app)
+
+    response = client.get("/", headers={"host": "[::1]"})
+    assert response.status_code == 200
+
+    response = client.get("/", headers={"host": "[::1]:8000"})
+    assert response.status_code == 200
+
+    response = client.get("/", headers={"host": "invalidhost"})
+    assert response.status_code == 400
+
+
 def test_www_redirect(test_client_factory: TestClientFactory) -> None:
     def homepage(request: Request) -> PlainTextResponse:
         return PlainTextResponse("OK", status_code=200)


### PR DESCRIPTION
Fixes #3357

---

`TrustedHostMiddleware` splits the `Host` header on `:` to strip the port, but IPv6 addresses like `[::1]:8000` contain colons within brackets. The split produces `[` instead of `[::1]`, so IPv6 hosts are always rejected.

This detects bracket notation and splits on `]` instead, preserving the full IPv6 address for the allowed-hosts comparison.

Assisted-by: Claude Opus 4.6

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

