### PR TITLE
fix: support IPv6 addresses in TrustedHostMiddleware

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -37,7 +37,13 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = headers.get("host", "").split(":")[0]
+        host = headers.get("host", "")
+        if host.startswith("["):
+            closing_bracket = host.find("]")
+            if closing_bracket != -1 and (closing_bracket == len(host) - 1 or host[closing_bracket + 1] == ":"):
+                host = host[: closing_bracket + 1]
+        else:
+            host = host.split(":", 1)[0]
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -40,7 +40,8 @@ class TrustedHostMiddleware:
         host = headers.get("host", "")
         if host.startswith("["):
             closing_bracket = host.find("]")
-            if closing_bracket != -1 and (closing_bracket == len(host) - 1 or host[closing_bracket + 1] == ":"):
+            suffix = host[closing_bracket + 1 :] if closing_bracket != -1 else ""
+            if closing_bracket != -1 and (not suffix or (suffix.startswith(":") and suffix[1:].isdigit())):
                 host = host[: closing_bracket + 1]
         else:
             host = host.split(":", 1)[0]

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -41,7 +41,9 @@ class TrustedHostMiddleware:
         if host.startswith("["):
             closing_bracket = host.find("]")
             suffix = host[closing_bracket + 1 :] if closing_bracket != -1 else ""
-            if closing_bracket != -1 and (not suffix or (suffix.startswith(":") and suffix[1:].isdigit())):
+            if closing_bracket != -1 and (
+                not suffix or (suffix.startswith(":") and suffix[1:].isascii() and suffix[1:].isdigit())
+            ):
                 host = host[: closing_bracket + 1]
         else:
             host = host.split(":", 1)[0]

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -29,6 +29,20 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
     assert response.status_code == 400
 
 
+def test_trusted_host_middleware_with_ipv6(test_client_factory: TestClientFactory) -> None:
+    def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("OK", status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]"])],
+    )
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"host": "[::1]:8000"})
+    assert response.status_code == 200
+
+
 def test_default_allowed_hosts() -> None:
     app = Starlette()
     middleware = TrustedHostMiddleware(app)

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -42,6 +42,12 @@ def test_trusted_host_middleware_with_ipv6(test_client_factory: TestClientFactor
     response = client.get("/", headers={"host": "[::1]:8000"})
     assert response.status_code == 200
 
+    response = client.get("/", headers={"host": "[::1]:attacker"})
+    assert response.status_code == 400
+
+    response = client.get("/", headers={"host": "[::1]:"})
+    assert response.status_code == 400
+
 
 def test_default_allowed_hosts() -> None:
     app = Starlette()

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -48,6 +48,9 @@ def test_trusted_host_middleware_with_ipv6(test_client_factory: TestClientFactor
     response = client.get("/", headers={"host": "[::1]:"})
     assert response.status_code == 400
 
+    response = client.get("/", headers={b"host": b"[::1]:\xb2"})
+    assert response.status_code == 400
+
 
 def test_default_allowed_hosts() -> None:
     app = Starlette()


### PR DESCRIPTION
## Summary
- preserve bracketed IPv6 literals while removing an optional port from `Host`
- add `TrustedHostMiddleware` coverage for `[::1]:8000`

## Root cause
The middleware split `Host` on the first colon, converting `[::1]:8000` to `[`. A configured `[::1]` host was therefore rejected.

Fixes #3357

## Validation
- `python -m pytest tests/middleware/test_trusted_host.py -q`
- `ruff check starlette/middleware/trustedhost.py tests/middleware/test_trusted_host.py`
- `ruff format --check starlette/middleware/trustedhost.py tests/middleware/test_trusted_host.py`
- `mypy starlette/middleware/trustedhost.py tests/middleware/test_trusted_host.py`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

