### PR TITLE
Add brotli compression capability to starlette

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ $ uvicorn main:app
 
 Starlette only requires `anyio`, and the following are optional:
 
+* [`brotli`][brotli] - Required if you want to use the `BrotliMiddleware`.
 * [`httpx2`][httpx2] - Required if you want to use the `TestClient`.
 * [`jinja2`][jinja2] - Required if you want to use `Jinja2Templates`.
 * [`python-multipart`][python-multipart] - Required if you want to support form parsing, with `request.form()`.
@@ -132,6 +133,7 @@ in isolation.
 <p align="center"><i>Starlette is <a href="https://github.com/Kludex/starlette/blob/main/LICENSE.md">BSD licensed</a> code.<br/>Designed & crafted with care.</i></br>&mdash; ⭐️ &mdash;</p>
 
 [asgi]: https://asgi.readthedocs.io/en/latest/
+[brotli]: https://pypi.org/project/brotli/
 [httpx2]: https://pypi.org/project/httpx2/
 [jinja2]: https://jinja.palletsprojects.com/
 [python-multipart]: https://multipart.fastapiexpert.com/

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ It is production-ready, and gives you the following:
 * WebSocket support.
 * In-process background tasks.
 * Startup and shutdown events.
-* Test client built on `httpx`.
-* CORS, GZip, Static Files, Streaming responses.
+* Test client built on `httpx2`.
+* CORS, Brotli, GZip, Static Files, Streaming responses.
 * Session and Cookie support.
 * 100% test coverage.
 * 100% type annotated codebase.

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -246,6 +246,59 @@ The following arguments are supported:
 The middleware won't GZip responses that already have either a `Content-Encoding` set, to prevent them from
 being encoded twice, or a `Content-Type` set to `text/event-stream`, to avoid compressing server-sent events.
 
+## BrotliMiddleware
+
+Handles Brotli responses for any request that includes `"br"` in the `Accept-Encoding` header.
+
+The middleware will handle both standard and streaming responses.
+
+??? info "Buffer on streaming responses"
+    On streaming responses, the middleware will buffer the response before compressing it.
+
+    The idea is that we don't want to compress every small chunk of data, as it would be inefficient.
+    Instead, we buffer the response until it reaches a certain size, and then compress it.
+
+    This may cause a delay in the response, as the middleware waits for the buffer to fill up before compressing it.
+
+```python
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.brotli import BrotliMiddleware
+
+
+routes = ...
+
+middleware = [
+    Middleware(BrotliMiddleware, minimum_size=400, quality=4, mode="text")
+]
+
+app = Starlette(routes=routes, middleware=middleware)
+```
+
+!!! tip "Installation"
+    The Brotli middleware requires the `brotli` package. Install it with the `brotli` extra:
+
+    ```bash
+    pip install "starlette[brotli]"
+    ```
+    Or include it with the full extra:
+    ```bash
+    pip install "starlette[full]"
+    ```
+
+The following arguments are supported:
+
+* `minimum_size` - Do not Brotli responses that are smaller than this minimum size in bytes. Defaults to `400`.
+* `quality` - Compression quality from 0 to 11. Defaults to `4`. Higher values give better compression but are slower.
+* `mode` - Compression mode: `"text"` (default), `"generic"`, or `"font"`.
+* `lgwin` - Base-2 logarithm of the sliding window size (10-24). Defaults to `22`.
+* `lgblock` - Base-2 logarithm of the maximum input block size (0-24). Defaults to `0` (automatic).
+* `gzip_fallback` - If `True` (default), fall back to GZip when client doesn't accept `br` but accepts `gzip`.
+* `excluded_handlers` - List of regex patterns for request paths to skip compression entirely.
+* `thread_minimum_size` - Compress body chunks at least this large in a worker thread. Defaults to `131072` (128 KiB).
+
+The middleware won't Brotli responses that already have a `Content-Encoding` set, to prevent double-encoding, or a `Content-Type` of `text/event-stream`, to avoid compressing server-sent events.
+
 ## BaseHTTPMiddleware
 
 An abstract class that allows you to write ASGI middleware against a request/response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ full = [
     "pyyaml",
     "httpx>=0.27.0,<0.29.0",
     "httpx2>=2.0.0",
+    "brotli",
+]
+brotli = [
+    "brotli",
 ]
 
 [dependency-groups]

--- a/starlette/middleware/brotli.py
+++ b/starlette/middleware/brotli.py
@@ -68,7 +68,7 @@ class BrotliMiddleware:
 
         # Honor q-values: q=0 explicitly refuses a coding; on a tie brotli wins
         # (better compression than gzip).
