### PR TITLE
Add multipart parsing benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,6 +37,7 @@ jobs:
           run: >-
             uv run pytest
             benchmarks/gzip_benchmark.py
+            benchmarks/multipart_benchmark.py
             benchmarks/request_benchmark.py
             benchmarks/response_benchmark.py
             benchmarks/routing_benchmark.py

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -34,6 +34,22 @@ Run it locally with:
 uv run pytest benchmarks/request_benchmark.py --codspeed
 ```
 
+## Multipart forms
+
+The multipart benchmark measures `Request.form()` with field-heavy, in-memory
+file, spooled file, mixed form, and boundary-like payloads. It also covers
+malformed forms and field, file, and part-size limit failures.
+
+File workloads use 64 KiB ASGI chunks. The 10 MiB file also has a single-message
+control case. Multipart body and chunk construction happen outside the measured
+region, while parsing and upload cleanup happen inside it.
+
+Run it locally with:
+
+```console
+uv run pytest benchmarks/multipart_benchmark.py --codspeed
+```
+
 ## Routing
 
 The routing benchmark exercises `Router` dispatch through its ASGI interface

--- a/benchmarks/_utils.py
+++ b/benchmarks/_utils.py
@@ -9,6 +9,23 @@ async def unreadable_receive() -> Message:
     raise AssertionError("The benchmark app must not receive a request body")
 
 
+class ChunkedReceive:
+    def __init__(self, chunks: tuple[bytes, ...]) -> None:
+        self.chunks = chunks
+        self.index = 0
+
+    async def __call__(self) -> Message:
+        if self.index >= len(self.chunks):
+            raise AssertionError("The benchmark app read beyond the request body")
+        chunk = self.chunks[self.index]
+        self.index += 1
+        return {
+            "type": "http.request",
+            "body": chunk,
+            "more_body": self.index < len(self.chunks),
+        }
+
+
 async def run_asgi(app: ASGIApp, scope: Scope, receive: Receive = unreadable_receive) -> list[Message]:
     messages: list[Message] = []
 
@@ -27,4 +44,5 @@ class ASGIRunner:
         return self.loop.run_until_complete(run_asgi(app, scope, receive))
 
     def close(self) -> None:
+        self.loop.run_until_complete(self.loop.shutdown_asyncgens())
         self.loop.close()

--- a/benchmarks/multipart_benchmark.py
+++ b/benchmarks/multipart_benchmark.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from pytest_codspeed.plugin import BenchmarkFixture
+
+from benchmarks._utils import ASGIRunner, ChunkedReceive
+from starlette.datastructures import UploadFile
+from starlette.formparsers import MultiPartException
+from starlette.requests import Request
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+KiB = 1024
+MiB = 1024 * KiB
+BOUNDARY = b"starlette-benchmark-boundary"
+CONTENT_TYPE = b"multipart/form-data; boundary=" + BOUNDARY
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    id: str
+    fields: int = 0
+    field_size: int = 8
+    file_sizes: tuple[int, ...] = ()
+    chunk_size: int | None = 64 * KiB
+    boundary_like: bool = False
+    malformed: bool = False
+    max_files: int = 1000
+    max_fields: int = 1000
+    max_part_size: int = MiB
+    expected_error: str | None = None
+
+
+CASES = (
+    BenchmarkCase("fields-1000", fields=1000),
+    BenchmarkCase("file-512KiB", file_sizes=(512 * KiB,)),
+    BenchmarkCase("file-10MiB-single", file_sizes=(10 * MiB,), chunk_size=None),
+    BenchmarkCase("file-10MiB-64KiB", file_sizes=(10 * MiB,)),
+    BenchmarkCase("mixed", fields=100, file_sizes=(512 * KiB,)),
+    BenchmarkCase("boundary-like-file", file_sizes=(MiB,), boundary_like=True),
+    BenchmarkCase(
+        "malformed-after-spooled-file",
+        file_sizes=(2 * MiB,),
+        malformed=True,
+        expected_error='The Content-Disposition header field "name" must be provided.',
+    ),
+    BenchmarkCase(
+        "max-fields",
+        fields=101,
+        max_fields=100,
+        expected_error="Too many fields. Maximum number of fields is 100.",
+    ),
+    BenchmarkCase(
+        "max-files",
+        file_sizes=(1, 1),
+        max_files=1,
+        expected_error="Too many files. Maximum number of files is 1.",
+    ),
+    BenchmarkCase(
+        "max-part-size",
+        fields=1,
+        field_size=2 * KiB,
+        max_part_size=KiB,
+        expected_error="Part exceeded maximum size of 1KB.",
+    ),
+)
+
+
+class MultipartApp:
+    def __init__(self, case: BenchmarkCase) -> None:
+        self.case = case
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        request = Request(scope, receive)
+        try:
+            async with request.form(
+                max_files=self.case.max_files,
+                max_fields=self.case.max_fields,
+                max_part_size=self.case.max_part_size,
+            ) as form:
+                fields = 0
+                files = 0
+                file_bytes = 0
+                for _, value in form.multi_items():
+                    if isinstance(value, UploadFile):
+                        files += 1
+                        assert value.size is not None
+                        file_bytes += value.size
+                    else:
+                        fields += 1
+        except MultiPartException as exc:
+            await send_result(send, 400, exc.message.encode())
+            return
+
+        await send_result(send, 200, f"{fields}:{files}:{file_bytes}".encode())
+
+
+async def send_result(send: Send, status: int, body: bytes) -> None:
+    await send({"type": "http.response.start", "status": status, "headers": []})
+    await send({"type": "http.response.body", "body": body})
+
+
+def http_scope() -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.5"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "root_path": "",
+        "query_string": b"",
+        "headers": [(b"content-type", CONTENT_TYPE)],
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 80),
+    }
+
+
+def field_part(index: int, size: int) -> bytes:
+    value = bytes((65 + index % 26,)) * size
+    return (
+        b"--"
+        + BOUNDARY
+        + b'\r\nContent-Disposition: form-data; name="field'
+        + str(index).encode()
+        + b'"\r\n\r\n'
+        + value
+        + b"\r\n"
+    )
+
+
+def file_part(index: int, size: int, boundary_like: bool) -> bytes:
+    if boundary_like:
+        marker = b"\r\n--" + BOUNDARY[:-1] + b"x"
+        content = (marker * (size // len(marker) + 1))[:size]
+    else:
+        content = bytes((65 + index % 26,)) * size
+    return (
+        b"--"
+        + BOUNDARY
+        + b'\r\nContent-Disposition: form-data; name="file'
+        + str(index).encode()
+        + b'"; filename="file.bin"\r\nContent-Type: application/octet-stream\r\n\r\n'
+        + content
+        + b"\r\n"
+    )
+
+
+def make_body(case: BenchmarkCase) -> bytes:
+    parts = [field_part(index, case.field_size) for index in range(case.fields)]
+    parts.extend(file_part(index, size, case.boundary_like) for index, size in enumerate(case.file_sizes))
+    if case.malformed:
+        parts.append(b"--" + BOUNDARY + b"\r\nContent-Disposition: form-data\r\n\r\ninvalid\r\n")
+    parts.append(b"--" + BOUNDARY + b"--\r\n")
+    return b"".join(parts)
+
+
+def make_chunks(body: bytes, chunk_size: int | None) -> tuple[bytes, ...]:
+    if chunk_size is None:
+        return (body,)
+    return tuple(body[offset : offset + chunk_size] for offset in range(0, len(body), chunk_size))
+
+
+def dispatch(runner: ASGIRunner, app: ASGIApp, chunks: tuple[bytes, ...]) -> list[Message]:
+    return runner.run(app, http_scope(), ChunkedReceive(chunks))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def warm_multipart(asgi_runner: ASGIRunner) -> None:
+    case = BenchmarkCase("warm", fields=1, file_sizes=(1,))
+    chunks = make_chunks(make_body(case), case.chunk_size)
+    app = MultipartApp(case)
+    for _ in range(100):
+        dispatch(asgi_runner, app, chunks)
+
+    spooled_case = BenchmarkCase("warm-spooled", file_sizes=(MiB + 1,))
+    chunks = make_chunks(make_body(spooled_case), spooled_case.chunk_size)
+    dispatch(asgi_runner, MultipartApp(spooled_case), chunks)
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=1)
+def test_multipart(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
+    body = make_body(case)
+    chunks = make_chunks(body, case.chunk_size)
+    messages = benchmark.pedantic(dispatch, args=(asgi_runner, MultipartApp(case), chunks), rounds=1)
+
+    if case.expected_error is None:
+        expected_status = 200
+        expected_body = f"{case.fields}:{len(case.file_sizes)}:{sum(case.file_sizes)}".encode()
+    else:
+        expected_status = 400
+        expected_body = case.expected_error.encode()
+
+    assert messages == [
+        {"type": "http.response.start", "status": expected_status, "headers": []},
+        {"type": "http.response.body", "body": expected_body},
+    ]
+    benchmark.extra_info["body_bytes"] = len(body)
+    benchmark.extra_info["chunk_bytes"] = case.chunk_size or len(body)
+    benchmark.extra_info["chunks"] = len(chunks)
+    benchmark.extra_info["fields"] = case.fields
+    benchmark.extra_info["files"] = len(case.file_sizes)

--- a/benchmarks/request_benchmark.py
+++ b/benchmarks/request_benchmark.py
@@ -6,7 +6,7 @@ from typing import Literal
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
-from benchmarks._utils import ASGIRunner
+from benchmarks._utils import ASGIRunner, ChunkedReceive
 from starlette.requests import Request
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -14,23 +14,6 @@ KiB = 1024
 MiB = 1024 * KiB
 
 ReadMode = Literal["body", "stream"]
-
-
-class BodyReceive:
-    def __init__(self, chunks: tuple[bytes, ...]) -> None:
-        self.chunks = chunks
-        self.index = 0
-
-    async def __call__(self) -> Message:
-        if self.index >= len(self.chunks):
-            raise AssertionError("The benchmark app read beyond the request body")
-        chunk = self.chunks[self.index]
-        self.index += 1
-        return {
-            "type": "http.request",
-            "body": chunk,
-            "more_body": self.index < len(self.chunks),
-        }
 
 
 class BodyApp:
@@ -106,7 +89,7 @@ def make_chunks(body_size: int, chunk_size: int) -> tuple[bytes, ...]:
 
 
 def dispatch(runner: ASGIRunner, app: ASGIApp, chunks: tuple[bytes, ...]) -> list[Message]:
-    return runner.run(app, http_scope(), BodyReceive(chunks))
+    return runner.run(app, http_scope(), ChunkedReceive(chunks))
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
## Summary

Benchmark `Request.form()` with field-heavy, in-memory file, spooled file, mixed, and boundary-like multipart payloads. Cover malformed input and field, file, and part-size limit failures.

Share the chunked ASGI receive helper with the request-body benchmarks and close asynchronous generators during benchmark runner teardown.

## Tests

- `uv run pytest benchmarks/multipart_benchmark.py benchmarks/request_benchmark.py --codspeed`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

