### PR TITLE
Fix TestClient IPv6 base_url parsing

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -231,7 +231,15 @@ class _TestClientTransport(httpx.BaseTransport):
 
         default_port = {"http": 80, "ws": 80, "https": 443, "wss": 443}[scheme]
 
-        if ":" in netloc:
+        if netloc.startswith("["):
+            # IPv6: "[::1]" or "[::1]:port"
+            bracket_end = netloc.index("]")
+            host = netloc[1:bracket_end]
+            if bracket_end + 1 < len(netloc) and netloc[bracket_end + 1] == ":":
+                port = int(netloc[bracket_end + 2 :])
+            else:
+                port = default_port
+        elif ":" in netloc:
             host, port_string = netloc.split(":", 1)
             port = int(port_string)
         else:

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -425,6 +425,28 @@ def test_websocket_raw_path_without_params(test_client_factory: TestClientFactor
         assert data == b"/hello-world"
 
 
+def test_testclient_ipv6_base_url(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert scope["server"] == ["::1", 8000]
+        response = Response("OK")
+        await response(scope, receive, send)
+
+    client = test_client_factory(app, base_url="http://[::1]:8000")
+    response = client.get("/")
+    assert response.status_code == 200
+
+
+def test_testclient_ipv6_base_url_default_port(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert scope["server"] == ["::1", 80]
+        response = Response("OK")
+        await response(scope, receive, send)
+
+    client = test_client_factory(app, base_url="http://[::1]")
+    response = client.get("/")
+    assert response.status_code == 200
+
+
 def test_timeout_deprecation() -> None:
     with pytest.warns(
         StarletteDeprecationWarning, match="You should not use the 'timeout' argument with the TestClient."


### PR DESCRIPTION
Related to #3357 (same class of bug — `:` splitting breaks IPv6).

---

`TestClient` with an IPv6 `base_url` like `http://[::1]:8000` crashes with `ValueError: invalid literal for int() with base 10: ':1]'` because the netloc is split on `:` without accounting for bracket notation.

This adds IPv6-aware parsing that extracts the bare address and port from bracketed notation before falling through to the existing split logic.

Assisted-by: Claude Opus 4.6

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

