### PR TITLE
docs: fix grammar in authentication redirect guidance

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -135,7 +135,7 @@ async def dashboard(request):
     ...
 ```
 
-When redirecting users, the page you redirect them to will include URL they originally requested at the `next` query param:
+When redirecting users, the page you redirect them to will include the URL they originally requested at the `next` query param:
 
 ```python
 from starlette.authentication import requires


### PR DESCRIPTION
# Summary

Fix the missing article in the authentication redirect documentation.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

## Validation

- `uv run zensical build --strict`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

