### PR TITLE
Add minimal response dispatch benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,5 +34,10 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
         with:
-          run: uv run pytest benchmarks/gzip_benchmark.py benchmarks/routing_benchmark.py --codspeed
+          run: >-
+            uv run pytest
+            benchmarks/gzip_benchmark.py
+            benchmarks/response_benchmark.py
+            benchmarks/routing_benchmark.py
+            --codspeed
           mode: simulation,memory

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,5 +1,22 @@
 # Benchmarks
 
+## Minimal response dispatch
+
+The response benchmark measures a two-byte response through progressively larger
+parts of the public stack: raw ASGI, a prebuilt `Response`, a newly constructed
+`Response`, a single `Route`, and a complete `Starlette` application. The raw
+ASGI case is the control for event-loop and message-capture overhead.
+
+Each dispatch receives a fresh ASGI scope. The application cases are warmed
+before measurement so lazy middleware construction and interpreter specialization
+are not attributed to every request.
+
+Run it locally with:
+
+```console
+uv run pytest benchmarks/response_benchmark.py --codspeed
+```
+
 ## Routing
 
 The routing benchmark exercises `Router` dispatch through its ASGI interface

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/benchmarks/_utils.py
+++ b/benchmarks/_utils.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import asyncio
+
+from starlette.types import ASGIApp, Message, Receive, Scope
+
+
+async def unreadable_receive() -> Message:
+    raise AssertionError("The benchmark app must not receive a request body")
+
+
+async def run_asgi(app: ASGIApp, scope: Scope, receive: Receive = unreadable_receive) -> list[Message]:
+    messages: list[Message] = []
+
+    async def send(message: Message) -> None:
+        messages.append(message)
+
+    await app(scope, receive, send)
+    return messages
+
+
+class ASGIRunner:
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+
+    def run(self, app: ASGIApp, scope: Scope, receive: Receive = unreadable_receive) -> list[Message]:
+        return self.loop.run_until_complete(run_asgi(app, scope, receive))
+
+    def close(self) -> None:
+        self.loop.close()

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from benchmarks._utils import ASGIRunner
+
+
+@pytest.fixture(scope="module")
+def asgi_runner() -> Iterator[ASGIRunner]:
+    runner = ASGIRunner()
+    yield runner
+    runner.close()

--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -14,6 +14,7 @@ import anyio
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
+from benchmarks._utils import ASGIRunner, run_asgi
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -52,30 +53,6 @@ class StaticResponseApp:
             if "headers" in outgoing_message:
                 outgoing_message["headers"] = list(outgoing_message["headers"])
             await send(outgoing_message)
-
-
-class ASGIRunner:
-    def __init__(self) -> None:
-        self.loop = asyncio.new_event_loop()
-
-    def run(self, app: ASGIApp, scope: Scope) -> list[Message]:
-        return self.loop.run_until_complete(run_asgi(app, scope))
-
-    def close(self) -> None:
-        self.loop.close()
-
-
-async def run_asgi(app: ASGIApp, scope: Scope) -> list[Message]:
-    messages: list[Message] = []
-
-    async def receive() -> Message:
-        raise AssertionError("The benchmark app must not receive a request body")
-
-    async def send(message: Message) -> None:
-        messages.append(message)
-
-    await app(scope, receive, send)
-    return messages
 
 
 @dataclass