-        if br_q > 0 and br_q >= gzip_q:
+        if br_q > 0 and (not self.gzip_fallback or br_q >= gzip_q):
             responder = BrotliResponder(
                 self.app,
                 self.minimum_size,

--- a/starlette/middleware/brotli.py
+++ b/starlette/middleware/brotli.py
@@ -4,7 +4,7 @@ import re
 from typing import NoReturn
 
 import anyio
-from brotli import MODE_FONT, MODE_GENERIC, MODE_TEXT, Compressor
+from brotli import MODE_FONT, MODE_GENERIC, MODE_TEXT, Compressor  # type: ignore[import-untyped]
 
 from starlette.datastructures import Headers, MutableHeaders  # noqa: F401  (re-exported for parity with gzip.py)
 from starlette.middleware.gzip import (
@@ -143,9 +143,9 @@ class BrotliResponder(IdentityResponder):
 
     def _compress_body(self, body: bytes, more_body: bool) -> bytes:
         # For streaming chunks call flush() to emit partial output; for final chunk call finish().
-        if more_body:
-            return self.compressor.process(body) + self.compressor.flush()
-        return self.compressor.process(body) + self.compressor.finish()
+        chunk: bytes = self.compressor.process(body)
+        tail: bytes = self.compressor.flush() if more_body else self.compressor.finish()
+        return chunk + tail
 
 
 async def unattached_send(message: Message) -> NoReturn:

--- a/starlette/middleware/brotli.py
+++ b/starlette/middleware/brotli.py
@@ -62,8 +62,9 @@ class BrotliMiddleware:
 
         headers = Headers(scope=scope)
         codings = self._parse_accept_encoding(headers.get("Accept-Encoding", ""))
-        br_q = codings.get("br", 0.0)
-        gzip_q = codings.get("gzip", 0.0)
+        wildcard_q = codings.get("*", 0.0)
+        br_q = codings.get("br", wildcard_q)
+        gzip_q = codings.get("gzip", wildcard_q)
 
         # Honor q-values: q=0 explicitly refuses a coding; on a tie brotli wins
         # (better compression than gzip).

--- a/starlette/middleware/brotli.py
+++ b/starlette/middleware/brotli.py
@@ -7,10 +7,12 @@ import anyio
 from brotli import MODE_FONT, MODE_GENERIC, MODE_TEXT, Compressor  # type: ignore[import-untyped]
 
 from starlette.datastructures import Headers, MutableHeaders  # noqa: F401  (re-exported for parity with gzip.py)
-from starlette.middleware.gzip import (
+from starlette.middleware.gzip import (  # consider moving these into a common file
+    DEFAULT_EXCLUDED_CONTENT_TYPES,
     GZipResponder,
     IdentityResponder,
     _get_gzip_capacity_limiter,
+    _normalize_content_types,
 )
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -35,6 +37,7 @@ class BrotliMiddleware:
         gzip_fallback: bool = True,
         excluded_handlers: list[str] | None = None,
         thread_minimum_size: int = DEFAULT_THREAD_MIN_SIZE,
+        exclude_content_types: tuple[str, ...] = DEFAULT_EXCLUDED_CONTENT_TYPES,
     ) -> None:
         self.app = app
         self.quality = quality
@@ -46,6 +49,7 @@ class BrotliMiddleware:
         self.minimum_size = minimum_size
         self.gzip_fallback = gzip_fallback
         self.thread_minimum_size = thread_minimum_size
+        self.exclude_content_types = _normalize_content_types(exclude_content_types)
         if excluded_handlers:
             self.excluded_handlers: list[re.Pattern[str]] = [re.compile(p) for p in excluded_handlers]
         else:
@@ -77,6 +81,7 @@ class BrotliMiddleware:
                 lgwin=self.lgwin,
                 lgblock=self.lgblock,
                 thread_minimum_size=self.thread_minimum_size,
+                exclude_content_types=self.exclude_content_types,
             )
             await responder(scope, receive, send)
             return
@@ -88,6 +93,7 @@ class BrotliMiddleware:
                 self.minimum_size,
                 compresslevel=9,
                 thread_minimum_size=self.thread_minimum_size,
+                exclude_content_types=self.exclude_content_types,
             )
             await gzip_responder(scope, receive, send)
             return
@@ -138,8 +144,9 @@ class BrotliResponder(IdentityResponder):
         lgwin: int,
         lgblock: int,
         thread_minimum_size: int,
+        exclude_content_types: tuple[str, ...] = DEFAULT_EXCLUDED_CONTENT_TYPES,
     ) -> None:
-        super().__init__(app, minimum_size)
+        super().__init__(app, minimum_size, exclude_content_types=exclude_content_types)
         self.quality = quality
         self.mode = mode
         self.lgwin = lgwin

--- a/starlette/middleware/brotli.py
+++ b/starlette/middleware/brotli.py
@@ -61,9 +61,13 @@ class BrotliMiddleware:
             return
 
         headers = Headers(scope=scope)
-        accept_encoding = headers.get("Accept-Encoding", "")
+        codings = self._parse_accept_encoding(headers.get("Accept-Encoding", ""))
+        br_q = codings.get("br", 0.0)
+        gzip_q = codings.get("gzip", 0.0)
 
