### PR TITLE
Add request body benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,6 +37,7 @@ jobs:
           run: >-
             uv run pytest
             benchmarks/gzip_benchmark.py
+            benchmarks/request_benchmark.py
             benchmarks/response_benchmark.py
             benchmarks/routing_benchmark.py
             --codspeed

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,6 +17,23 @@ Run it locally with:
 uv run pytest benchmarks/response_benchmark.py --codspeed
 ```
 
+## Request bodies
+
+The request benchmark compares `Request.body()` with `Request.stream()` for
+1 KiB, 1 MiB, and 10 MiB payloads. The larger payloads are delivered both as a
+single ASGI message and in 64 KiB chunks to separate byte volume from
+per-message overhead.
+
+Payload and chunk construction happen outside the measured region. Every
+dispatch creates a fresh `Request`, ASGI scope, and receive callable. The
+response reports the consumed byte count, which is validated after measurement.
+
+Run it locally with:
+
+```console
+uv run pytest benchmarks/request_benchmark.py --codspeed
+```
+
 ## Routing
 
 The routing benchmark exercises `Router` dispatch through its ASGI interface

--- a/benchmarks/request_benchmark.py
+++ b/benchmarks/request_benchmark.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+from pytest_codspeed.plugin import BenchmarkFixture
+
+from benchmarks._utils import ASGIRunner
+from starlette.requests import Request
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+KiB = 1024
+MiB = 1024 * KiB
+
+ReadMode = Literal["body", "stream"]
+
+
+class BodyReceive:
+    def __init__(self, chunks: tuple[bytes, ...]) -> None:
+        self.chunks = chunks
+        self.index = 0
+
+    async def __call__(self) -> Message:
+        if self.index >= len(self.chunks):
+            raise AssertionError("The benchmark app read beyond the request body")
+        chunk = self.chunks[self.index]
+        self.index += 1
+        return {
+            "type": "http.request",
+            "body": chunk,
+            "more_body": self.index < len(self.chunks),
+        }
+
+
+class BodyApp:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        body = await Request(scope, receive).body()
+        await send_length(send, len(body))
+
+
+class StreamApp:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        length = 0
+        async for chunk in Request(scope, receive).stream():
+            length += len(chunk)
+        await send_length(send, length)
+
+
+async def send_length(send: Send, length: int) -> None:
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": str(length).encode()})
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    mode: ReadMode
+    body_size: int
+    chunk_size: int
+
+    @property
+    def id(self) -> str:
+        body_size = format_size(self.body_size)
+        chunk_size = "single" if self.chunk_size == self.body_size else format_size(self.chunk_size)
+        return f"{self.mode}-{body_size}-{chunk_size}"
+
+
+READ_MODES: tuple[ReadMode, ...] = ("body", "stream")
+BODY_CASES = (
+    (KiB, KiB),
+    (MiB, MiB),
+    (MiB, 64 * KiB),
+    (10 * MiB, 10 * MiB),
+    (10 * MiB, 64 * KiB),
+)
+CASES = tuple(BenchmarkCase(mode, body_size, chunk_size) for mode in READ_MODES for body_size, chunk_size in BODY_CASES)
+APPS: dict[ReadMode, ASGIApp] = {"body": BodyApp(), "stream": StreamApp()}
+
+
+def format_size(size: int) -> str:
+    if size >= MiB:
+        return f"{size // MiB}MiB"
+    return f"{size // KiB}KiB"
+
+
+def http_scope() -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.5"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "root_path": "",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 80),
+    }
+
+
+def make_chunks(body_size: int, chunk_size: int) -> tuple[bytes, ...]:
+    payload = b"x" * body_size
+    return tuple(payload[offset : offset + chunk_size] for offset in range(0, body_size, chunk_size))
+
+
+def dispatch(runner: ASGIRunner, app: ASGIApp, chunks: tuple[bytes, ...]) -> list[Message]:
+    return runner.run(app, http_scope(), BodyReceive(chunks))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def warm_apps(asgi_runner: ASGIRunner) -> None:
+    chunks = (b"x" * KiB,)
+    for app in APPS.values():
+        for _ in range(100):
+            dispatch(asgi_runner, app, chunks)
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=1)
+def test_request_body(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
+    chunks = make_chunks(case.body_size, case.chunk_size)
+    messages = benchmark.pedantic(dispatch, args=(asgi_runner, APPS[case.mode], chunks), rounds=1)
+
+    assert messages == [
+        {"type": "http.response.start", "status": 200, "headers": []},
+        {"type": "http.response.body", "body": str(case.body_size).encode()},
+    ]
+    benchmark.extra_info["read_mode"] = case.mode
+    benchmark.extra_info["body_bytes"] = case.body_size
+    benchmark.extra_info["chunk_bytes"] = case.chunk_size
+    benchmark.extra_info["chunks"] = len(chunks)


### PR DESCRIPTION
## Summary

Benchmark `Request.body()` and `Request.stream()` with 1 KiB, 1 MiB, and 10 MiB request bodies. Cover single-message delivery and 64 KiB ASGI chunks while keeping payload construction outside the measured region.

## Tests

- `uv run pytest benchmarks/request_benchmark.py --codspeed`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