--- a/benchmarks/response_benchmark.py
+++ b/benchmarks/response_benchmark.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+from pytest_codspeed.plugin import BenchmarkFixture
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Route
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+PAYLOAD = b"ok"
+EXPECTED_HEADERS = [(b"content-length", b"2")]
+
+
+async def endpoint(request: Request) -> Response:
+    return Response(PAYLOAD)
+
+
+class RawResponseApp:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": list(EXPECTED_HEADERS)})
+        await send({"type": "http.response.body", "body": PAYLOAD})
+
+
+class ConstructedResponseApp:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await Response(PAYLOAD)(scope, receive, send)
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    name: str
+    app: ASGIApp
+
+
+CASES = (
+    BenchmarkCase("raw-asgi", RawResponseApp()),
+    BenchmarkCase("prebuilt-response", Response(PAYLOAD)),
+    BenchmarkCase("constructed-response", ConstructedResponseApp()),
+    BenchmarkCase("route", Route("/", endpoint)),
+    BenchmarkCase("starlette", Starlette(routes=[Route("/", endpoint)])),
+)
+
+
+def http_scope() -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.5"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "root_path": "",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 80),
+    }
+
+
+async def run_asgi(app: ASGIApp) -> list[Message]:
+    messages: list[Message] = []
+
+    async def receive() -> Message:
+        raise AssertionError("The benchmark app must not receive a request body")
+
+    async def send(message: Message) -> None:
+        messages.append(message)
+
+    await app(http_scope(), receive, send)
+    return messages
+
+
+class ASGIRunner:
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+
+    def run(self, app: ASGIApp) -> list[Message]:
+        return self.loop.run_until_complete(run_asgi(app))
+
+    def close(self) -> None:
+        self.loop.close()
+
+
+@pytest.fixture(scope="module")
+def runner() -> Iterator[ASGIRunner]:
+    runner = ASGIRunner()
+    for case in CASES:
+        for _ in range(100):
+            runner.run(case.app)
+    yield runner
+    runner.close()
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.name)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=20)
+def test_minimal_response_dispatch(
+    runner: ASGIRunner,
+    benchmark: BenchmarkFixture,
+    case: BenchmarkCase,
+) -> None:
+    messages = benchmark(runner.run, case.app)
+
+    assert messages == [
+        {"type": "http.response.start", "status": 200, "headers": EXPECTED_HEADERS},
+        {"type": "http.response.body", "body": PAYLOAD},
+    ]
+    benchmark.extra_info["stack"] = case.name

--- a/benchmarks/response_benchmark.py
+++ b/benchmarks/response_benchmark.py
@@ -23,7 +23,7 @@ async def endpoint(request: Request) -> Response:
 
 class RawResponseApp:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        await send({"type": "http.response.start", "status": 200, "headers": list(EXPECTED_HEADERS)})
+        await send({"type": "http.response.start", "status": 200, "headers": EXPECTED_HEADERS})
         await send({"type": "http.response.body", "body": PAYLOAD})
 
 

--- a/benchmarks/response_benchmark.py
+++ b/benchmarks/response_benchmark.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import asyncio
-from collections.abc import Iterator
 from dataclasses import dataclass
 
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
+from benchmarks._utils import ASGIRunner
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import Response
@@ -64,48 +63,25 @@ def http_scope() -> Scope:
     }
 
 
-async def run_asgi(app: ASGIApp) -> list[Message]:
-    messages: list[Message] = []
-
-    async def receive() -> Message:
-        raise AssertionError("The benchmark app must not receive a request body")
-
-    async def send(message: Message) -> None:
-        messages.append(message)
-
-    await app(http_scope(), receive, send)
-    return messages
+def dispatch(runner: ASGIRunner, app: ASGIApp) -> list[Message]:
+    return runner.run(app, http_scope())
 
 
-class ASGIRunner:
-    def __init__(self) -> None:
-        self.loop = asyncio.new_event_loop()
-
-    def run(self, app: ASGIApp) -> list[Message]:
-        return self.loop.run_until_complete(run_asgi(app))
-
-    def close(self) -> None:
-        self.loop.close()
-
-
-@pytest.fixture(scope="module")
-def runner() -> Iterator[ASGIRunner]:
-    runner = ASGIRunner()
+@pytest.fixture(scope="module", autouse=True)
+def warm_apps(asgi_runner: ASGIRunner) -> None:
     for case in CASES:
         for _ in range(100):
-            runner.run(case.app)
-    yield runner
-    runner.close()
+            dispatch(asgi_runner, case.app)
 
 
 @pytest.mark.parametrize("case", CASES, ids=lambda case: case.name)
 @pytest.mark.benchmark(max_time=0.5, max_rounds=20)
 def test_minimal_response_dispatch(
-    runner: ASGIRunner,
+    asgi_runner: ASGIRunner,
     benchmark: BenchmarkFixture,
     case: BenchmarkCase,
 ) -> None:
