### PR TITLE
Extract route resolution into `Router.resolve`

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -683,6 +683,25 @@ class Router:
             self._trie = trie
         return [routes[i] for i in self._trie.match_all(get_route_path(scope))]
 
+    def resolve(self, scope: Scope) -> tuple[BaseRoute, Scope] | None:
+        """Pick the route that should handle `scope`, and the scope it needs.
+
+        Returns the first route that fully matches, or else the first that
+        partially matches, which is how a `405 Method Not Allowed` is produced.
+        Returns `None` when nothing matches.
+
+        Override this to change how routes are found, without reimplementing the
+        rest of dispatch.
+        """
+        partial: tuple[BaseRoute, Scope] | None = None
+        for route in self._candidate_routes(scope):
+            match, child_scope = route.matches(scope)
+            if match == Match.FULL:
+                return route, child_scope
+            if match == Match.PARTIAL and partial is None:
+                partial = (route, child_scope)
+        return partial
+
     async def app(self, scope: Scope, receive: Receive, send: Send) -> None:
         assert scope["type"] in ("http", "websocket", "lifespan")
 
@@ -693,26 +712,11 @@ class Router:
             await self.lifespan(scope, receive, send)
             return
 
-        partial = None
-
-        for route in self._candidate_routes(scope):
-            # Determine if any route matches the incoming scope,
-            # and hand over to the matching route if found.
-            match, child_scope = route.matches(scope)
-            if match == Match.FULL:
-                scope.update(child_scope)
-                await route.handle(scope, receive, send)
-                return
-            elif match == Match.PARTIAL and partial is None:
-                partial = route
-                partial_scope = child_scope
-
-        if partial is not None:
-            #  Handle partial matches. These are cases where an endpoint is
-            # able to handle the request, but is not a preferred option.
-            # We use this in particular to deal with "405 Method Not Allowed".
-            scope.update(partial_scope)
-            await partial.handle(scope, receive, send)
+        resolved = self.resolve(scope)
+        if resolved is not None:
+            route, child_scope = resolved
+            scope.update(child_scope)
+            await route.handle(scope, receive, send)
             return
 
         route_path = get_route_path(scope)
@@ -723,13 +727,11 @@ class Router:
             else:
                 redirect_scope["path"] = redirect_scope["path"] + "/"
 
-            for route in self._candidate_routes(redirect_scope):
-                match, child_scope = route.matches(redirect_scope)
-                if match != Match.NONE:
-                    redirect_url = URL(scope=redirect_scope)
-                    response = RedirectResponse(url=str(redirect_url))
-                    await response(scope, receive, send)
-                    return
+            if self.resolve(redirect_scope) is not None:
+                redirect_url = URL(scope=redirect_scope)
+                response = RedirectResponse(url=str(redirect_url))
+                await response(scope, receive, send)
+                return
 
         await self.default(scope, receive, send)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -15,7 +15,7 @@ from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response
-from starlette.routing import Host, Match, Mount, NoMatchFound, Route, Router, WebSocketRoute
+from starlette.routing import BaseRoute, Host, Match, Mount, NoMatchFound, Route, Router, WebSocketRoute
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect
@@ -304,6 +304,31 @@ def test_mount_does_not_match_outside_its_prefix() -> None:
     route = Mount("/mounted", app=PlainTextResponse("hello"))
     match, _ = route.matches({"type": "http", "method": "GET", "path": "/elsewhere", "headers": []})
     assert match == Match.NONE
+
+
+def test_router_resolve() -> None:
+    route = Route("/func", endpoint=func_homepage, methods=["GET"])
+    router = Router(routes=[route])
+
+    resolved = router.resolve({"type": "http", "method": "GET", "path": "/func", "headers": []})
+    assert resolved is not None
+    assert resolved[0] is route
+
+    # A partial match is what produces the 405, so it is resolved too.
+    partial = router.resolve({"type": "http", "method": "POST", "path": "/func", "headers": []})
+    assert partial is not None
+    assert partial[0] is route
+
+    assert router.resolve({"type": "http", "method": "GET", "path": "/nope", "headers": []}) is None
+
+
+def test_router_resolve_can_be_overridden(test_client_factory: TestClientFactory) -> None:
+    class OnlyLastRoute(Router):
+        def resolve(self, scope: Scope) -> tuple[BaseRoute, Scope] | None:
+            return (self.routes[-1], {}) if self.routes else None
+
+    router = OnlyLastRoute(routes=[Route("/first", endpoint=homepage), Route("/second", endpoint=func_homepage)])
+    assert test_client_factory(router).get("/first").text == "Hello, world!"
 
 
 def test_router_duplicate_path(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

`Router.app` inlines the match loop twice, once for the request and once for the trailing-slash retry. Anything that wants to change how a route is found has to reimplement dispatch around it.

```python
def resolve(self, scope: Scope) -> tuple[BaseRoute, Scope] | None:
    """Pick the route that should handle `scope`, and the scope it needs."""
```

It returns the first full match, or else the first partial one (which is how a `405` is produced), or `None`. `app()` becomes the four steps around it: resolve, handle, redirect, default.

> [!NOTE]
> Based on #3339, so the diff here is only the extraction.

## Why

FastAPI's `APIRouter.app` (`fastapi/routing.py`, since 0.138.0) is a copy of this method. Diffed against ours it is identical apart from cosmetics, plus one inserted block immediately before `await self.default(...)` for its low-priority (SPA fallback) tier. The copy also scans `self.routes` linearly, so a FastAPI app does not benefit from the narrowing in #3339.

Two things follow from this PR:

- Downstream routers can override `resolve()` to change route lookup and inherit the rest of dispatch, including the narrowing.
- FastAPI's low-priority tier sits exactly where `self.default` is invoked, so it can be expressed as a `default` callable rather than a copied `app()`. Verified against this branch: a custom `default` gives SPA fallback on a miss, while `redirect_slashes` still takes precedence and 405s are unaffected.

## Behaviour

Unchanged. The one difference worth noting is internal: the trailing-slash check previously returned on the first route with any match, and now asks `resolve()`, which prefers a full match over a partial. The redirect fires in exactly the same cases.

1058 tests pass, 100% coverage, mypy strict and ruff clean.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

