### PR TITLE
fix(datastructures): safely handle non-string and non-latin1 keys in Headers.__contains__

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -549,7 +549,12 @@ class Headers(Mapping[str, str]):
         raise KeyError(key)
 
     def __contains__(self, key: Any) -> bool:
-        get_header_key = key.lower().encode("latin-1")
+        if not isinstance(key, str):
+            return False
+        try:
+            get_header_key = key.lower().encode("latin-1")
+        except UnicodeEncodeError:
+            return False
         for header_key, header_value in self._list:
             if header_key == get_header_key:
                 return True

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -230,6 +230,9 @@ def test_headers() -> None:
     assert "b" in h
     assert "B" in h
     assert "c" not in h
+    assert 123 not in h
+    assert None not in h
+    assert "\u20ac" not in h
     assert h["a"] == "123"
     assert h.get("a") == "123"
     assert h.get("nope", None) is None


### PR DESCRIPTION
### Problem
`Headers.__contains__` directly called `key.lower().encode("latin-1")`. When `key` was not a string (e.g. `123 in headers`) or contained characters not encodable in latin-1 (e.g. `"\u20ac" in headers`), it raised unhandled `AttributeError` or `UnicodeEncodeError` instead of returning `False` as expected by the standard Python `Mapping` interface.

### Solution
- In `Headers.__contains__`, check `isinstance(key, str)` and catch `UnicodeEncodeError`, returning `False`.
- Add assertions in `test_headers` in `tests/test_datastructures.py`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

