### PR TITLE
Fix: Support IPv6 addresses in TrustedHostMiddleware and TestClient

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -42,7 +42,7 @@ class TrustedHostMiddleware:
             if "]" in raw_host:
                 closing_bracket = raw_host.find("]")
                 suffix = raw_host[closing_bracket + 1 :]
-                if not suffix or (suffix.startswith(":") and suffix[1:].isdigit()):
+                if not suffix or (suffix.startswith(":") and suffix[1:].isascii() and suffix[1:].isdigit()):
                     host = raw_host[: closing_bracket + 1]
                 else:
                     host = raw_host
@@ -53,7 +53,11 @@ class TrustedHostMiddleware:
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:
-            if host == pattern or (pattern.startswith("*") and host.endswith(pattern[1:])):
+            if host == pattern or (
+                pattern.startswith("*")
+                and not host.startswith("[")
+                and host.endswith(pattern[1:])
+            ):
                 is_valid_host = True
                 break
             elif "www." + host == pattern:

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -39,7 +39,15 @@ class TrustedHostMiddleware:
         headers = Headers(scope=scope)
         raw_host = headers.get("host", "")
         if raw_host.startswith("["):
-            host = raw_host.partition("]")[0] + "]" if "]" in raw_host else raw_host
+            if "]" in raw_host:
+                closing_bracket = raw_host.find("]")
+                suffix = raw_host[closing_bracket + 1 :]
+                if not suffix or (suffix.startswith(":") and suffix[1:].isdigit()):
+                    host = raw_host[: closing_bracket + 1]
+                else:
+                    host = raw_host
+            else:
+                host = raw_host
         else:
             host = raw_host.split(":")[0]
         is_valid_host = False

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -53,11 +53,7 @@ class TrustedHostMiddleware:
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:
-            if host == pattern or (
-                pattern.startswith("*")
-                and not host.startswith("[")
-                and host.endswith(pattern[1:])
-            ):
+            if host == pattern or (pattern.startswith("*") and not host.startswith("[") and host.endswith(pattern[1:])):
                 is_valid_host = True
                 break
             elif "www." + host == pattern:

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -37,7 +37,11 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = headers.get("host", "").split(":")[0]
+        raw_host = headers.get("host", "")
+        if raw_host.startswith("["):
+            host = raw_host.partition("]")[0] + "]" if "]" in raw_host else raw_host
+        else:
+            host = raw_host.split(":")[0]
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -232,26 +232,35 @@ class _TestClientTransport(httpx.BaseTransport):
         default_port = {"http": 80, "ws": 80, "https": 443, "wss": 443}[scheme]
 
         if netloc.startswith("["):
-            if "]:" in netloc:
-                host, port_string = netloc.rsplit(":", 1)
-                port = int(port_string)
+            if "]" in netloc:
+                closing_bracket = netloc.find("]")
+                host = netloc[1:closing_bracket]
+                suffix = netloc[closing_bracket + 1 :]
+                if suffix.startswith(":"):
+                    port = int(suffix[1:])
+                else:
+                    port = default_port
+                header_host = f"[{host}]"
             else:
                 host = netloc
                 port = default_port
+                header_host = netloc
         elif ":" in netloc:
             host, port_string = netloc.rsplit(":", 1)
             port = int(port_string)
+            header_host = host
         else:
             host = netloc
             port = default_port
+            header_host = host
 
         # Include the 'host' header.
         if "host" in request.headers:
             headers: list[tuple[bytes, bytes]] = []
         elif port == default_port:  # pragma: no cover
-            headers = [(b"host", host.encode())]
+            headers = [(b"host", header_host.encode())]
         else:  # pragma: no cover
-            headers = [(b"host", (f"{host}:{port}").encode())]
+            headers = [(b"host", (f"{header_host}:{port}").encode())]
 
         # Include other request headers.
         headers += [(key.lower().encode(), value.encode()) for key, value in request.headers.multi_items()]

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -231,20 +231,15 @@ class _TestClientTransport(httpx.BaseTransport):
 
         default_port = {"http": 80, "ws": 80, "https": 443, "wss": 443}[scheme]
 
