### PR TITLE
Fix KeyError on empty text frame in WebSocketEndpoint with default encoding

### DIFF
--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -90,13 +90,13 @@ class WebSocketEndpoint:
 
     async def decode(self, websocket: WebSocket, message: Message) -> Any:
         if self.encoding == "text":
-            if "text" not in message:
+            if message.get("text") is None:
                 await websocket.close(code=status.WS_1003_UNSUPPORTED_DATA)
                 raise RuntimeError("Expected text websocket messages, but got bytes")
             return message["text"]
 
         elif self.encoding == "bytes":
-            if "bytes" not in message:
+            if message.get("bytes") is None:
                 await websocket.close(code=status.WS_1003_UNSUPPORTED_DATA)
                 raise RuntimeError("Expected bytes websocket messages, but got text")
             return message["bytes"]

--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -114,7 +114,7 @@ class WebSocketEndpoint:
                 raise RuntimeError("Malformed JSON data received.")
 
         assert self.encoding is None, f"Unsupported 'encoding' attribute {self.encoding}"
-        return message["text"] if message.get("text") else message["bytes"]
+        return message["text"] if message.get("text") is not None else message["bytes"]
 
     async def on_connect(self, websocket: WebSocket) -> None:
         """Override to handle an incoming websocket connection"""

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -165,6 +165,22 @@ def test_websocket_endpoint_on_default(test_client_factory: TestClientFactory) -
         assert _text == "Message text was: Hello, world!"
 
 
+def test_websocket_endpoint_on_default_empty_text(
+    test_client_factory: TestClientFactory,
+) -> None:
+    class WebSocketApp(WebSocketEndpoint):
+        encoding = None
+
+        async def on_receive(self, websocket: WebSocket, data: str) -> None:
+            await websocket.send_text(f"Message text was: {data!r}")
+
+    client = test_client_factory(WebSocketApp)
+    with client.websocket_connect("/ws") as websocket:
+        websocket.send_text("")
+        _text = websocket.receive_text()
+        assert _text == "Message text was: ''"
+
+
 def test_websocket_endpoint_on_disconnect(
     test_client_factory: TestClientFactory,
 ) -> None:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,12 +1,15 @@
 from collections.abc import Iterator
+from typing import Literal
 
 import pytest
 
+from starlette import status
 from starlette.endpoints import HTTPEndpoint, WebSocketEndpoint
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route, Router
 from starlette.testclient import TestClient
+from starlette.types import Message
 from starlette.websockets import WebSocket
 from tests.types import TestClientFactory
 
@@ -179,6 +182,57 @@ def test_websocket_endpoint_on_default_empty_text(
         websocket.send_text("")
         _text = websocket.receive_text()
         assert _text == "Message text was: ''"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "encoding,message,expected_error",
+    [
+        (
+            "text",
+            {"type": "websocket.receive", "text": None, "bytes": b"Hello, world!"},
+            "Expected text websocket messages, but got bytes",
+        ),
+        (
+            "bytes",
+            {"type": "websocket.receive", "bytes": None, "text": "Hello, world!"},
+            "Expected bytes websocket messages, but got text",
+        ),
+    ],
+)
+async def test_websocket_endpoint_encoding_mismatch_with_explicit_none(
+    encoding: Literal["text", "bytes"],
+    message: Message,
+    expected_error: str,
+) -> None:
+    # The ASGI spec allows servers to send both `text` and `bytes` with the unused one set
+    # to `None` ("Optional; if missing, it is equivalent to None"). Hypercorn always does
+    # this, so the encoding check must treat an explicit `None` like a missing key.
+    class WebSocketApp(WebSocketEndpoint):
+        pass
+
+    WebSocketApp.encoding = encoding
+
+    received = [
+        {"type": "websocket.connect"},
+        message,
+        {"type": "websocket.disconnect", "code": status.WS_1000_NORMAL_CLOSURE},
+    ]
+    sent: list[Message] = []
+
+    async def receive() -> Message:
+        return received.pop(0)
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    with pytest.raises(RuntimeError, match=expected_error):
+        await WebSocketApp({"type": "websocket", "path": "/ws"}, receive, send)
+
+    assert sent == [
+        {"type": "websocket.accept", "subprotocol": None, "headers": []},
+        {"type": "websocket.close", "code": status.WS_1003_UNSUPPORTED_DATA, "reason": ""},
+    ]
 
 
 def test_websocket_endpoint_on_disconnect(


### PR DESCRIPTION
## Summary

`WebSocketEndpoint.decode` raises `KeyError: 'bytes'` when a client sends an **empty text frame** and the endpoint uses the default `encoding = None`.

## Reproduction

```python
from starlette.applications import Starlette
from starlette.endpoints import WebSocketEndpoint
from starlette.routing import WebSocketRoute
from starlette.testclient import TestClient

class Echo(WebSocketEndpoint):
    encoding = None  # default

    async def on_receive(self, websocket, data):
        await websocket.send_text(f"got:{data!r}")

client = TestClient(Starlette(routes=[WebSocketRoute("/ws", Echo)]))
with client.websocket_connect("/ws") as ws:
    ws.send_text("")          # empty text frame
    print(ws.receive_text())  # KeyError: 'bytes'
```

- **Actual:** `KeyError: 'bytes'` inside `decode`; `dispatch` catches it, closes with code `1011`, and re-raises. `on_receive` is never called.
- **Expected:** `on_receive` receives `""`.

## Root cause

```python
return message["text"] if message.get("text") else message["bytes"]
```

An empty text frame is `{"type": "websocket.receive", "text": ""}` with no `"bytes"` key. The truthiness check treats the valid empty string `""` as falsy, so it falls through to `message["bytes"]` and raises `KeyError`.

## Fix

Use `is not None`, matching the check already used in the `encoding == "json"` branch a few lines above:

```python
return message["text"] if message.get("text") is not None else message["bytes"]
```

This only changes the `text == ""` case (from `KeyError` to returning `""`); empty binary frames and all other cases are unchanged.

## Test

Added `test_websocket_endpoint_on_default_empty_text` in `tests/test_endpoints.py`, mirroring the existing `test_websocket_endpoint_on_default`. It fails before the change (`KeyError: 'bytes'`) and passes after. `scripts/check` (ruff format, ruff check, mypy) passes locally.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

