### PR TITLE
Track session mutations from popitem() and |=

### DIFF
--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -115,6 +115,11 @@ class Session(dict[str, typing.Any]):
         self.modified = self.modified or key in self
         return super().pop(key, *args)
 
+    def popitem(self) -> tuple[str, typing.Any]:
+        item = super().popitem()
+        self.mark_modified()
+        return item
+
     def setdefault(self, key: str, default: typing.Any = None) -> typing.Any:
         if key not in self:
             self.mark_modified()
@@ -123,3 +128,10 @@ class Session(dict[str, typing.Any]):
     def update(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         self.mark_modified()
         super().update(*args, **kwargs)
+
+    # `dict.__ior__` updates in place without going through `__setitem__`, so it needs to be
+    # tracked explicitly. mypy requires `__ior__` to line up with the widening `dict.__or__`
+    # overloads, which a `dict` subclass returning itself cannot satisfy.
+    def __ior__(self, other: typing.Any, /) -> Session:  # type: ignore[override,misc]
+        self.mark_modified()
+        return super().__ior__(other)

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -129,9 +129,6 @@ class Session(dict[str, typing.Any]):
         self.mark_modified()
         super().update(*args, **kwargs)
 
-    # `dict.__ior__` updates in place without going through `__setitem__`, so it needs to be
-    # tracked explicitly. mypy requires `__ior__` to line up with the widening `dict.__or__`
-    # overloads, which a `dict` subclass returning itself cannot satisfy.
     def __ior__(self, other: typing.Any, /) -> Session:  # type: ignore[override,misc]
         self.mark_modified()
         return super().__ior__(other)

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -1,5 +1,7 @@
 import re
 
+import pytest
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.sessions import Session, SessionMiddleware
@@ -17,6 +19,18 @@ def view_session(request: Request) -> JSONResponse:
 async def update_session(request: Request) -> JSONResponse:
     data = await request.json()
     request.session.update(data)
+    return JSONResponse({"session": request.session})
+
+
+async def inplace_update_session(request: Request) -> JSONResponse:
+    data = await request.json()
+    session = request.session
+    session |= data
+    return JSONResponse({"session": request.session})
+
+
+async def popitem_session(request: Request) -> JSONResponse:
+    request.session.popitem()
     return JSONResponse({"session": request.session})
 
 
@@ -285,3 +299,59 @@ def test_session_tracks_modification() -> None:
     session = Session({"a": "1"})
     session.setdefault("a", "2")
     assert not session.modified
+
+    # popitem
+    session = Session({"a": "1"})
+    session.popitem()
+    assert session.modified
+
+    # popitem on an empty session raises and leaves the session untouched
+    session = Session()
+    with pytest.raises(KeyError):
+        session.popitem()
+    assert not session.modified
+
+    # in-place update
+    session = Session({"a": "1"})
+    session |= {"b": "2"}
+    assert session.modified
+
+
+def test_session_persists_inplace_update(test_client_factory: TestClientFactory) -> None:
+    app = Starlette(
+        routes=[
+            Route("/view_session", endpoint=view_session),
+            Route("/inplace_update_session", endpoint=inplace_update_session, methods=["POST"]),
+        ],
+        middleware=[Middleware(SessionMiddleware, secret_key="example")],
+    )
+    client = test_client_factory(app)
+
+    response = client.post("/inplace_update_session", json={"some": "data"})
+    assert response.json() == {"session": {"some": "data"}}
+    assert "set-cookie" in response.headers
+
+    response = client.get("/view_session")
+    assert response.json() == {"session": {"some": "data"}}
+
+
+def test_session_persists_popitem(test_client_factory: TestClientFactory) -> None:
+    app = Starlette(
+        routes=[
+            Route("/view_session", endpoint=view_session),
+            Route("/update_session", endpoint=update_session, methods=["POST"]),
+            Route("/popitem_session", endpoint=popitem_session, methods=["POST"]),
+        ],
+        middleware=[Middleware(SessionMiddleware, secret_key="example")],
+    )
+    client = test_client_factory(app)
+
+    response = client.post("/update_session", json={"a": "1", "b": "2"})
+    assert response.json() == {"session": {"a": "1", "b": "2"}}
+
+    response = client.post("/popitem_session")
+    assert response.json() == {"session": {"a": "1"}}
+    assert "set-cookie" in response.headers
+
+    response = client.get("/view_session")
+    assert response.json() == {"session": {"a": "1"}}

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -300,46 +300,25 @@ def test_session_tracks_modification() -> None:
     session.setdefault("a", "2")
     assert not session.modified
 
-    # popitem
-    session = Session({"a": "1"})
-    session.popitem()
-    assert session.modified
 
-    # popitem on an empty session raises and leaves the session untouched
-    session = Session()
-    with pytest.raises(KeyError):
-        session.popitem()
-    assert not session.modified
-
-    # in-place update
-    session = Session({"a": "1"})
-    session |= {"b": "2"}
-    assert session.modified
-
-
-def test_session_persists_inplace_update(test_client_factory: TestClientFactory) -> None:
-    app = Starlette(
-        routes=[
-            Route("/view_session", endpoint=view_session),
-            Route("/inplace_update_session", endpoint=inplace_update_session, methods=["POST"]),
-        ],
-        middleware=[Middleware(SessionMiddleware, secret_key="example")],
-    )
-    client = test_client_factory(app)
-
-    response = client.post("/inplace_update_session", json={"some": "data"})
-    assert response.json() == {"session": {"some": "data"}}
-    assert "set-cookie" in response.headers
-
-    response = client.get("/view_session")
-    assert response.json() == {"session": {"some": "data"}}
-
-
-def test_session_persists_popitem(test_client_factory: TestClientFactory) -> None:
+@pytest.mark.parametrize(
+    ("path", "data", "expected"),
+    [
+        ("/inplace_update_session", {"c": "3"}, {"a": "1", "b": "2", "c": "3"}),
+        ("/popitem_session", None, {"a": "1"}),
+    ],
+)
+def test_session_persists_mutations(
+    test_client_factory: TestClientFactory,
+    path: str,
+    data: dict[str, str] | None,
+    expected: dict[str, str],
+) -> None:
     app = Starlette(
         routes=[
             Route("/view_session", endpoint=view_session),
             Route("/update_session", endpoint=update_session, methods=["POST"]),
+            Route("/inplace_update_session", endpoint=inplace_update_session, methods=["POST"]),
             Route("/popitem_session", endpoint=popitem_session, methods=["POST"]),
         ],
         middleware=[Middleware(SessionMiddleware, secret_key="example")],
@@ -349,9 +328,8 @@ def test_session_persists_popitem(test_client_factory: TestClientFactory) -> Non
     response = client.post("/update_session", json={"a": "1", "b": "2"})
     assert response.json() == {"session": {"a": "1", "b": "2"}}
 
-    response = client.post("/popitem_session")
-    assert response.json() == {"session": {"a": "1"}}
-    assert "set-cookie" in response.headers
+    response = client.post(path, json=data)
+    assert response.json() == {"session": expected}
 
     response = client.get("/view_session")
-    assert response.json() == {"session": {"a": "1"}}
+    assert response.json() == {"session": expected}


### PR DESCRIPTION
# Summary

`Session` tracks mutations so that `SessionMiddleware` knows when to emit an updated cookie. `dict.popitem()` and the in-place union operator (`|=`) were not overridden, so those mutations left `Session.modified` false.

A request handler could observe the changed mapping, but the response omitted `Set-Cookie`, and the mutation disappeared on the next request.

This change overrides both mutators and adds middleware-level persistence regression coverage.

# Reproduction

1. Store at least one value in `request.session`.
2. In a later request, call `request.session.popitem()`, or assign `session = request.session` and then call `session |= values`.
3. Observe the changed mapping in that request.
4. Make another request and observe that the previous cookie value is restored because the mutating response did not emit `Set-Cookie`.

# Tests

- `uv run pytest tests/middleware/test_session.py` - 23 passed
- `uv run ruff check starlette/middleware/sessions.py tests/middleware/test_session.py` - passed
- `uv run ruff format --check starlette/middleware/sessions.py tests/middleware/test_session.py` - passed
- `uv run mypy starlette/middleware/sessions.py tests/middleware/test_session.py` - passed

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] Documentation is unchanged because this fixes existing mapping mutation behavior without introducing a new public API.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