-        if "br" in accept_encoding:
+        # Honor q-values: q=0 explicitly refuses a coding; on a tie brotli wins
+        # (better compression than gzip).
+        if br_q > 0 and br_q >= gzip_q:
             responder = BrotliResponder(
                 self.app,
                 self.minimum_size,
@@ -76,7 +80,7 @@ class BrotliMiddleware:
             await responder(scope, receive, send)
             return
 
-        if self.gzip_fallback and "gzip" in accept_encoding:
+        if self.gzip_fallback and gzip_q > 0:
             # Delegate to Starlette's GZipResponder.
             gzip_responder = GZipResponder(
                 self.app,
@@ -87,13 +91,35 @@ class BrotliMiddleware:
             await gzip_responder(scope, receive, send)
             return
 
-        # Client accepts neither br nor gzip (or gzip_fallback=False): pass
-        # through unchanged.
+        # Client accepts neither br nor gzip (or refused both): pass through unchanged.
         await self.app(scope, receive, send)
 
     def _is_handler_excluded(self, scope: Scope) -> bool:
         path = scope.get("path", "")
         return any(pattern.search(path) for pattern in self.excluded_handlers)
+
+    def _parse_accept_encoding(self, header: str) -> dict[str, float]:
+        # Parse Accept-Encoding into {coding: q-value}. Content codings are
+        # case-insensitive (RFC 7231 §5.3.4); q defaults to 1.0 and q=0 refuses.
+        codings: dict[str, float] = {}
+        for part in header.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            pieces = part.split(";")
+            coding = pieces[0].strip().lower()
+            if not coding:
+                continue
+            q = 1.0
+            for param in pieces[1:]:
+                param = param.strip()
+                if param.startswith("q="):
+                    try:
+                        q = float(param[2:])
+                    except ValueError:
+                        q = 1.0
+            codings[coding] = q
+        return codings
 
 
 class BrotliResponder(IdentityResponder):

--- a/starlette/middleware/brotli.py
+++ b/starlette/middleware/brotli.py
@@ -1,5 +1,3 @@
-
-
 from __future__ import annotations
 
 import re
@@ -49,9 +47,7 @@ class BrotliMiddleware:
         self.gzip_fallback = gzip_fallback
         self.thread_minimum_size = thread_minimum_size
         if excluded_handlers:
-            self.excluded_handlers: list[re.Pattern[str]] = [
-                re.compile(p) for p in excluded_handlers
-            ]
+            self.excluded_handlers: list[re.Pattern[str]] = [re.compile(p) for p in excluded_handlers]
         else:
             self.excluded_handlers = []
 
@@ -142,9 +138,7 @@ class BrotliResponder(IdentityResponder):
         if len(body) >= self.thread_minimum_size:
             # Offload large bodies to worker thread via Starlette's gzip capacity limiter.
             limiter = _get_gzip_capacity_limiter()
-            return await anyio.to_thread.run_sync(
-                self._compress_body, body, more_body, limiter=limiter
-            )
+            return await anyio.to_thread.run_sync(self._compress_body, body, more_body, limiter=limiter)
         return self._compress_body(body, more_body)
 
     def _compress_body(self, body: bytes, more_body: bool) -> bytes:

--- a/starlette/middleware/brotli.py
+++ b/starlette/middleware/brotli.py
@@ -1,0 +1,158 @@
+
+
+from __future__ import annotations
+
+import re
+from typing import NoReturn
+
+import anyio
+from brotli import MODE_FONT, MODE_GENERIC, MODE_TEXT, Compressor
+
+from starlette.datastructures import Headers, MutableHeaders  # noqa: F401  (re-exported for parity with gzip.py)
+from starlette.middleware.gzip import (
+    GZipResponder,
+    IdentityResponder,
+    _get_gzip_capacity_limiter,
+)
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+DEFAULT_THREAD_MIN_SIZE = 128 * 1024  # 128 KiB; mirrors GZipMiddleware default
+
+
+class Mode:
+    generic = MODE_GENERIC
+    text = MODE_TEXT
+    font = MODE_FONT
+
+
+class BrotliMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        quality: int = 4,
+        mode: str = "text",
+        lgwin: int = 22,
+        lgblock: int = 0,
+        minimum_size: int = 400,
+        gzip_fallback: bool = True,
+        excluded_handlers: list[str] | None = None,
+        thread_minimum_size: int = DEFAULT_THREAD_MIN_SIZE,
+    ) -> None:
+        self.app = app
+        self.quality = quality
+        # mode is a string ("text"|"generic"|"font") on the public API, but
+        # brotli.Compressor expects the integer constant. Resolve once here.
+        self.mode = getattr(Mode, mode)
+        self.lgwin = lgwin
+        self.lgblock = lgblock
+        self.minimum_size = minimum_size
+        self.gzip_fallback = gzip_fallback
+        self.thread_minimum_size = thread_minimum_size
+        if excluded_handlers:
+            self.excluded_handlers: list[re.Pattern[str]] = [
+                re.compile(p) for p in excluded_handlers
+            ]
+        else:
+            self.excluded_handlers = []
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if self._is_handler_excluded(scope):
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        accept_encoding = headers.get("Accept-Encoding", "")
+
+        if "br" in accept_encoding:
+            responder = BrotliResponder(
+                self.app,
+                self.minimum_size,
+                quality=self.quality,
+                mode=self.mode,
+                lgwin=self.lgwin,
+                lgblock=self.lgblock,
+                thread_minimum_size=self.thread_minimum_size,
+            )
+            await responder(scope, receive, send)
+            return
+
+        if self.gzip_fallback and "gzip" in accept_encoding:
+            # Delegate to Starlette's GZipResponder.
+            gzip_responder = GZipResponder(
+                self.app,
+                self.minimum_size,
+                compresslevel=9,
+                thread_minimum_size=self.thread_minimum_size,
+            )
+            await gzip_responder(scope, receive, send)
+            return
+
+        # Client accepts neither br nor gzip (or gzip_fallback=False): pass
+        # through unchanged.
+        await self.app(scope, receive, send)
+
+    def _is_handler_excluded(self, scope: Scope) -> bool:
+        path = scope.get("path", "")
+        return any(pattern.search(path) for pattern in self.excluded_handlers)
+
+
+class BrotliResponder(IdentityResponder):
+    content_encoding = "br"
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        minimum_size: int,
+        *,
+        quality: int,
+        mode: int,
+        lgwin: int,
+        lgblock: int,
+        thread_minimum_size: int,
+    ) -> None:
+        super().__init__(app, minimum_size)
+        self.quality = quality
+        self.mode = mode
+        self.lgwin = lgwin
+        self.lgblock = lgblock
+        self.thread_minimum_size = thread_minimum_size
+        # Lazy-init: only allocate a brotli.Compressor when we actually need to
+        # compress. This avoids paying the cost for pathsend / small / excluded
+        # responses that never reach apply_compression.
+        self._compressor: Compressor | None = None
+
+    @property
+    def compressor(self) -> Compressor:
+        if self._compressor is None:
+            self._compressor = Compressor(
+                quality=self.quality,
+                mode=self.mode,
+                lgwin=self.lgwin,
+                lgblock=self.lgblock,
+            )
+        return self._compressor
+
+    async def apply_compression(self, body: bytes, *, more_body: bool) -> bytes:
+        # Must call finish() on final empty chunk to write brotli end-of-stream marker.
+        # Compressor is lazy-init'd; skipped for small/SSE/pathsend/already-encoded responses.
+        if len(body) >= self.thread_minimum_size:
+            # Offload large bodies to worker thread via Starlette's gzip capacity limiter.
+            limiter = _get_gzip_capacity_limiter()
+            return await anyio.to_thread.run_sync(
+                self._compress_body, body, more_body, limiter=limiter
+            )
+        return self._compress_body(body, more_body)
+
+    def _compress_body(self, body: bytes, more_body: bool) -> bytes:
+        # For streaming chunks call flush() to emit partial output; for final chunk call finish().
+        if more_body:
+            return self.compressor.process(body) + self.compressor.flush()
+        return self.compressor.process(body) + self.compressor.finish()
+
+
+async def unattached_send(message: Message) -> NoReturn:
+    raise RuntimeError("send awaitable not set")  # pragma: no cover

--- a/starlette/middleware/brotli.py
+++ b/starlette/middleware/brotli.py
@@ -116,6 +116,8 @@ class BrotliMiddleware:
                 if param.startswith("q="):
                     try:
                         q = float(param[2:])
+                        if not 0.0 <= q <= 1.0:
+                            q = 1.0
                     except ValueError:
                         q = 1.0
             codings[coding] = q

--- a/tests/middleware/test_brotli.py
+++ b/tests/middleware/test_brotli.py
@@ -238,6 +238,9 @@ def test_parse_accept_encoding_handles_malformed_input() -> None:
     assert parse(";q=0.5") == {}
     # Malformed q-value falls back to 1.0.
     assert parse("br;q=abc") == {"br": 1.0}
+    # Out-of-range q-values (>1.0 or <0.0) fall back to 1.0.
+    assert parse("br;q=1.5") == {"br": 1.0}
+    assert parse("br;q=-0.5") == {"br": 1.0}
     # Non-q parameters are ignored.
     assert parse("br;ext=1") == {"br": 1.0}
     # q=0 parses to 0.0 (explicit refusal).

