### PR TITLE
Add HTTP 103 Early Hints support

### DIFF
--- a/docs/early-hints.md
+++ b/docs/early-hints.md
@@ -1,0 +1,39 @@
+Starlette supports [HTTP 103 Early Hints](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/103)
+through the ASGI [`http.response.early_hint`](https://asgi.readthedocs.io/en/latest/extensions.html#early-hints)
+extension. Early Hints let a client start loading resources while the endpoint prepares the final response.
+
+### `Request.send_early_hints`
+
+Used to send one or more `Link` header values before the final response. If the ASGI server does not support
+Early Hints, this method does nothing.
+
+Signature: `send_early_hints(links)`
+
+* `links` - An iterable of strings or bytes containing [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288.html)
+  `Link` header values.
+
+```python
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import HTMLResponse
+from starlette.routing import Route
+
+
+async def homepage(request: Request) -> HTMLResponse:
+    links = [
+        "</static/style.css>; rel=preload; as=style",
+        "</static/app.js>; rel=modulepreload",
+    ]
+    await request.send_early_hints(links)
+
+    # The client can load the hinted resources while this work runs.
+    content = await render_homepage()
+    return HTMLResponse(content)
+
+
+app = Starlette(routes=[Route("/", endpoint=homepage)])
+```
+
+The ASGI server is responsible for sending Early Hints to the client. For example, Hypercorn supports the
+extension over HTTP/2 and HTTP/3. Browsers may ignore Early Hints, so the resources must still be referenced by
+the final response.

--- a/docs/early-hints.md
+++ b/docs/early-hints.md
@@ -13,9 +13,13 @@ Signature: `send_early_hints(link, *additional_links)`
 * `additional_links` - Additional `Link` header values.
 
 ```python
+from __future__ import annotations
+
+import anyio
+
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import HTMLResponse
+from starlette.responses import HTMLResponse, Response
 from starlette.routing import Route
 
 
@@ -25,13 +29,43 @@ async def homepage(request: Request) -> HTMLResponse:
         "</static/app.js>; rel=modulepreload",
     )
 
-    # The client can load the hinted resources while this work runs.
-    content = await render_homepage()
-    return HTMLResponse(content)
+    await anyio.sleep(1)
+    return HTMLResponse("""
+        <!doctype html>
+        <html lang="en">
+            <head>
+                <title>Early Hints</title>
+                <link rel="stylesheet" href="/static/style.css">
+                <script type="module" src="/static/app.js"></script>
+            </head>
+            <body><h1>Hello!</h1></body>
+        </html>
+    """)
 
 
-app = Starlette(routes=[Route("/", endpoint=homepage)])
+async def stylesheet(request: Request) -> Response:
+    return Response("body { font-family: sans-serif; }", media_type="text/css")
+
+
+async def javascript(request: Request) -> Response:
+    return Response(
+        'document.querySelector("h1").textContent = "Hello from Starlette!";',
+        media_type="text/javascript",
+    )
+
+
+app = Starlette(
+    routes=[
+        Route("/", endpoint=homepage),
+        Route("/static/style.css", endpoint=stylesheet),
+        Route("/static/app.js", endpoint=javascript),
+    ]
+)
 ```
+
+The one-second sleep simulates slow work, such as a database query. You send the hints before this work so
+the client can load the stylesheet and script while it waits. This example serves both assets through routes,
+so you do not need to create separate static files.
 
 The ASGI server is responsible for sending Early Hints to the client. For example, Hypercorn supports the
 extension over HTTP/2 and HTTP/3. Browsers may ignore Early Hints, so the resources must still be referenced by

--- a/docs/early-hints.md
+++ b/docs/early-hints.md
@@ -7,10 +7,10 @@ extension. Early Hints let a client start loading resources while the endpoint p
 Used to send one or more `Link` header values before the final response. If the ASGI server does not support
 Early Hints, this method does nothing.
 
-Signature: `send_early_hints(links)`
+Signature: `send_early_hints(link, *additional_links)`
 
-* `links` - An iterable of strings or bytes containing [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288.html)
-  `Link` header values.
+* `link` - An [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288.html) `Link` header value.
+* `additional_links` - Additional `Link` header values.
 
 ```python
 from starlette.applications import Starlette
@@ -20,11 +20,10 @@ from starlette.routing import Route
 
 
 async def homepage(request: Request) -> HTMLResponse:
-    links = [
+    await request.send_early_hints(
         "</static/style.css>; rel=preload; as=style",
         "</static/app.js>; rel=modulepreload",
-    ]
-    await request.send_early_hints(links)
+    )
 
     # The client can load the hinted resources while this work runs.
     content = await render_homepage()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
       - Lifespan: "lifespan.md"
       - Background Tasks: "background.md"
       - Server Push: "server-push.md"
+      - Early Hints: "early-hints.md"
       - Exceptions: "exceptions.md"
       - Configuration: "config.md"
       - Thread Pool: "threadpool.md"

--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -30,7 +30,7 @@ class HTTPEndpoint:
         return self.dispatch().__await__()
 
     async def dispatch(self) -> None:
-        request = Request(self.scope, receive=self.receive)
+        request = Request(self.scope, receive=self.receive, send=self.send)
         handler_name = "get" if request.method == "HEAD" and not hasattr(self, "head") else request.method.lower()
 
         handler: Callable[[Request], Any]

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -25,8 +25,8 @@ class _CachedRequest(Request):
     empty body so that downstream things don't hang forever.
     """
 
-    def __init__(self, scope: Scope, receive: Receive):
-        super().__init__(scope, receive)
+    def __init__(self, scope: Scope, receive: Receive, send: Send):
+        super().__init__(scope, receive, send)
         self._wrapped_rcv_disconnected = False
         self._wrapped_rcv_consumed = False
         self._wrapped_rc_stream = self.stream()
@@ -103,7 +103,7 @@ class BaseHTTPMiddleware:
             await self.app(scope, receive, send)
             return
 
-        request = _CachedRequest(scope, receive)
+        request = _CachedRequest(scope, receive, send)
         wrapped_receive = request.wrapped_receive
         response_sent = anyio.Event()
         app_exc: Exception | None = None
@@ -148,10 +148,16 @@ class BaseHTTPMiddleware:
             task_group.start_soon(coro)
 
             try:
-                message = await recv_stream.receive()
-                info = message.get("info", None)
-                if message["type"] == "http.response.debug" and info is not None:
+                info = None
+                while True:
                     message = await recv_stream.receive()
+                    if message["type"] == "http.response.debug":
+                        info = message["info"]
+                        continue
+                    elif message["type"] == "http.response.early_hint":
+                        await send(message)
+                        continue
+                    break
             except anyio.EndOfStream:
                 if app_exc is not None:
                     nonlocal exception_already_raised

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -104,9 +104,7 @@ class IdentityResponder:
 
     async def send_with_compression(self, message: Message) -> None:
         message_type = message["type"]
-        if message_type == "http.response.early_hint":
-            await self.send(message)
-        elif message_type == "http.response.start":
+        if message_type == "http.response.start":
             # Don't send the initial message until we've determined how to
             # modify the outgoing headers correctly.
             self.initial_message = message
@@ -165,8 +163,9 @@ class IdentityResponder:
             message["body"] = await self.apply_compression(body, more_body=more_body)
 
             await self.send(message)
+        elif message_type == "http.response.early_hint":
+            await self.send(message)
         elif message_type == "http.response.pathsend":  # pragma: no branch
-            # Don't apply GZip to pathsend responses
             await self.send(self.initial_message)
             await self.send(message)
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -104,7 +104,9 @@ class IdentityResponder:
 
     async def send_with_compression(self, message: Message) -> None:
         message_type = message["type"]
-        if message_type == "http.response.start":
+        if message_type == "http.response.early_hint":
+            await self.send(message)
+        elif message_type == "http.response.start":
             # Don't send the initial message until we've determined how to
             # modify the outgoing headers correctly.
             self.initial_message = message

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
-from collections.abc import AsyncGenerator, Iterable, Iterator, Mapping
+from collections.abc import AsyncGenerator, Iterator, Mapping
 from http import cookies as http_cookies
 from typing import TYPE_CHECKING, Any, Generic, NoReturn, cast
 
@@ -347,7 +347,7 @@ class Request(HTTPConnection[StateT]):
                     raw_headers.append((name.encode("latin-1"), value.encode("latin-1")))
             await self._send({"type": "http.response.push", "path": path, "headers": raw_headers})
 
-    async def send_early_hints(self, links: Iterable[str | bytes]) -> None:
+    async def send_early_hints(self, link: str, /, *additional_links: str) -> None:
         if "http.response.early_hint" in self.scope.get("extensions", {}):
-            raw_links = [link.encode("latin-1") if isinstance(link, str) else link for link in links]
+            raw_links = [value.encode("latin-1") for value in (link, *additional_links)]
             await self._send({"type": "http.response.early_hint", "links": raw_links})

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
-from collections.abc import AsyncGenerator, Iterator, Mapping
+from collections.abc import AsyncGenerator, Iterable, Iterator, Mapping
 from http import cookies as http_cookies
 from typing import TYPE_CHECKING, Any, Generic, NoReturn, cast
 
@@ -346,3 +346,8 @@ class Request(HTTPConnection[StateT]):
                 for value in self.headers.getlist(name):
                     raw_headers.append((name.encode("latin-1"), value.encode("latin-1")))
             await self._send({"type": "http.response.push", "path": path, "headers": raw_headers})
+
+    async def send_early_hints(self, links: Iterable[str | bytes]) -> None:
+        if "http.response.early_hint" in self.scope.get("extensions", {}):
+            raw_links = [link.encode("latin-1") if isinstance(link, str) else link for link in links]
+            await self._send({"type": "http.response.early_hint", "links": raw_links})

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1220,11 +1220,11 @@ async def test_early_hints_events() -> None:
     events: list[Message] = []
 
     async def endpoint(request: Request) -> PlainTextResponse:
-        await request.send_early_hints(["</endpoint.css>; rel=preload; as=style"])
+        await request.send_early_hints("</endpoint.css>; rel=preload; as=style")
         return PlainTextResponse("hello")
 
     async def send_early_hints(request: Request, call_next: RequestResponseEndpoint) -> Response:
-        await request.send_early_hints(["</middleware.css>; rel=preload; as=style"])
+        await request.send_early_hints("</middleware.css>; rel=preload; as=style")
         return await call_next(request)
 
     app = Starlette(

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1216,6 +1216,55 @@ async def test_poll_for_disconnect_repeated(send_body: bool) -> None:
 
 
 @pytest.mark.anyio
+async def test_early_hints_events() -> None:
+    events: list[Message] = []
+
+    async def endpoint(request: Request) -> PlainTextResponse:
+        await request.send_early_hints(["</endpoint.css>; rel=preload; as=style"])
+        return PlainTextResponse("hello")
+
+    async def send_early_hints(request: Request, call_next: RequestResponseEndpoint) -> Response:
+        await request.send_early_hints(["</middleware.css>; rel=preload; as=style"])
+        return await call_next(request)
+
+    app = Starlette(
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=send_early_hints)],
+        routes=[Route("/", endpoint)],
+    )
+    scope: Scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+        "extensions": {"http.response.early_hint": {}},
+    }
+
+    async def receive() -> Message:
+        raise NotImplementedError("Should not be called")  # pragma: no cover
+
+    async def send(message: Message) -> None:
+        events.append(message)
+
+    await app(scope, receive, send)
+
+    assert events[:2] == [
+        {
+            "type": "http.response.early_hint",
+            "links": [b"</middleware.css>; rel=preload; as=style"],
+        },
+        {
+            "type": "http.response.early_hint",
+            "links": [b"</endpoint.css>; rel=preload; as=style"],
+        },
+    ]
+    assert [event["type"] for event in events[2:]] == [
+        "http.response.start",
+        "http.response.body",
+        "http.response.body",
+    ]
+
+
+@pytest.mark.anyio
 async def test_asgi_pathsend_events(tmpdir: Path) -> None:
     path = tmpdir / "example.txt"
     with path.open("w") as file:

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -217,6 +217,41 @@ def test_gzip_ignored_on_server_sent_events(test_client_factory: TestClientFacto
 
 
 @pytest.mark.anyio
+async def test_gzip_passes_through_early_hints() -> None:
+    early_hint: Message = {
+        "type": "http.response.early_hint",
+        "links": [b"</style.css>; rel=preload; as=style"],
+    }
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send(early_hint)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"content"})
+
+    events: list[Message] = []
+
+    async def send(message: Message) -> None:
+        events.append(message)
+
+    async def receive() -> Message:
+        raise NotImplementedError  # pragma: no cover
+
+    scope: Scope = {
+        "type": "http",
+        "headers": [(b"accept-encoding", b"gzip")],
+        "extensions": {"http.response.early_hint": {}},
+    }
+    await GZipMiddleware(app)(scope, receive, send)
+
+    assert events[0] == early_hint
+    assert [event["type"] for event in events] == [
+        "http.response.early_hint",
+        "http.response.start",
+        "http.response.body",
+    ]
+
+
+@pytest.mark.anyio
 async def test_gzip_ignored_for_pathsend_responses(tmpdir: Path) -> None:
     path = tmpdir / "example.txt"
     with path.open("w") as file:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -7,6 +7,7 @@ from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route, Router
 from starlette.testclient import TestClient
+from starlette.types import Message, Scope
 from starlette.websockets import WebSocket
 from tests.types import TestClientFactory
 
@@ -45,6 +46,36 @@ def test_http_endpoint_route_method(client: TestClient) -> None:
     assert response.status_code == 405
     assert response.text == "Method Not Allowed"
     assert response.headers["allow"] == "GET"
+
+
+@pytest.mark.anyio
+async def test_http_endpoint_supports_early_hints() -> None:
+    class Endpoint(HTTPEndpoint):
+        async def get(self, request: Request) -> PlainTextResponse:
+            await request.send_early_hints(["</style.css>; rel=preload; as=style"])
+            return PlainTextResponse("Hello, world!")
+
+    scope: Scope = {
+        "type": "http",
+        "method": "GET",
+        "extensions": {"http.response.early_hint": {}},
+    }
+    messages: list[Message] = []
+
+    async def receive() -> Message:
+        raise NotImplementedError  # pragma: no cover
+
+    async def send(message: Message) -> None:
+        messages.append(message)
+
+    await Endpoint(scope, receive, send)
+
+    assert messages[0] == {
+        "type": "http.response.early_hint",
+        "links": [b"</style.css>; rel=preload; as=style"],
+    }
+    assert messages[1]["type"] == "http.response.start"
+    assert messages[2]["type"] == "http.response.body"
 
 
 def test_http_endpoint_does_not_dispatch_non_verb_method(test_client_factory: TestClientFactory) -> None:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -52,7 +52,7 @@ def test_http_endpoint_route_method(client: TestClient) -> None:
 async def test_http_endpoint_supports_early_hints() -> None:
     class Endpoint(HTTPEndpoint):
         async def get(self, request: Request) -> PlainTextResponse:
-            await request.send_early_hints(["</style.css>; rel=preload; as=style"])
+            await request.send_early_hints("</style.css>; rel=preload; as=style")
             return PlainTextResponse("Hello, world!")
 
     scope: Scope = {

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -574,10 +574,8 @@ async def test_request_send_early_hints() -> None:
     scope: Scope = {"type": "http", "extensions": {"http.response.early_hint": {}}}
     request = Request(scope, send=send)
     await request.send_early_hints(
-        [
-            "</style.css>; rel=preload; as=style",
-            b"</app.js>; rel=modulepreload",
-        ]
+        "</style.css>; rel=preload; as=style",
+        "</app.js>; rel=modulepreload",
     )
 
     assert messages == [
@@ -592,6 +590,14 @@ async def test_request_send_early_hints() -> None:
 
 
 @pytest.mark.anyio
+async def test_request_send_early_hints_requires_positional_link() -> None:
+    request = Request({"type": "http"})
+
+    with pytest.raises(TypeError, match="positional-only"):
+        await request.send_early_hints(link="</style.css>; rel=preload; as=style")  # type: ignore[call-arg]
+
+
+@pytest.mark.anyio
 async def test_request_send_early_hints_without_extension() -> None:
     messages: list[Message] = []
 
@@ -599,7 +605,7 @@ async def test_request_send_early_hints_without_extension() -> None:
         messages.append(message)
 
     request = Request({"type": "http", "extensions": {}}, send=send)
-    await request.send_early_hints(["</style.css>; rel=preload; as=style"])
+    await request.send_early_hints("</style.css>; rel=preload; as=style")
 
     assert messages == []
 
@@ -609,7 +615,7 @@ async def test_request_send_early_hints_without_send_channel() -> None:
     request = Request({"type": "http", "extensions": {"http.response.early_hint": {}}})
 
     with pytest.raises(RuntimeError, match="Send channel has not been made available"):
-        await request.send_early_hints(["</style.css>; rel=preload; as=style"])
+        await request.send_early_hints("</style.css>; rel=preload; as=style")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -564,6 +564,54 @@ def test_request_send_push_promise_without_setting_send(
     assert response.json() == {"json": "Send channel not available"}
 
 
+@pytest.mark.anyio
+async def test_request_send_early_hints() -> None:
+    messages: list[Message] = []
+
+    async def send(message: Message) -> None:
+        messages.append(message)
+
+    scope: Scope = {"type": "http", "extensions": {"http.response.early_hint": {}}}
+    request = Request(scope, send=send)
+    await request.send_early_hints(
+        [
+            "</style.css>; rel=preload; as=style",
+            b"</app.js>; rel=modulepreload",
+        ]
+    )
+
+    assert messages == [
+        {
+            "type": "http.response.early_hint",
+            "links": [
+                b"</style.css>; rel=preload; as=style",
+                b"</app.js>; rel=modulepreload",
+            ],
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_request_send_early_hints_without_extension() -> None:
+    messages: list[Message] = []
+
+    async def send(message: Message) -> None:  # pragma: no cover
+        messages.append(message)
+
+    request = Request({"type": "http", "extensions": {}}, send=send)
+    await request.send_early_hints(["</style.css>; rel=preload; as=style"])
+
+    assert messages == []
+
+
+@pytest.mark.anyio
+async def test_request_send_early_hints_without_send_channel() -> None:
+    request = Request({"type": "http", "extensions": {"http.response.early_hint": {}}})
+
+    with pytest.raises(RuntimeError, match="Send channel has not been made available"):
+        await request.send_early_hints(["</style.css>; rel=preload; as=style"])
+
+
 @pytest.mark.parametrize(
     "messages",
     [


### PR DESCRIPTION
## Summary

Add `Request.send_early_hints()` for the ASGI `http.response.early_hint` extension.

```python
await request.send_early_hints(
    "</static/style.css>; rel=preload; as=style",
    "</static/app.js>; rel=modulepreload",
)
```

Each Link value is a positional string argument. Requiring the first link avoids accidentally treating a bare string as an iterable of characters, and making it positional-only prevents `link=` from becoming part of the API. Starlette encodes the values to the byte strings required by ASGI and does nothing when the server does not advertise the extension.

## Integration

This also makes Early Hints work across Starlette's response stack:

- `HTTPEndpoint` supplies its `Request` with the ASGI send channel.
- `BaseHTTPMiddleware` supplies its dispatch request with the send channel and forwards Early Hints emitted by downstream endpoints before Response Start.
- `GZipMiddleware` passes Early Hints through without dropping or compressing them.

The event ordering follows Hypercorn's implementation, which accepts Early Hints while the stream is in the request state, before Response Start:

https://github.com/pgjones/hypercorn/blob/0e2311f1ad2ae587aaa590f3824f59aa5dc0e770/src/hypercorn/protocol/http_stream.py#L142-L186

The corresponding ASGI documentation clarification is proposed in https://github.com/django/asgiref/pull/579.

A dedicated documentation page covers usage, server support, and the requirement to reference hinted resources in the final response.

## Testing

- Added unit and integration coverage for `Request`, `HTTPEndpoint`, `BaseHTTPMiddleware`, and `GZipMiddleware`.
- 100% coverage
- `ruff`, `mypy`, and documentation build pass

Closes #3308.
