### PR TITLE
Repoint dead TechEmpower benchmarks link to the source repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ in isolation.
 [itsdangerous]: https://itsdangerous.palletsprojects.com/
 [sqlalchemy]: https://www.sqlalchemy.org
 [pyyaml]: https://pyyaml.org/wiki/PyYAMLDocumentation
-[techempower]: https://www.techempower.com/benchmarks/#hw=ph&test=fortune&l=zijzen-sf
+[techempower]: https://github.com/TechEmpower/FrameworkBenchmarks

--- a/docs/index.md
+++ b/docs/index.md
@@ -153,4 +153,4 @@ in isolation.
 [itsdangerous]: https://itsdangerous.palletsprojects.com/
 [sqlalchemy]: https://www.sqlalchemy.org
 [pyyaml]: https://pyyaml.org/wiki/PyYAMLDocumentation
-[techempower]: https://www.techempower.com/benchmarks/#hw=ph&test=fortune&l=zijzen-sf
+[techempower]: https://github.com/TechEmpower/FrameworkBenchmarks


### PR DESCRIPTION
As discussed in #3433, the `[techempower]` reference link points to the TechEmpower benchmarks results page, which no longer serves content. The project was sunset and the repository archived upstream, so there is no live results URL to swap in.

This repoints the link to the FrameworkBenchmarks source repository, which stays live and still substantiates that Starlette was part of the suite (`frameworks/Python/starlette` is present in the archived repo).

Updates the link definition in `README.md` and `docs/index.md`; the surrounding text is unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