-        if netloc.startswith("["):
-            if "]" in netloc:
-                closing_bracket = netloc.find("]")
-                host = netloc[1:closing_bracket]
-                suffix = netloc[closing_bracket + 1 :]
-                if suffix.startswith(":"):
-                    port = int(suffix[1:])
-                else:
-                    port = default_port
-                header_host = f"[{host}]"
+        if netloc.startswith("[") and "]" in netloc:
+            closing_bracket = netloc.find("]")
+            host = netloc[1:closing_bracket]
+            suffix = netloc[closing_bracket + 1 :]
+            if suffix.startswith(":"):
+                port = int(suffix[1:])
             else:
-                host = netloc
                 port = default_port
-                header_host = netloc
+            header_host = f"[{host}]"
         elif ":" in netloc:
             host, port_string = netloc.rsplit(":", 1)
             port = int(port_string)

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -231,8 +231,15 @@ class _TestClientTransport(httpx.BaseTransport):
 
         default_port = {"http": 80, "ws": 80, "https": 443, "wss": 443}[scheme]
 
-        if ":" in netloc:
-            host, port_string = netloc.split(":", 1)
+        if netloc.startswith("["):
+            if "]:" in netloc:
+                host, port_string = netloc.rsplit(":", 1)
+                port = int(port_string)
+            else:
+                host = netloc
+                port = default_port
+        elif ":" in netloc:
+            host, port_string = netloc.rsplit(":", 1)
             port = int(port_string)
         else:
             host = netloc

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -48,3 +48,21 @@ def test_www_redirect(test_client_factory: TestClientFactory) -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert response.url == "https://www.example.com/"
+
+
+def test_ipv6_trusted_host(test_client_factory: TestClientFactory) -> None:
+    def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("OK", status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]"])],
+    )
+
+    client = test_client_factory(app, base_url="http://[::1]:8000")
+    response = client.get("/")
+    assert response.status_code == 200
+
+    client = test_client_factory(app, base_url="http://[::2]:8000")
+    response = client.get("/")
+    assert response.status_code == 400

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -77,11 +77,7 @@ def test_ipv6_trusted_host(test_client_factory: TestClientFactory) -> None:
 
 
 def test_ipv6_invalid_host_header(test_client_factory: TestClientFactory) -> None:
-    def homepage(request: Request) -> PlainTextResponse:
-        return PlainTextResponse("OK", status_code=200)
-
     app = Starlette(
-        routes=[Route("/", endpoint=homepage)],
         middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]", "*.example.com"])],
     )
 
@@ -101,7 +97,7 @@ async def test_ipv6_non_ascii_port_rejected() -> None:
     sent_status = None
 
     async def dummy_app(scope: Scope, receive: Receive, send: Send) -> None:
-        await send({"type": "http.response.start", "status": 200, "headers": []})
+        raise RuntimeError("Should not be called")  # pragma: no cover
 
     middleware = TrustedHostMiddleware(dummy_app, allowed_hosts=["[::1]"])
     scope: Scope = {
@@ -117,7 +113,7 @@ async def test_ipv6_non_ascii_port_rejected() -> None:
             sent_status = message["status"]
 
     async def receive() -> Message:
-        return {"type": "http.request"}
+        raise RuntimeError("Should not be called")  # pragma: no cover
 
     await middleware(scope, receive, send)
     assert sent_status == 400

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -72,11 +72,19 @@ def test_ipv6_trusted_host(test_client_factory: TestClientFactory) -> None:
     response = client.get("/")
     assert response.status_code == 400
 
-    # Invalid host with suffix after closing bracket
+
+def test_ipv6_invalid_host_header(test_client_factory: TestClientFactory) -> None:
+    def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("OK", status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]"])],
+    )
+
     client = test_client_factory(app)
     response = client.get("/", headers={"host": "[::1]evil.com"})
     assert response.status_code == 400
 
-    # Invalid host with unclosed bracket
     response = client.get("/", headers={"host": "[unclosed"})
     assert response.status_code == 400

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -51,7 +51,11 @@ def test_www_redirect(test_client_factory: TestClientFactory) -> None:
 
 
 def test_ipv6_trusted_host(test_client_factory: TestClientFactory) -> None:
