### PR TITLE
Fix: In starlette/middleware/trustedhost.py __call__, the host is extracted...

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -37,7 +37,13 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = headers.get("host", "").split(":")[0]
+        host_header = headers.get("host", "")
+        if host_header.startswith("["):
+            # IPv6 literal in bracket notation, e.g. "[::1]" or "[::1]:8000".
+            # Only strip a port if it follows the closing bracket.
+            host = host_header.partition("]")[0] + "]"
+        else:
+            host = host_header.split(":")[0]
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -29,6 +29,26 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
     assert response.status_code == 400
 
 
+def test_trusted_host_middleware_ipv6(test_client_factory: TestClientFactory) -> None:
+    def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("OK", status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]"])],
+    )
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"host": "[::1]:8000"})
+    assert response.status_code == 200
+
+    response = client.get("/", headers={"host": "[::1]"})
+    assert response.status_code == 200
+
+    response = client.get("/", headers={"host": "[::2]:8000"})
+    assert response.status_code == 400
+
+
 def test_default_allowed_hosts() -> None:
     app = Starlette()
     middleware = TrustedHostMiddleware(app)


### PR DESCRIPTION
## Summary
In TrustedHostMiddleware.__call__, if the Host header starts with '[', extract everything up to and including the matching ']' as the host (via str.partition(']')), ignoring any port that follows ']:'. Otherwise, keep the original single-colon-split behavior for IPv4/regular hostnames.

## Problem
encode/starlette issue reference: encode/starlette#3357

## Root Cause
In starlette/middleware/trustedhost.py __call__, the host is extracted via `.split(':')[0]`, which assumes at most one colon (host:port). IPv6 literals in Host headers use bracket notation (e.g. '[::1]:8000') specifically because the address itself contains colons; naive splitting truncates the host to just '['.

## Testing
PASS - all 7 tests pass (including the new IPv6 test across trio/asyncio backends and the pre-existing IPv4/hostname tests, confirming no regression).

## Related Issue
encode/starlette#3357


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

