### PR TITLE
fix: handle IPv6 addresses in TrustedHostMiddleware

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -37,14 +37,28 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = headers.get("host", "").split(":")[0]
+        raw_host = headers.get("host", "")
+        # IPv6 addresses are bracketed in the Host header (e.g.
+        # "[::1]:8000").  Strip the port from the outside of the
+        # brackets, not by naively splitting on ":" which would
+        # break on the colon inside the address. (#3357)
+        if raw_host.startswith("["):
+            close = raw_host.find("]")
+            host = raw_host[1:close] if close != -1 else raw_host
+        else:
+            host = raw_host.split(":")[0]
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:
-            if host == pattern or (pattern.startswith("*") and host.endswith(pattern[1:])):
+            # Allow IPv6 hosts to be configured with or without brackets
+            # ("[::1]" vs "::1") — host is extracted without brackets per #3357
+            if host == pattern or (pattern.startswith("[") and pattern.endswith("]") and host == pattern[1:-1]):
                 is_valid_host = True
                 break
-            elif "www." + host == pattern:
+            if pattern.startswith("*") and host.endswith(pattern[1:]):
+                is_valid_host = True
+                break
+            if "www." + host == pattern:
                 found_www_redirect = True
 
         if is_valid_host:


### PR DESCRIPTION
## Summary

Fixes #3357

The middleware previously split the Host header on ":" and took the first element, which broke IPv6 addresses like `[::1]:8000` — the split produced `[` as the host, which never matched any allowed host.

## Fix

Now the middleware detects bracketed IPv6 addresses and extracts the address from inside the brackets, falling back to the original split-based port stripping for IPv4 and hostname-only values.

## Testing

All 3 existing TrustedHostMiddleware tests pass. Verified manually:
- `[::1]:8000` → extracts `::1`
- `[2001:db8::1]:3000` → extracts `2001:db8::1`
- `127.0.0.1:8080` → extracts `127.0.0.1` (unchanged)
- `example.com:443` → extracts `example.com` (unchanged)

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