--- a/tests/middleware/test_brotli.py
+++ b/tests/middleware/test_brotli.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.brotli import BrotliMiddleware, Mode
+from starlette.requests import Request
+from starlette.responses import ContentStream, PlainTextResponse, Response, StreamingResponse
+from starlette.routing import Route, WebSocketRoute
+from starlette.types import Message, Receive, Scope, Send
+from starlette.websockets import WebSocket
+from tests.types import TestClientFactory
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(**mw_kwargs) -> Starlette:
+    """Build a Starlette app with several routes wrapped in BrotliMiddleware."""
+
+    async def big(request: Request) -> Response:
+        # 4000 bytes of highly compressible text.
+        return PlainTextResponse("a" * 4000)
+
+    async def small(request: Request) -> Response:
+        # 20 bytes, below the default minimum_size=400.
+        return PlainTextResponse("hello world, small!")
+
+    async def stream(request: Request) -> Response:
+        async def gen() -> ContentStream:
+            for i in range(5):
+                # Each chunk is large enough to be worth compressing.
+                yield f"chunk-{i}-".encode() + b"x" * 1000
+
+        return StreamingResponse(gen(), media_type="text/plain")
+
+    async def already_encoded(request: Request) -> Response:
+        # Pre-set Content-Encoding to ensure we don't double-compress.
+        return PlainTextResponse("a" * 4000, headers={"Content-Encoding": "gzip"})
+
+    async def sse(request: Request) -> Response:
+        async def gen() -> ContentStream:
+            yield b"data: hello\n\n"
+            yield b"data: world\n\n"
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    async def size_endpoint(request: Request) -> Response:
+        n = int(request.query_params["n"])
+        return PlainTextResponse("a" * n)
+
+    routes = [
+        Route("/big", big),
+        Route("/small", small),
+        Route("/stream", stream),
+        Route("/already", already_encoded),
+        Route("/sse", sse),
+        Route("/size", size_endpoint),
+    ]
+    middleware = [Middleware(BrotliMiddleware, **mw_kwargs)]
+    return Starlette(routes=routes, middleware=middleware)
+
+
+def _compressed_len(r) -> int | None:
+    """Return the on-wire compressed body length.
+
+    httpx auto-decompresses brotli/gzip, so r.content is the decompressed
+    payload. The Content-Length header carries the compressed (on-wire) length
+    for non-streaming responses.
+    """
+    cl = r.headers.get("content-length")
+    if cl is None:
+        # Streaming responses don't have Content-Length; fall back to None.
+        return None
+    return int(cl)
+
+
+# ---------------------------------------------------------------------------
+# Brotli path
+# ---------------------------------------------------------------------------
+
+
+def test_brotli_responses(test_client_factory: TestClientFactory) -> None:
+    app = _make_app()
+    client = test_client_factory(app)
+    response = client.get("/big", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.text == "a" * 4000
+    assert response.headers["Content-Encoding"] == "br"
+    assert response.headers["Vary"] == "Accept-Encoding"
+    assert int(response.headers["Content-Length"]) < 4000
+
+
+def test_brotli_not_in_accept_encoding(test_client_factory: TestClientFactory) -> None:
+    # BrotliMiddleware does not wrap the inner app with IdentityResponder when
+    # neither br nor gzip is accepted, so it passes the response through
+    # verbatim (no Vary header, no compression, original Content-Length).
+    app = _make_app()
+    client = test_client_factory(app)
+    response = client.get("/big", headers={"accept-encoding": "identity"})
+    assert response.status_code == 200
+    assert response.text == "a" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+    assert int(response.headers["Content-Length"]) == 4000
+
+
+def test_brotli_ignored_for_small_responses(test_client_factory: TestClientFactory) -> None:
+    app = _make_app()
+    client = test_client_factory(app)
+    response = client.get("/small", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.text == "hello world, small!"
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+    assert int(response.headers["Content-Length"]) == len("hello world, small!")
+
+
+def test_brotli_minimum_size_boundary(test_client_factory: TestClientFactory) -> None:
+    # minimum_size=400; verify the boundary is inclusive (>=400 compresses).
+    app = _make_app(minimum_size=400)
+    client = test_client_factory(app)
+    r_just_below = client.get("/size", params={"n": 399}, headers={"accept-encoding": "br"})
+    r_boundary = client.get("/size", params={"n": 400}, headers={"accept-encoding": "br"})
+
+    assert "content-encoding" not in r_just_below.headers
+    assert r_just_below.content == b"a" * 399
+    assert r_boundary.headers["content-encoding"] == "br"
+    assert r_boundary.content == b"a" * 400
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+
+def test_brotli_streaming_response(test_client_factory: TestClientFactory) -> None:
+    app = _make_app()
+    client = test_client_factory(app)
+    response = client.get("/stream", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.text == "".join(f"chunk-{i}-" + "x" * 1000 for i in range(5))
+    assert response.headers["Content-Encoding"] == "br"
+    assert response.headers["Vary"] == "Accept-Encoding"
+    assert "Content-Length" not in response.headers
+
+
+def test_brotli_streaming_response_identity(test_client_factory: TestClientFactory) -> None:
+    # Accept-Encoding: identity -> BrotliMiddleware passes through unchanged
+    # (no IdentityResponder wrapping, so no Vary header).
+    app = _make_app()
+    client = test_client_factory(app)
+    response = client.get("/stream", headers={"accept-encoding": "identity"})
+    assert response.status_code == 200
+    assert response.text == "".join(f"chunk-{i}-" + "x" * 1000 for i in range(5))
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+    assert "Content-Length" not in response.headers
+
+
+# ---------------------------------------------------------------------------
+# GZip fallback
+# ---------------------------------------------------------------------------
+
+
+def test_brotli_gzip_only_uses_gzip_fallback(test_client_factory: TestClientFactory) -> None:
+    app = _make_app()
+    client = test_client_factory(app)
+    response = client.get("/big", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers["Vary"] == "Accept-Encoding"
+    assert int(response.headers["Content-Length"]) < 4000
+    assert response.text == "a" * 4000
+
+
+def test_brotli_gzip_fallback_disabled(test_client_factory: TestClientFactory) -> None:
+    app = _make_app(gzip_fallback=False)
+    client = test_client_factory(app)
+    response = client.get("/big", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    # gzip_fallback=False -> no compression when only gzip is accepted.
+    assert "Content-Encoding" not in response.headers
+    assert response.text == "a" * 4000
+
+
+def test_brotli_wins_over_gzip_when_both_accepted(test_client_factory: TestClientFactory) -> None:
+    app = _make_app()
+    client = test_client_factory(app)
+    response = client.get("/big", headers={"accept-encoding": "br, gzip"})
+    assert response.status_code == 200
+    assert response.headers["Content-Encoding"] == "br"
+
+
+# ---------------------------------------------------------------------------
+# Bypass paths
+# ---------------------------------------------------------------------------
+
+
+def test_brotli_ignored_for_responses_with_encoding_set() -> None:
+    """Verify the 'content_encoding_set' bypass via a direct ASGI call.
+
+    We can't use TestClient here because httpx would try to decompress the
+    response body (which advertises Content-Encoding: gzip but is actually
+    plaintext). Instead we capture the raw ASGI messages and assert that:
+      - Content-Encoding: gzip is preserved (not overwritten with br)
+      - The body is forwarded unchanged (no brotli re-compression)
+    """
+    received: list[Message] = []
+
+    async def inner_app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"text/plain"),
+                    (b"content-encoding", b"gzip"),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"a" * 4000,
+                "more_body": False,
+            }
+        )
+
+    async def capturing_send(message: Message) -> None:
+        received.append(message)
+
+    async def run() -> None:
+        mw = BrotliMiddleware(inner_app)
+        scope: Scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/already",
+            "headers": [(b"accept-encoding", b"br")],
+            "query_string": b"",
+            "extensions": {},
+            "http_version": "1.1",
+            "scheme": "http",
+            "server": ("test", 80),
+            "client": ("test", 0),
+            "root_path": "",
+        }
+
+        async def receive() -> Message:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        await mw(scope, receive, capturing_send)
+
+    asyncio.run(run())
+
+    assert len(received) == 2
+    start = received[0]
+    body = received[1]
+    assert start["type"] == "http.response.start"
+    headers = dict(start["headers"])
+    # Content-Encoding: gzip must be preserved (not overwritten with br).
+    assert headers[b"content-encoding"] == b"gzip"
+    # Body must be forwarded unchanged (not re-compressed).
+    assert body["body"] == b"a" * 4000
+
+
+def test_brotli_ignored_on_server_sent_events(test_client_factory: TestClientFactory) -> None:
+    app = _make_app()
+    client = test_client_factory(app)
+    response = client.get("/sse", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.text == "data: hello\n\ndata: world\n\n"
+    assert "Content-Encoding" not in response.headers
+    assert "Content-Length" not in response.headers
+
+
+def test_brotli_excluded_handlers_skip_compression(test_client_factory: TestClientFactory) -> None:
+    app = _make_app(excluded_handlers=[r"^/big$"])
+    client = test_client_factory(app)
+    response = client.get("/big", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert "Content-Encoding" not in response.headers
+    assert response.text == "a" * 4000
+
+
+def test_brotli_pathsend_event_is_passed_through_unchanged() -> None:
+    """Directly exercise the pathsend branch of IdentityResponder via a custom
+    ASGI app that emits http.response.pathsend events.
+
+    TestClient does not advertise the pathsend extension, so FileResponse
+    would fall back to normal file reads (and get compressed).
+    """
+    received: list[Message] = []
+
+    async def inner_app(scope: Scope, receive: Receive, send: Send) -> None:
+        # Emit a normal start + a pathsend event (what FileResponse does when
+        # the server advertises pathsend support).
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.pathsend",
+                "path": "/tmp/some-file.txt",
+            }
+        )
+
+    async def capturing_send(message: Message) -> None:
+        received.append(message)
+
+    async def run() -> None:
+        mw = BrotliMiddleware(inner_app)
+        scope: Scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/file",
+            "headers": [(b"accept-encoding", b"br")],
+            "query_string": b"",
+            "extensions": {"http.response.pathsend": {}},
+            "http_version": "1.1",
+            "scheme": "http",
+            "server": ("test", 80),
+            "client": ("test", 0),
+            "root_path": "",
+        }
+
+        async def receive() -> Message:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        await mw(scope, receive, capturing_send)
+
+    asyncio.run(run())
+
+    # The pathsend branch must:
+    #  - forward the initial start message unchanged
+    #  - forward the pathsend event unchanged
+    #  - NOT set Content-Encoding: br (no compression)
+    assert len(received) == 2
+    assert received[0]["type"] == "http.response.start"
+    assert received[0]["status"] == 200
+    headers = dict(received[0]["headers"])
+    assert b"content-encoding" not in headers
+    assert received[1]["type"] == "http.response.pathsend"
+    assert received[1]["path"] == "/tmp/some-file.txt"
+
+
+# ---------------------------------------------------------------------------
+# Threading
+# ---------------------------------------------------------------------------
+
+
+def test_brotli_compression_in_thread(test_client_factory: TestClientFactory) -> None:
+    # thread_minimum_size=1 forces EVERY body through anyio.to_thread, exercising
+    # the worker-thread path on the smallest possible input.
+    app = _make_app(thread_minimum_size=1)
+    client = test_client_factory(app)
+    response = client.get("/big", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.headers["Content-Encoding"] == "br"
+    assert response.text == "a" * 4000
+    assert int(response.headers["Content-Length"]) < 4000
+
+
+def test_brotli_streaming_compression_in_thread(test_client_factory: TestClientFactory) -> None:
+    app = _make_app(thread_minimum_size=1)
+    client = test_client_factory(app)
+    response = client.get("/stream", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.headers["Content-Encoding"] == "br"
+    assert response.text == "".join(f"chunk-{i}-" + "x" * 1000 for i in range(5))
+
+
+# ---------------------------------------------------------------------------
+# Quality
+# ---------------------------------------------------------------------------
+
+
+def test_brotli_quality_affects_size(test_client_factory: TestClientFactory) -> None:
+    # Higher quality => smaller (or equal) output for highly compressible input.
+    # Build two apps at q=0 and q=11 and compare compressed sizes.
+    app_q0 = _make_app(quality=0)
+    app_q11 = _make_app(quality=11)
+    c0 = test_client_factory(app_q0)
+    c11 = test_client_factory(app_q11)
+    r0 = c0.get("/big", headers={"accept-encoding": "br"})
+    r11 = c11.get("/big", headers={"accept-encoding": "br"})
+
+    assert r0.headers["content-encoding"] == "br"
+    assert r11.headers["content-encoding"] == "br"
+    # Both must roundtrip correctly (httpx decompresses).
+    assert r0.text == "a" * 4000
+    assert r11.text == "a" * 4000
+    # And q=11 should be at least as small as q=0 (on-wire size).
+    assert _compressed_len(r11) <= _compressed_len(r0)
+
+
+# ---------------------------------------------------------------------------
+# Mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode_name", ["text", "generic", "font"])
+def test_brotli_mode_string_is_accepted(test_client_factory: TestClientFactory, mode_name: str) -> None:
+    # Just verify construction + a round-trip works for each mode.
+    app = _make_app(mode=mode_name)
+    client = test_client_factory(app)
+    response = client.get("/big", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.headers["Content-Encoding"] == "br"
+    assert response.text == "a" * 4000
+
+
+def test_brotli_mode_constants_match_brotli() -> None:
+    assert Mode.text == 1
+    assert Mode.generic == 0
+    assert Mode.font == 2
+
+
+# ---------------------------------------------------------------------------
+# Non-HTTP scope
+# ---------------------------------------------------------------------------
+
+
+def test_brotli_websocket_scope_passes_through(test_client_factory: TestClientFactory) -> None:
+    # BrotliMiddleware should not interfere with websocket handshakes.
+    async def ws_endpoint(websocket: WebSocket) -> None:
+        await websocket.accept()
+        await websocket.send_text("hello")
+        await websocket.close()
+
+    app = Starlette(
+        routes=[WebSocketRoute("/ws", ws_endpoint)],
+        middleware=[Middleware(BrotliMiddleware)],
+    )
+    client = test_client_factory(app)
+    with client.websocket_connect("/ws") as ws:
+        msg = ws.receive_text()
+    assert msg == "hello"

--- a/tests/middleware/test_brotli.py
+++ b/tests/middleware/test_brotli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
+import httpx2 as httpx
 import pytest
 
 from starlette.applications import Starlette
@@ -19,7 +21,7 @@ from tests.types import TestClientFactory
 # ---------------------------------------------------------------------------
 
 
-def _make_app(**mw_kwargs) -> Starlette:
+def _make_app(**mw_kwargs: Any) -> Starlette:
     """Build a Starlette app with several routes wrapped in BrotliMiddleware."""
 
     async def big(request: Request) -> Response:
@@ -38,10 +40,6 @@ def _make_app(**mw_kwargs) -> Starlette:
 
         return StreamingResponse(gen(), media_type="text/plain")
 
-    async def already_encoded(request: Request) -> Response:
-        # Pre-set Content-Encoding to ensure we don't double-compress.
-        return PlainTextResponse("a" * 4000, headers={"Content-Encoding": "gzip"})
-
     async def sse(request: Request) -> Response:
         async def gen() -> ContentStream:
             yield b"data: hello\n\n"
@@ -57,7 +55,6 @@ def _make_app(**mw_kwargs) -> Starlette:
         Route("/big", big),
         Route("/small", small),
         Route("/stream", stream),
-        Route("/already", already_encoded),
         Route("/sse", sse),
         Route("/size", size_endpoint),
     ]
@@ -65,7 +62,7 @@ def _make_app(**mw_kwargs) -> Starlette:
     return Starlette(routes=routes, middleware=middleware)
 
 
-def _compressed_len(r) -> int | None:
+def _compressed_len(r: httpx.Response) -> int:
     """Return the on-wire compressed body length.
 
     httpx auto-decompresses brotli/gzip, so r.content is the decompressed
@@ -73,9 +70,7 @@ def _compressed_len(r) -> int | None:
     for non-streaming responses.
     """
     cl = r.headers.get("content-length")
-    if cl is None:
-        # Streaming responses don't have Content-Length; fall back to None.
-        return None
+    assert cl is not None
     return int(cl)
 
 
@@ -213,6 +208,7 @@ def test_brotli_ignored_for_responses_with_encoding_set() -> None:
     received: list[Message] = []
 
     async def inner_app(scope: Scope, receive: Receive, send: Send) -> None:
+        _ = await receive()  # consume the (empty) request body
         await send(
             {
                 "type": "http.response.start",
@@ -299,6 +295,7 @@ def test_brotli_pathsend_event_is_passed_through_unchanged() -> None:
     async def inner_app(scope: Scope, receive: Receive, send: Send) -> None:
         # Emit a normal start + a pathsend event (what FileResponse does when
         # the server advertises pathsend support).
+        _ = await receive()  # consume the (empty) request body
         await send(
             {
                 "type": "http.response.start",

--- a/tests/middleware/test_brotli.py
+++ b/tests/middleware/test_brotli.py
@@ -494,3 +494,103 @@ def test_brotli_websocket_scope_passes_through(test_client_factory: TestClientFa
     with client.websocket_connect("/ws") as ws:
         msg = ws.receive_text()
     assert msg == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Exclude content types
+# ---------------------------------------------------------------------------
+
+
+def test_brotli_custom_exclude_content_types(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/zip")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = BrotliMiddleware(app, exclude_content_types=("application/zip",))
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
+def test_brotli_cleared_exclude_content_types(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/event-stream")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = BrotliMiddleware(app, exclude_content_types=())
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert response.headers["Content-Encoding"] == "br"
+    assert response.headers["Vary"] == "Accept-Encoding"
+
+
+def test_brotli_exclude_content_types_for_identity_client(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/zip")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = BrotliMiddleware(app, exclude_content_types=("application/zip",))
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "identity"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
+@pytest.mark.parametrize(
+    ("exclude_content_types", "content_type"),
+    [
+        pytest.param(("text/event-stream",), b"Text/Event-Stream; charset=utf-8", id="header-is-normalized"),
+        pytest.param(("Application/ZIP; charset=utf-8",), b"application/zip", id="configured-value-is-normalized"),
+        pytest.param(("image/*",), b"image/png", id="wildcard"),
+    ],
+)
+def test_brotli_exclude_content_types_matching(
+    exclude_content_types: tuple[str, ...], content_type: bytes, test_client_factory: TestClientFactory
+) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", content_type)]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = BrotliMiddleware(app, exclude_content_types=exclude_content_types)
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
+def test_brotli_responder_normalizes_content_types(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/zip")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    from starlette.middleware.brotli import BrotliResponder
+
+    responder = BrotliResponder(
+        app,
+        500,
+        quality=4,
+        mode=Mode.text,
+        lgwin=22,
+        lgblock=0,
+        thread_minimum_size=128 * 1024,
+        exclude_content_types=("Application/ZIP; charset=utf-8",),
+    )
+
+    client = test_client_factory(responder)
+    response = client.get("/", headers={"accept-encoding": "br"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers

--- a/tests/middleware/test_brotli.py
+++ b/tests/middleware/test_brotli.py
@@ -192,6 +192,59 @@ def test_brotli_wins_over_gzip_when_both_accepted(test_client_factory: TestClien
 
 
 # ---------------------------------------------------------------------------
+# Accept-Encoding parsing (case-insensitivity, q-values, substring safety)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("accept_encoding", "expected_encoding"),
+    [
+        ("br", "br"),
+        # Content codings are case-insensitive (RFC 7231 5.3.4).
+        ("BR", "br"),
+        # q=0 explicitly refuses the coding.
+        ("br;q=0", None),
+        ("gzip;q=0", None),
+        # A token that merely contains "br" as a substring must not match.
+        ("zbr", None),
+        # Higher q-value wins.
+        ("gzip;q=1.0, br;q=0.5", "gzip"),
+        ("br;q=0.5, gzip;q=1.0", "gzip"),
+        # Equal q-values -> prefer brotli (better compression).
+        ("br, gzip", "br"),
+    ],
+)
+def test_brotli_accept_encoding_parsing(
+    test_client_factory: TestClientFactory, accept_encoding: str, expected_encoding: str | None
+) -> None:
+    app = _make_app()
+    client = test_client_factory(app)
+    response = client.get("/big", headers={"accept-encoding": accept_encoding})
+    assert response.status_code == 200
+    assert response.text == "a" * 4000
+    if expected_encoding is None:
+        assert "Content-Encoding" not in response.headers
+        assert int(response.headers["Content-Length"]) == 4000
+    else:
+        assert response.headers["Content-Encoding"] == expected_encoding
+        assert int(response.headers["Content-Length"]) < 4000
+
+
+def test_parse_accept_encoding_handles_malformed_input() -> None:
+    parse = BrotliMiddleware(_make_app())._parse_accept_encoding
+    # Empty segments (e.g. trailing comma) are skipped.
+    assert parse("br,") == {"br": 1.0}
+    # Empty coding token (e.g. ";q=0.5") is skipped.
+    assert parse(";q=0.5") == {}
+    # Malformed q-value falls back to 1.0.
+    assert parse("br;q=abc") == {"br": 1.0}
+    # Non-q parameters are ignored.
+    assert parse("br;ext=1") == {"br": 1.0}
+    # q=0 parses to 0.0 (explicit refusal).
+    assert parse("gzip;q=0") == {"gzip": 0.0}
+
+
+# ---------------------------------------------------------------------------
 # Bypass paths
 # ---------------------------------------------------------------------------
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import importlib.util
 from collections.abc import Iterator
 from typing import Any
 
@@ -16,7 +16,7 @@ from tests.types import TestClientFactory
 # When brotli (or brotlicffi) is importable, urllib3 advertises it in Accept-Encoding.
 ACCEPT_ENCODING = (
     "gzip, deflate, br, zstd"
-    if any(module in sys.modules for module in ("brotli", "brotlicffi"))
+    if any(importlib.util.find_spec(module) for module in ("brotli", "brotlicffi"))
     else "gzip, deflate, zstd"
 )
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -13,6 +13,13 @@ from starlette.responses import JSONResponse, PlainTextResponse, Response
 from starlette.types import Message, Receive, Scope, Send
 from tests.types import TestClientFactory
 
+# When brotli (or brotlicffi) is importable, urllib3 advertises it in Accept-Encoding.
+ACCEPT_ENCODING = (
+    "gzip, deflate, br, zstd"
+    if any(module in sys.modules for module in ("brotli", "brotlicffi"))
+    else "gzip, deflate, zstd"
+)
+
 
 def test_request_url(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
@@ -41,10 +48,6 @@ def test_request_query_params(test_client_factory: TestClientFactory) -> None:
     assert response.json() == {"params": {"a": "123", "b": "456"}}
 
 
-@pytest.mark.skipif(
-    any(module in sys.modules for module in ("brotli", "brotlicffi")),
-    reason='urllib3 includes "br" to the "accept-encoding" headers.',
-)
 def test_request_headers(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)
@@ -58,7 +61,7 @@ def test_request_headers(test_client_factory: TestClientFactory) -> None:
         "headers": {
             "host": "example.org",
             "user-agent": "testclient",
-            "accept-encoding": "gzip, deflate, zstd",
+            "accept-encoding": ACCEPT_ENCODING,
             "accept": "*/*",
             "connection": "keep-alive",
         }

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,4 +1,4 @@
-import sys
+import importlib.util
 from collections.abc import AsyncGenerator, MutableMapping
 from pathlib import Path
 from typing import Any
@@ -17,7 +17,7 @@ from tests.types import TestClientFactory
 # When brotli (or brotlicffi) is importable, urllib3 advertises it in Accept-Encoding.
 ACCEPT_ENCODING = (
     "gzip, deflate, br, zstd"
-    if any(module in sys.modules for module in ("brotli", "brotlicffi"))
+    if any(importlib.util.find_spec(module) for module in ("brotli", "brotlicffi"))
     else "gzip, deflate, zstd"
 )
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -14,6 +14,13 @@ from starlette.types import Message, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 from tests.types import TestClientFactory
 
+# When brotli (or brotlicffi) is importable, urllib3 advertises it in Accept-Encoding.
+ACCEPT_ENCODING = (
+    "gzip, deflate, br, zstd"
+    if any(module in sys.modules for module in ("brotli", "brotlicffi"))
+    else "gzip, deflate, zstd"
+)
+
 
 def test_websocket_url(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
@@ -75,10 +82,6 @@ def test_websocket_query_params(test_client_factory: TestClientFactory) -> None:
         assert data == {"params": {"a": "abc", "b": "456"}}
 
 
-@pytest.mark.skipif(
-    any(module in sys.modules for module in ("brotli", "brotlicffi")),
-    reason='urllib3 includes "br" to the "accept-encoding" headers.',
-)
 def test_websocket_headers(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         websocket = WebSocket(scope, receive=receive, send=send)
@@ -91,7 +94,7 @@ def test_websocket_headers(test_client_factory: TestClientFactory) -> None:
     with client.websocket_connect("/") as websocket:
         expected_headers = {
             "accept": "*/*",
-            "accept-encoding": "gzip, deflate, zstd",
+            "accept-encoding": ACCEPT_ENCODING,
             "connection": "upgrade",
             "host": "testserver",
             "user-agent": "testclient",

--- a/uv.lock
+++ b/uv.lock
@@ -127,6 +127,64 @@ wheels = [
 ]
 
 [[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/10/a090475284fc4a71aed40a96f32e44a7fe5bda39687353dd977720b211b6/brotli-1.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b90b767916ac44e93a8e28ce6adf8d551e43affb512f2377c732d486ac6514e", size = 863089, upload-time = "2025-11-05T18:38:01.181Z" },
+    { url = "https://files.pythonhosted.org/packages/03/41/17416630e46c07ac21e378c3464815dd2e120b441e641bc516ac32cc51d2/brotli-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6be67c19e0b0c56365c6a76e393b932fb0e78b3b56b711d180dd7013cb1fd984", size = 445442, upload-time = "2025-11-05T18:38:02.434Z" },
+    { url = "https://files.pythonhosted.org/packages/24/31/90cc06584deb5d4fcafc0985e37741fc6b9717926a78674bbb3ce018957e/brotli-1.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0bbd5b5ccd157ae7913750476d48099aaf507a79841c0d04a9db4415b14842de", size = 1532658, upload-time = "2025-11-05T18:38:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/62/17/33bf0c83bcbc96756dfd712201d87342732fad70bb3472c27e833a44a4f9/brotli-1.2.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3f3c908bcc404c90c77d5a073e55271a0a498f4e0756e48127c35d91cf155947", size = 1631241, upload-time = "2025-11-05T18:38:04.582Z" },
+    { url = "https://files.pythonhosted.org/packages/48/10/f47854a1917b62efe29bc98ac18e5d4f71df03f629184575b862ef2e743b/brotli-1.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1b557b29782a643420e08d75aea889462a4a8796e9a6cf5621ab05a3f7da8ef2", size = 1424307, upload-time = "2025-11-05T18:38:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b7/f88eb461719259c17483484ea8456925ee057897f8e64487d76e24e5e38d/brotli-1.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81da1b229b1889f25adadc929aeb9dbc4e922bd18561b65b08dd9343cfccca84", size = 1488208, upload-time = "2025-11-05T18:38:06.613Z" },
+    { url = "https://files.pythonhosted.org/packages/26/59/41bbcb983a0c48b0b8004203e74706c6b6e99a04f3c7ca6f4f41f364db50/brotli-1.2.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ff09cd8c5eec3b9d02d2408db41be150d8891c5566addce57513bf546e3d6c6d", size = 1597574, upload-time = "2025-11-05T18:38:07.838Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e6/8c89c3bdabbe802febb4c5c6ca224a395e97913b5df0dff11b54f23c1788/brotli-1.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a1778532b978d2536e79c05dac2d8cd857f6c55cd0c95ace5b03740824e0e2f1", size = 1492109, upload-time = "2025-11-05T18:38:08.816Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/9a/4b19d4310b2dbd545c0c33f176b0528fa68c3cd0754e34b2f2bcf56548ae/brotli-1.2.0-cp310-cp310-win32.whl", hash = "sha256:b232029d100d393ae3c603c8ffd7e3fe6f798c5e28ddca5feabb8e8fdb732997", size = 334461, upload-time = "2025-11-05T18:38:10.729Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/39/70981d9f47705e3c2b95c0847dfa3e7a37aa3b7c6030aedc4873081ed005/brotli-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:ef87b8ab2704da227e83a246356a2b179ef826f550f794b2c52cddb4efbd0196", size = 369035, upload-time = "2025-11-05T18:38:11.827Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ef/f285668811a9e1ddb47a18cb0b437d5fc2760d537a2fe8a57875ad6f8448/brotli-1.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:15b33fe93cedc4caaff8a0bd1eb7e3dab1c61bb22a0bf5bdfdfd97cd7da79744", size = 863110, upload-time = "2025-11-05T18:38:12.978Z" },
+    { url = "https://files.pythonhosted.org/packages/50/62/a3b77593587010c789a9d6eaa527c79e0848b7b860402cc64bc0bc28a86c/brotli-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:898be2be399c221d2671d29eed26b6b2713a02c2119168ed914e7d00ceadb56f", size = 445438, upload-time = "2025-11-05T18:38:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e1/7fadd47f40ce5549dc44493877db40292277db373da5053aff181656e16e/brotli-1.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:350c8348f0e76fff0a0fd6c26755d2653863279d086d3aa2c290a6a7251135dd", size = 1534420, upload-time = "2025-11-05T18:38:15.111Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8b/1ed2f64054a5a008a4ccd2f271dbba7a5fb1a3067a99f5ceadedd4c1d5a7/brotli-1.2.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e1ad3fda65ae0d93fec742a128d72e145c9c7a99ee2fcd667785d99eb25a7fe", size = 1632619, upload-time = "2025-11-05T18:38:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5a/7071a621eb2d052d64efd5da2ef55ecdac7c3b0c6e4f9d519e9c66d987ef/brotli-1.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:40d918bce2b427a0c4ba189df7a006ac0c7277c180aee4617d99e9ccaaf59e6a", size = 1426014, upload-time = "2025-11-05T18:38:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6d/0971a8ea435af5156acaaccec1a505f981c9c80227633851f2810abd252a/brotli-1.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2a7f1d03727130fc875448b65b127a9ec5d06d19d0148e7554384229706f9d1b", size = 1489661, upload-time = "2025-11-05T18:38:18.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/75/c1baca8b4ec6c96a03ef8230fab2a785e35297632f402ebb1e78a1e39116/brotli-1.2.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9c79f57faa25d97900bfb119480806d783fba83cd09ee0b33c17623935b05fa3", size = 1599150, upload-time = "2025-11-05T18:38:19.792Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1a/23fcfee1c324fd48a63d7ebf4bac3a4115bdb1b00e600f80f727d850b1ae/brotli-1.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:844a8ceb8483fefafc412f85c14f2aae2fb69567bf2a0de53cdb88b73e7c43ae", size = 1493505, upload-time = "2025-11-05T18:38:20.913Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e5/12904bbd36afeef53d45a84881a4810ae8810ad7e328a971ebbfd760a0b3/brotli-1.2.0-cp311-cp311-win32.whl", hash = "sha256:aa47441fa3026543513139cb8926a92a8e305ee9c71a6209ef7a97d91640ea03", size = 334451, upload-time = "2025-11-05T18:38:21.94Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8b/ecb5761b989629a4758c394b9301607a5880de61ee2ee5fe104b87149ebc/brotli-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:022426c9e99fd65d9475dce5c195526f04bb8be8907607e27e747893f6ee3e24", size = 369035, upload-time = "2025-11-05T18:38:22.941Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1459,7 +1517,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+brotli = [
+    { name = "brotli" },
+]
 full = [
+    { name = "brotli" },
     { name = "httpx" },
     { name = "httpx2" },
     { name = "itsdangerous" },
@@ -1492,6 +1554,8 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=3.6.2,<5" },
+    { name = "brotli", marker = "extra == 'brotli'" },
+    { name = "brotli", marker = "extra == 'full'" },
     { name = "httpx", marker = "extra == 'full'", specifier = ">=0.27.0,<0.29.0" },
     { name = "httpx2", marker = "extra == 'full'", specifier = ">=2.0.0" },
     { name = "itsdangerous", marker = "extra == 'full'" },
@@ -1500,7 +1564,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'full'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.10.0" },
 ]
-provides-extras = ["full"]
+provides-extras = ["brotli", "full"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

I've added brotli support via the official [google OSS](https://pypi.org/project/brotli/).

Does not touch normal working of starlette; Package is enabled only via `extras` -> `full` | `brotli`

Previous discussion's that welcomed this PR:

https://github.com/emmett-framework/granian/issues/686#issuecomment-3306345524

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

