### PR TITLE
fix(websockets): raise WebSocketDisconnect after close on send

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -95,7 +95,9 @@ class WebSocket(HTTPConnection[StateT]):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            # Already disconnected: raise WebSocketDisconnect so concurrent
+            # close/send paths can handle this like a normal disconnect (#2766).
+            raise WebSocketDisconnect()
 
     async def accept(
         self,

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -15,6 +15,7 @@ class WebSocketState(enum.Enum):
     CONNECTED = 1
     DISCONNECTED = 2
     RESPONSE = 3
+    RESPONSE_COMPLETE = 4
 
 
 class WebSocketDisconnect(Exception):
@@ -92,8 +93,10 @@ class WebSocket(HTTPConnection[StateT]):
             if message_type != "websocket.http.response.body":
                 raise RuntimeError(f'Expected ASGI message "websocket.http.response.body", but got {message_type!r}')
             if not message.get("more_body", False):
-                self.application_state = WebSocketState.DISCONNECTED
+                self.application_state = WebSocketState.RESPONSE_COMPLETE
             await self._send(message)
+        elif self.application_state == WebSocketState.RESPONSE_COMPLETE:
+            raise RuntimeError('Cannot call "send" once an HTTP denial response has been completed.')
         else:
             # Already disconnected: raise WebSocketDisconnect so concurrent
             # close/send paths can handle this like a normal disconnect (#2766).

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -488,7 +488,7 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/"):
             pass  # pragma: no cover
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -385,6 +385,20 @@ def test_send_response_multi(test_client_factory: TestClientFactory) -> None:
     assert exc.value.headers["foo"] == "bar"
 
 
+def test_send_after_completed_denial_response_raises_runtime_error(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive=receive, send=send)
+        message = await websocket.receive()
+        assert message == {"type": "websocket.connect"}
+        await websocket.send_denial_response(Response(status_code=404, content="foo"))
+        await websocket.send({"type": "websocket.http.response.body", "body": b"again"})
+
+    client = test_client_factory(app)
+    with pytest.raises(RuntimeError, match='Cannot call "send" once an HTTP denial response has been completed'):
+        with client.websocket_connect("/"):
+            pass  # pragma: no cover
+
+
 def test_send_response_unsupported(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         del scope["extensions"]["websocket.http.response"]


### PR DESCRIPTION
# Summary

After a WebSocket has already been closed / disconnected, further `send`/`close` used to raise `RuntimeError`. Per discussion #2762 / issue #2766, raise `WebSocketDisconnect` instead so concurrent close/send paths can treat this as a normal disconnect.

Updated `test_duplicate_close` accordingly.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

Fixes #2766


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

