### PR TITLE
fix(websockets): raise WebSocketDisconnect after app already closed

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -95,7 +95,9 @@ class WebSocket(HTTPConnection[StateT]):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            # After the application has closed the socket, further sends should look like a
+            # disconnect to callers (same family as OSError-on-send), not a programmer RuntimeError.
+            raise WebSocketDisconnect(code=1000)
 
     async def accept(
         self,

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -488,7 +488,7 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/"):
             pass  # pragma: no cover
 


### PR DESCRIPTION
# Summary

Fixes #2766 / discussion #2762.

After the application has already closed a WebSocket, further `send()` / `close()` calls raised `RuntimeError("Cannot call "send" once a close message has been sent.")`. That looks like a programming error, while the analogous case where the client is gone already raises `WebSocketDisconnect` (via `OSError` on send).

Raise `WebSocketDisconnect(code=1000)` instead so callers can handle post-close sends with the same exception family.

Leave the **receive-after-disconnect** path as `RuntimeError` — that remains a distinct misuse.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (Discussion #2762 / issue #2766)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

## Test plan

```bash
pytest tests/test_websockets.py::test_duplicate_close \
       tests/test_websockets.py::test_duplicate_disconnect \
       tests/test_websockets.py::test_application_close \
       tests/test_websockets.py::test_client_disconnect_on_send -q
# 4 passed
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

