### PR TITLE
Propagate lifespan events to mounted applications

### DIFF
--- a/docs/lifespan.md
+++ b/docs/lifespan.md
@@ -156,3 +156,18 @@ def test_homepage():
 
     # And the lifespan's teardown is run when exiting the block.
 ```
+
+## Mounted applications
+
+Lifespan events are propagated to mounted applications (`Mount` and `Host`).
+Each mounted ASGI app receives its own startup and shutdown.
+
+This is what makes composable apps work: an MCP server, a FastAPI sub-app, or
+any other ASGI app with a lifespan can be mounted without the parent having to
+re-implement that child's startup.
+
+Applications that do not support the lifespan protocol — for example
+`StaticFiles` or a plain `Response` — are skipped.
+
+Nested mounts are supported. Each router propagates lifespan to its own mounts.
+Child lifespan state is merged into the same `state` dictionary as the parent.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,12 @@
 toc_depth: 2
 ---
 
+## Unreleased
+
+#### Added
+
+* Propagate ASGI lifespan events to mounted applications and hosts [#649](https://github.com/Kludex/starlette/issues/649).
+
 ## 1.6.0 (August 8, 2026)
 
 #### Added

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -146,6 +146,10 @@ routes = [
 app = Starlette(routes=routes)
 ```
 