-    messages = benchmark(runner.run, case.app)
+    messages = benchmark(dispatch, asgi_runner, case.app)
 
     assert messages == [
         {"type": "http.response.start", "status": 200, "headers": EXPECTED_HEADERS},

--- a/benchmarks/routing_benchmark.py
+++ b/benchmarks/routing_benchmark.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import asyncio
-from collections.abc import Iterator
-
-import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
+from benchmarks._utils import ASGIRunner
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route, Router
@@ -40,62 +37,35 @@ def http_scope(method: str, path: str) -> Scope:
     return {"type": "http", "method": method, "path": path, "root_path": "", "headers": [], "query_string": b""}
 
 
-async def run_asgi(app: ASGIApp, scope: Scope) -> list[Message]:
-    messages: list[Message] = []
-
-    async def receive() -> Message:
-        raise AssertionError("The benchmark app must not receive a request body")
-
-    async def send(message: Message) -> None:
-        messages.append(message)
-
-    await app(scope, receive, send)
-    return messages
+def dispatch(runner: ASGIRunner, app: ASGIApp, method: str, path: str) -> list[Message]:
+    return runner.run(app, http_scope(method, path))
 
 
-class ASGIRunner:
-    def __init__(self) -> None:
-        self.loop = asyncio.new_event_loop()
-
-    def run(self, app: ASGIApp, method: str, path: str) -> list[Message]:
-        return self.loop.run_until_complete(run_asgi(app, http_scope(method, path)))
-
-    def close(self) -> None:
-        self.loop.close()
-
-
-@pytest.fixture(scope="module")
-def runner() -> Iterator[ASGIRunner]:
-    runner = ASGIRunner()
-    yield runner
-    runner.close()
-
-
-def test_routing_static_early(runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
-    messages = benchmark(lambda: runner.run(LARGE_ROUTER, "GET", "/resources0"))
+def test_routing_static_early(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
+    messages = benchmark(dispatch, asgi_runner, LARGE_ROUTER, "GET", "/resources0")
     assert messages[0]["status"] == 200
 
 
-def test_routing_static_late(runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
-    messages = benchmark(lambda: runner.run(LARGE_ROUTER, "GET", "/resources29"))
+def test_routing_static_late(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
+    messages = benchmark(dispatch, asgi_runner, LARGE_ROUTER, "GET", "/resources29")
     assert messages[0]["status"] == 200
 
 
-def test_routing_param_late(runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
-    messages = benchmark(lambda: runner.run(LARGE_ROUTER, "GET", "/resources29/123/items/first"))
+def test_routing_param_late(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
+    messages = benchmark(dispatch, asgi_runner, LARGE_ROUTER, "GET", "/resources29/123/items/first")
     assert messages[0]["status"] == 200
 
 
-def test_routing_miss(runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
-    messages = benchmark(lambda: runner.run(LARGE_ROUTER, "GET", "/no/such/path"))
+def test_routing_miss(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
+    messages = benchmark(dispatch, asgi_runner, LARGE_ROUTER, "GET", "/no/such/path")
     assert messages[0]["status"] == 404
 
 
-def test_routing_method_not_allowed(runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
-    messages = benchmark(lambda: runner.run(LARGE_ROUTER, "DELETE", "/resources29"))
+def test_routing_method_not_allowed(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
+    messages = benchmark(dispatch, asgi_runner, LARGE_ROUTER, "DELETE", "/resources29")
     assert messages[0]["status"] == 405
 
 
-def test_routing_small_app(runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
-    messages = benchmark(lambda: runner.run(SMALL_ROUTER, "GET", "/resources4/7"))
+def test_routing_small_app(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture) -> None:
+    messages = benchmark(dispatch, asgi_runner, SMALL_ROUTER, "GET", "/resources4/7")
     assert messages[0]["status"] == 200


### PR DESCRIPTION
## Summary

Add CodSpeed coverage for a minimal response through raw ASGI, `Response`, `Route`, and the complete `Starlette` stack. Warm each case before measurement and use a fresh ASGI scope for every dispatch.

## Tests

- `uv run pytest benchmarks/response_benchmark.py --codspeed`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