+    server_scope = None
+
     def homepage(request: Request) -> PlainTextResponse:
+        nonlocal server_scope
+        server_scope = request.scope["server"]
         return PlainTextResponse("OK", status_code=200)
 
     app = Starlette(
@@ -62,7 +66,13 @@ def test_ipv6_trusted_host(test_client_factory: TestClientFactory) -> None:
     client = test_client_factory(app, base_url="http://[::1]:8000")
     response = client.get("/")
     assert response.status_code == 200
+    assert server_scope == ["::1", 8000]
 
     client = test_client_factory(app, base_url="http://[::2]:8000")
     response = client.get("/")
+    assert response.status_code == 400
+
+    # Invalid host with suffix after closing bracket
+    client = test_client_factory(app)
+    response = client.get("/", headers={"host": "[::1]evil.com"})
     assert response.status_code == 400

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -76,3 +76,7 @@ def test_ipv6_trusted_host(test_client_factory: TestClientFactory) -> None:
     client = test_client_factory(app)
     response = client.get("/", headers={"host": "[::1]evil.com"})
     assert response.status_code == 400
+
+    # Invalid host with unclosed bracket
+    response = client.get("/", headers={"host": "[unclosed"})
+    assert response.status_code == 400

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -1,9 +1,11 @@
+import pytest
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
+from starlette.types import Message, Receive, Scope, Send
 from tests.types import TestClientFactory
 
 
@@ -79,7 +81,7 @@ def test_ipv6_invalid_host_header(test_client_factory: TestClientFactory) -> Non
 
     app = Starlette(
         routes=[Route("/", endpoint=homepage)],
-        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]"])],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]", "*.example.com"])],
     )
 
     client = test_client_factory(app)
@@ -88,3 +90,33 @@ def test_ipv6_invalid_host_header(test_client_factory: TestClientFactory) -> Non
 
     response = client.get("/", headers={"host": "[unclosed"})
     assert response.status_code == 400
+
+    response = client.get("/", headers={"host": "[::1].example.com"})
+    assert response.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_ipv6_non_ascii_port_rejected() -> None:
+    sent_status = None
+
+    async def dummy_app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    middleware = TrustedHostMiddleware(dummy_app, allowed_hosts=["[::1]"])
+    scope: Scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [(b"host", "[::1]:\u0661".encode("utf-8"))],
+    }
+
+    async def send(message: Message) -> None:
+        nonlocal sent_status
+        if message["type"] == "http.response.start":
+            sent_status = message["status"]
+
+    async def receive() -> Message:
+        return {"type": "http.request"}
+
+    await middleware(scope, receive, send)
+    assert sent_status == 400

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -1,4 +1,5 @@
 import pytest
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -470,3 +470,23 @@ def test_timeout_deprecation() -> None:
     ):
         client = TestClient(mock_service)
         client.get("/", timeout=1)
+
+
+def test_testclient_ipv6_base_url(test_client_factory: TestClientFactory) -> None:
+    server_scope = None
+
+    def homepage(request: Request) -> Response:
+        nonlocal server_scope
+        server_scope = request.scope["server"]
+        return Response("OK")
+
+    app = Starlette(routes=[Route("/", endpoint=homepage)])
+
+    client = test_client_factory(app, base_url="http://[::1]")
+    response = client.get("/")
+    assert response.status_code == 200
+    assert server_scope == ["::1", 80]
+
+    client = test_client_factory(app, base_url="http://[unclosed")
+    response = client.get("/")
+    assert response.status_code == 200

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -486,7 +486,3 @@ def test_testclient_ipv6_base_url(test_client_factory: TestClientFactory) -> Non
     response = client.get("/")
     assert response.status_code == 200
     assert server_scope == ["::1", 80]
-
-    client = test_client_factory(app, base_url="http://[unclosed")
-    response = client.get("/")
-    assert response.status_code == 200


### PR DESCRIPTION
Fixes #3357

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