+Mounted applications receive [lifespan](lifespan.md#mounted-applications)
+startup and shutdown. Apps that do not implement the lifespan protocol are
+skipped.
+
 ## Reverse URL lookups
 
 You'll often want to be able to generate the URL for a particular route,

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -23,7 +23,7 @@ from starlette.middleware import Middleware
 from starlette.middleware.body_limit import RequestBodyLimitMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, RedirectResponse, Response
-from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send
+from starlette.types import ASGIApp, Lifespan, Message, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketClose
 
 
@@ -570,6 +570,81 @@ class _DefaultLifespan:
         return self
 
 
+def _mounted_lifespan_apps(routes: Sequence[BaseRoute]) -> list[ASGIApp]:
+    return [route.app for route in routes if isinstance(route, Mount | Host)]
+
+
+def _lifespan_child_scope(scope: Scope) -> Scope:
+    child_scope: Scope = {
+        "type": "lifespan",
+        # spec_version 2.4 so HTTP apps (Response, etc.) do not call receive()
+        # looking for http.disconnect when given a lifespan scope.
+        "asgi": {"version": "3.0", "spec_version": "2.4"},
+    }
+    if "state" in scope:
+        child_scope["state"] = scope["state"]
+    return child_scope
+
+
+async def _run_mounted_lifespans(
+    apps: Sequence[ASGIApp],
+    scope: Scope,
+    startup_complete: Callable[[], Awaitable[None]],
+) -> None:
+    """Run mounted ASGI lifespans, then `startup_complete`, then shut them down.
+
+    Child apps are stacked via receive() callbacks (an "onion"), not task groups.
+    Task groups previously caused review concerns around cancellation races
+    (see https://github.com/Kludex/starlette/pull/1988).
+    """
+    remaining = list(apps)
+
+    async def run_next() -> None:
+        if not remaining:
+            await startup_complete()
+            return
+
+        app = remaining.pop(0)
+        received: list[str] = []
+        sent: list[str] = []
+
+        async def child_receive() -> Message:
+            if not received:
+                received.append("lifespan.startup")
+                return {"type": "lifespan.startup"}
+            if received[-1] == "lifespan.startup":
+                await run_next()
+                received.append("lifespan.shutdown")
+                return {"type": "lifespan.shutdown"}
+            raise RuntimeError("Mounted application called receive() too many times during lifespan")
+
+        async def child_send(message: Message) -> None:
+            message_type = message.get("type")
+            if not isinstance(message_type, str) or not message_type.startswith("lifespan."):
+                return
+            sent.append(message_type)
+
+        try:
+            await app(_lifespan_child_scope(scope), child_receive, child_send)
+        except BaseException:
+            if "lifespan.startup" in received:
+                raise
+            await run_next()
+            return
+
+        if "lifespan.startup.failed" in sent:
+            raise RuntimeError("Mounted application failed during lifespan startup")
+        if "lifespan.shutdown.failed" in sent:
+            raise RuntimeError("Mounted application failed during lifespan shutdown")
+        if "lifespan.startup.complete" not in sent:
+            await run_next()
+            return
+        if "lifespan.shutdown" not in received:
+            raise RuntimeError("Mounted application lifespan exited before shutdown")
+
+    await run_next()
+
+
 class Router:
     def __init__(
         self,
@@ -644,15 +719,20 @@ class Router:
         started = False
         app: Any = scope.get("app")
         await receive()
+
+        async def startup_complete() -> None:
+            nonlocal started
+            await send({"type": "lifespan.startup.complete"})
+            started = True
+            await receive()
+
         try:
             async with self.lifespan_context(app) as maybe_state:
                 if maybe_state is not None:
                     if "state" not in scope:
                         raise RuntimeError('The server does not support "state" in the lifespan scope.')
                     scope["state"].update(maybe_state)
-                await send({"type": "lifespan.startup.complete"})
-                started = True
-                await receive()
+                await _run_mounted_lifespans(_mounted_lifespan_apps(self.routes), scope, startup_complete)
         except BaseException:
             exc_text = traceback.format_exc()
             if started:

--- a/tests/test_mount_lifespan.py
+++ b/tests/test_mount_lifespan.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+
+import pytest
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.routing import Host, Mount, Route, Router
+from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send
+from tests.types import TestClientFactory
+
+
+def _lifespan_app(events: list[str], name: str) -> ASGIApp:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "lifespan":
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+            return
+        await receive()
+        events.append(f"{name}:startup")
+        await send({"type": "lifespan.startup.complete"})
+        await receive()
+        events.append(f"{name}:shutdown")
+        await send({"type": "lifespan.shutdown.complete"})
+
+    return app
+
+
+def _starlette_lifespan(events: list[str], name: str) -> Lifespan[Starlette]:
+    @asynccontextmanager
+    async def lifespan(app: Starlette) -> AsyncIterator[None]:
+        events.append(f"{name}:startup")
+        yield
+        events.append(f"{name}:shutdown")
+
+    return lifespan
+
+
+def _text(body: str) -> Callable[[Request], PlainTextResponse]:
+    def endpoint(request: Request) -> PlainTextResponse:
+        return PlainTextResponse(body)
+
+    return endpoint
+
+
+def test_mounted_asgi_app_receives_lifespan(test_client_factory: TestClientFactory) -> None:
+    events: list[str] = []
+    app = Router(routes=[Mount("/mcp", _lifespan_app(events, "mcp"))])
+
+    with test_client_factory(app) as client:
+        assert events == ["mcp:startup"]
+        response = client.get("/mcp")
+        assert response.status_code == 200
+
+    assert events == ["mcp:startup", "mcp:shutdown"]
+
+
+def test_parent_and_mounted_lifespan_order(test_client_factory: TestClientFactory) -> None:
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def parent_lifespan(app: Starlette) -> AsyncIterator[None]:
+        events.append("parent:startup")
+        yield
+        events.append("parent:shutdown")
+
+    @asynccontextmanager
+    async def child_lifespan(app: Starlette) -> AsyncIterator[None]:
+        events.append("child:startup")
+        yield
+        events.append("child:shutdown")
+
+    child = Starlette(
+        routes=[Route("/", _text("child"))],
+        lifespan=child_lifespan,
+    )
+    app = Starlette(
+        routes=[
+            Route("/", _text("parent")),
+            Mount("/child", child),
+        ],
+        lifespan=parent_lifespan,
+    )
+
+    with test_client_factory(app) as client:
+        assert events == ["parent:startup", "child:startup"]
+        assert client.get("/").text == "parent"
+        assert client.get("/child").text == "child"
+
+    assert events == ["parent:startup", "child:startup", "child:shutdown", "parent:shutdown"]
+
+
+def test_multiple_mounts_start_in_order_and_shutdown_lifo(test_client_factory: TestClientFactory) -> None:
+    events: list[str] = []
+    app = Router(
+        routes=[
+            Mount("/a", _lifespan_app(events, "a")),
+            Mount("/b", _lifespan_app(events, "b")),
+        ]
+    )
+
+    with test_client_factory(app):
+        assert events == ["a:startup", "b:startup"]
+
+    assert events == ["a:startup", "b:startup", "b:shutdown", "a:shutdown"]
+
+
+def test_nested_mounts(test_client_factory: TestClientFactory) -> None:
+    events: list[str] = []
+    grandchild = Starlette(
+        routes=[Route("/", _text("gc"))],
+        lifespan=_starlette_lifespan(events, "grandchild"),
+    )
+    child = Starlette(
+        routes=[Mount("/gc", grandchild)],
+        lifespan=_starlette_lifespan(events, "child"),
+    )
+    app = Starlette(
+        routes=[Mount("/child", child)],
+        lifespan=_starlette_lifespan(events, "parent"),
+    )
+
+    with test_client_factory(app) as client:
+        assert events == ["parent:startup", "child:startup", "grandchild:startup"]
+        assert client.get("/child/gc").text == "gc"
+
+    assert events == [
+        "parent:startup",
+        "child:startup",
+        "grandchild:startup",
+        "grandchild:shutdown",
+        "child:shutdown",
+        "parent:shutdown",
+    ]
+
+
+def test_host_receives_lifespan(test_client_factory: TestClientFactory) -> None:
+    events: list[str] = []
+    app = Router(routes=[Host("api.example.org", _lifespan_app(events, "host"))])
+
+    with test_client_factory(app):
+        assert events == ["host:startup"]
+
+    assert events == ["host:startup", "host:shutdown"]
+
+
+def test_http_only_mount_is_ignored(test_client_factory: TestClientFactory) -> None:
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def parent_lifespan(app: Starlette) -> AsyncIterator[None]:
+        events.append("parent:startup")
+        yield
+        events.append("parent:shutdown")
+
+    app = Starlette(
+        routes=[Mount("/static", PlainTextResponse("asset"))],
+        lifespan=parent_lifespan,
+    )
+
+    with test_client_factory(app) as client:
+        assert events == ["parent:startup"]
+        assert client.get("/static").text == "asset"
+
+    assert events == ["parent:startup", "parent:shutdown"]
+
+
+def test_mounted_lifespan_state_is_merged(test_client_factory: TestClientFactory) -> None:
+    @asynccontextmanager
+    async def parent_lifespan(app: Starlette) -> AsyncIterator[dict[str, str]]:
+        yield {"from_parent": "yes"}
+
+    @asynccontextmanager
+    async def child_lifespan(app: Starlette) -> AsyncIterator[dict[str, str]]:
+        yield {"from_child": "yes"}
+
+    async def homepage(request: Request) -> JSONResponse:
+        return JSONResponse({"from_parent": request.state["from_parent"], "from_child": request.state["from_child"]})
+
+    child = Starlette(lifespan=child_lifespan)
+    app = Starlette(routes=[Route("/", homepage), Mount("/child", child)], lifespan=parent_lifespan)
+
+    with test_client_factory(app) as client:
+        assert client.get("/").json() == {"from_parent": "yes", "from_child": "yes"}
+
+
+def test_mounted_lifespan_without_server_state(test_client_factory: TestClientFactory) -> None:
+    events: list[str] = []
+    child = _lifespan_app(events, "child")
+    router = Router(routes=[Mount("/child", child)])
+
+    async def no_state_wrapper(scope: Scope, receive: Receive, send: Send) -> None:
+        scope.pop("state", None)
+        await router(scope, receive, send)
+
+    with test_client_factory(no_state_wrapper):
+        assert events == ["child:startup"]
+
+    assert events == ["child:startup", "child:shutdown"]
+
+
+def test_mounted_startup_failure(test_client_factory: TestClientFactory) -> None:
+    async def failing(scope: Scope, receive: Receive, send: Send) -> None:
+        await receive()
+        raise RuntimeError("child boom")
+
+    app = Router(routes=[Mount("/sub", failing)])
+
+    with pytest.raises(RuntimeError, match="child boom"):
+        with test_client_factory(app):
+            raise AssertionError("Should not be called")  # pragma: no cover
+
+
+def test_mounted_startup_failed_message_without_raise(test_client_factory: TestClientFactory) -> None:
+    async def failing(scope: Scope, receive: Receive, send: Send) -> None:
+        await receive()
+        await send({"type": "lifespan.startup.failed", "message": "nope"})
+
+    app = Router(routes=[Mount("/sub", failing)])
+
+    with pytest.raises(RuntimeError, match="failed during lifespan startup"):
+        with test_client_factory(app):
+            raise AssertionError("Should not be called")  # pragma: no cover
+
+
+def test_mounted_shutdown_failed_message_without_raise(test_client_factory: TestClientFactory) -> None:
+    async def failing(scope: Scope, receive: Receive, send: Send) -> None:
+        await receive()
+        await send({"type": "lifespan.startup.complete"})
+        await receive()
+        await send({"type": "lifespan.shutdown.failed", "message": "nope"})
+
+    app = Router(routes=[Mount("/sub", failing)])
+
+    with pytest.raises(RuntimeError, match="failed during lifespan shutdown"):
+        with test_client_factory(app):
+            pass
+
+
+def test_mounted_lifespan_exits_before_shutdown(test_client_factory: TestClientFactory) -> None:
+    async def broken(scope: Scope, receive: Receive, send: Send) -> None:
+        await receive()
+        await send({"type": "lifespan.startup.complete"})
+
+    app = Router(routes=[Mount("/sub", broken)])
+
+    with pytest.raises(RuntimeError, match="exited before shutdown"):
+        with test_client_factory(app):
+            raise AssertionError("Should not be called")  # pragma: no cover
+
+
+def test_mounted_app_that_never_receives_is_skipped(test_client_factory: TestClientFactory) -> None:
+    events: list[str] = []
+
+    async def silent(scope: Scope, receive: Receive, send: Send) -> None:
+        return
+
+    app = Router(routes=[Mount("/silent", silent), Mount("/ok", _lifespan_app(events, "ok"))])
+
+    with test_client_factory(app):
+        assert events == ["ok:startup"]
+
+    assert events == ["ok:startup", "ok:shutdown"]
+
+
+def test_mounted_app_raising_before_receive_is_skipped(test_client_factory: TestClientFactory) -> None:
+    events: list[str] = []
+
+    async def exploding(scope: Scope, receive: Receive, send: Send) -> None:
+        raise AssertionError("http only")
+
+    app = Router(routes=[Mount("/boom", exploding), Mount("/ok", _lifespan_app(events, "ok"))])
+
+    with test_client_factory(app):
+        assert events == ["ok:startup"]
+
+    assert events == ["ok:startup", "ok:shutdown"]
+
+
+def test_mounted_non_lifespan_messages_are_ignored(test_client_factory: TestClientFactory) -> None:
+    events: list[str] = []
+
+    async def messy(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"foo": "bar"})
+        await send({"type": 1})
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    app = Router(routes=[Mount("/messy", messy), Mount("/ok", _lifespan_app(events, "ok"))])
+
+    with test_client_factory(app):
+        assert events == ["ok:startup"]
+
+    assert events == ["ok:startup", "ok:shutdown"]
+
+
+def test_mounted_app_extra_receive_raises(test_client_factory: TestClientFactory) -> None:
+    async def greedy(scope: Scope, receive: Receive, send: Send) -> None:
+        await receive()
+        await send({"type": "lifespan.startup.complete"})
+        await receive()
+        await send({"type": "lifespan.shutdown.complete"})
+        await receive()
+
+    app = Router(routes=[Mount("/sub", greedy)])
+
+    with pytest.raises(RuntimeError, match="too many times"):
+        with test_client_factory(app):
+            pass


### PR DESCRIPTION
## Summary

- Mounted ASGI apps (`Mount` and `Host`) now receive lifespan startup and shutdown.
- This unblocks composing MCP / FastAPI / other ASGI apps that initialize resources in their own lifespan (fixes #649).
- Apps that do not speak the lifespan protocol (`StaticFiles`, `Response`, etc.) are skipped.
- Nested mounts work because each router propagates to its own children. Child lifespan state is merged into the parent `state` dict.

## Why this is not a resubmit of #1988

#1988 was closed to wait for 1.0. Starlette is now 1.6.0.

The earlier PR used AnyIO task groups to wrap each child lifespan. Review asked to avoid that (cancellation races, same class of issues as `BaseHTTPMiddleware`). This implementation uses the stacked-receive onion from [asgi-routing](https://github.com/adriangb/asgi-routing/blob/main/asgi_routing/_lifespan_dispatcher.py): each child's second `receive()` starts the next child, so no extra tasks.

Startup order: parent, then mounts in route order. Shutdown is LIFO.

## Test plan

- [x] `tests/test_mount_lifespan.py`: raw ASGI mount (MCP-style), parent+child order, multiple mounts LIFO shutdown, nested mounts, `Host`, HTTP-only mount ignored, state merge, startup/shutdown failures, apps that return or raise before participating
- [x] Existing `tests/test_routing.py` and `tests/test_applications.py` (including `Mount(Response)` and `Mount(Router)` under `TestClient` context)
- [x] `ruff` + `mypy` on the changed files

`uv run coverage run -m pytest tests/test_mount_lifespan.py tests/test_routing.py tests/test_applications.py` → 223 passed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

