### PR TITLE
fix(trustedhost): correctly parse IPv6 host headers in TrustedHostMiddleware

### DIFF
--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -37,11 +37,22 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = headers.get("host", "").split(":")[0]
+        host_header = headers.get("host", "")
+        if host_header.startswith("["):
+            end = host_header.find("]")
+            host = host_header[: end + 1] if end != -1 else host_header
+        else:
+            host = host_header.split(":")[0]
+
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:
-            if host == pattern or (pattern.startswith("*") and host.endswith(pattern[1:])):
+            if (
+                host == pattern
+                or (pattern.startswith("[") and pattern.endswith("]") and host == pattern[1:-1])
+                or (host.startswith("[") and host.endswith("]") and host[1:-1] == pattern)
+                or (pattern.startswith("*") and host.endswith(pattern[1:]))
+            ):
                 is_valid_host = True
                 break
             elif "www." + host == pattern:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -231,7 +231,16 @@ class _TestClientTransport(httpx.BaseTransport):
 
         default_port = {"http": 80, "ws": 80, "https": 443, "wss": 443}[scheme]
 
-        if ":" in netloc:
+        if netloc.startswith("["):
+            end = netloc.find("]")
+            if end != -1:
+                host = netloc[: end + 1]
+                rest = netloc[end + 1 :]
+                port = int(rest[1:]) if rest.startswith(":") else default_port
+            else:
+                host = netloc
+                port = default_port
+        elif ":" in netloc:
             host, port_string = netloc.split(":", 1)
             port = int(port_string)
         else:

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -48,3 +48,29 @@ def test_www_redirect(test_client_factory: TestClientFactory) -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert response.url == "https://www.example.com/"
+
+
+def test_trusted_host_middleware_ipv6(test_client_factory: TestClientFactory) -> None:
+    def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("OK", status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["::1", "[2001:db8::1]"])],
+    )
+
+    # Valid IPv6 allowed host with brackets and port
+    client = test_client_factory(app, base_url="http://[::1]:8000")
+    response = client.get("/")
+    assert response.status_code == 200
+
+    # Valid IPv6 allowed host without port
+    client = test_client_factory(app, base_url="http://[2001:db8::1]")
+    response = client.get("/")
+    assert response.status_code == 200
+
+    # Invalid IPv6 host
+    client = test_client_factory(app, base_url="http://[::2]:8000")
+    response = client.get("/")
+    assert response.status_code == 400
+

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -73,4 +73,3 @@ def test_trusted_host_middleware_ipv6(test_client_factory: TestClientFactory) ->
     client = test_client_factory(app, base_url="http://[::2]:8000")
     response = client.get("/")
     assert response.status_code == 400
-


### PR DESCRIPTION
## Summary

Fixes #3357

## Problem

TrustedHostMiddleware extracts the hostname from the Host header with:
`python
host = headers.get('host', '').split(':')[0]
`

This breaks for IPv6 addresses. For example [::1]:8000 yields [ instead of [::1], causing all IPv6 clients to get a 400 Invalid host header even when they should be trusted.

## Changes

### starlette/middleware/trustedhost.py
- Detect bracket-enclosed IPv6 addresses in the Host header (RFC 2732 / RFC 3986)
- Extract the full bracketed address (e.g. [::1]) as the host token, stripping any trailing :port
- Fall back to the existing split(':')[0] for normal hostnames / IPv4
- Allow llowed_hosts patterns both with brackets ([::1]) and without (::1) for flexibility

### starlette/testclient.py
- Apply the same bracket-aware 
etloc parsing in _TestClientTransport.handle_request so that TestClient(app, base_url='http://[::1]:8000') works correctly in tests

### 	ests/middleware/test_trusted_host.py
- Add 	est_trusted_host_middleware_ipv6 covering:
  - Allowed IPv6 with port → 200
  - Allowed IPv6 without port → 200
  - Disallowed IPv6 → 400

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

