### PR TITLE
Batch spooled multipart file writes

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -448,7 +448,7 @@ class UploadFile:
         future_size = self.file.tell() + size_to_add
         return bool(future_size > self._max_mem_size) if self._max_mem_size else False
 
-    async def write(self, data: bytes) -> None:
+    async def write(self, data: bytes | bytearray) -> None:
         new_data_len = len(data)
         if self.size is not None:
             self.size += new_data_len

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -39,6 +39,8 @@ class MultipartPart:
     field_name: str = ""
     data: bytearray = field(default_factory=bytearray)
     file: UploadFile | None = None
+    file_data: list[bytes] | None = None
+    file_data_size: int = 0
     item_headers: list[tuple[bytes, bytes]] = field(default_factory=list)
 
 
@@ -148,6 +150,7 @@ class MultiPartParser:
     """The maximum size of the spooled temporary file used to store file data."""
     max_part_size = 1024 * 1024  # 1MB
     """The maximum size of a part in the multipart request."""
+    _file_write_size = 1024 * 1024  # 1MB
 
     def __init__(
         self,
@@ -186,6 +189,14 @@ class MultiPartParser:
             self._current_part.data.extend(message_bytes)
         else:
             self._file_parts_to_write.append((self._current_part, message_bytes))
+
+    async def _flush_file_data(self, part: MultipartPart) -> None:
+        assert part.file is not None
+        assert part.file_data is not None
+        data = b"".join(part.file_data)
+        part.file_data.clear()
+        part.file_data_size = 0
+        await part.file.write(data)
 
     def on_part_end(self) -> None:
         if self._current_part.file is None:
@@ -235,6 +246,7 @@ class MultiPartParser:
                 filename=filename,
                 headers=Headers(raw=self._current_part.item_headers),
             )
+            self._current_part.file_data = []
         else:
             self._current_fields += 1
             if self._current_fields > self.max_fields:
@@ -280,10 +292,21 @@ class MultiPartParser:
                 # (regular, non-async functions), that would block the event loop in
                 # the main thread.
                 for part, data in self._file_parts_to_write:
-                    assert part.file  # for type checkers
-                    await part.file.write(data)
+                    assert part.file is not None
+                    assert part.file_data is not None
+                    if part.file_data and len(data) >= self._file_write_size:
+                        await self._flush_file_data(part)
+                    if part.file_data or (not part.file._in_memory and len(data) < self._file_write_size):
+                        part.file_data.append(data)
+                        part.file_data_size += len(data)
+                        if part.file_data_size >= self._file_write_size:
+                            await self._flush_file_data(part)
+                    else:
+                        await part.file.write(data)
                 for part in self._file_parts_to_finish:
-                    assert part.file  # for type checkers
+                    assert part.file is not None
+                    if part.file_data:
+                        await self._flush_file_data(part)
                     await part.file.seek(0)
                 self._file_parts_to_write.clear()
                 self._file_parts_to_finish.clear()

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -294,7 +294,7 @@ class MultiPartParser:
                 for part, data in self._file_parts_to_write:
                     assert part.file is not None
                     assert part.file_data is not None
-                    if part.file_data and len(data) >= self._file_write_size:
+                    if part.file_data and part.file_data_size + len(data) > self._file_write_size:
                         await self._flush_file_data(part)
                     if part.file_data or (not part.file._in_memory and len(data) < self._file_write_size):
                         part.file_data.append(data)

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -34,11 +34,16 @@ class FormMessage(Enum):
 
 
 @dataclass
+class MultipartFilePart:
+    upload: UploadFile
+
+
+@dataclass
 class MultipartPart:
     content_disposition: bytes | None = None
     field_name: str = ""
     data: bytearray = field(default_factory=bytearray)
-    file: UploadFile | None = None
+    file_part: MultipartFilePart | None = None
     item_headers: list[tuple[bytes, bytes]] = field(default_factory=list)
 
 
@@ -170,8 +175,8 @@ class MultiPartParser:
         self._current_partial_header_value: bytes = b""
         self._current_part = MultipartPart()
         self._charset = ""
-        self._file_parts_to_write: list[tuple[MultipartPart, bytes]] = []
-        self._file_parts_to_finish: list[MultipartPart] = []
+        self._file_parts_to_write: list[tuple[MultipartFilePart, bytes]] = []
+        self._file_parts_to_finish: list[MultipartFilePart] = []
         self._files_to_close_on_error: list[SpooledTemporaryFile[bytes]] = []
         self.max_part_size = max_part_size
 
@@ -180,15 +185,17 @@ class MultiPartParser:
 
     def on_part_data(self, data: bytes, start: int, end: int) -> None:
         message_bytes = data[start:end]
-        if self._current_part.file is None:
+        file_part = self._current_part.file_part
+        if file_part is None:
             if len(self._current_part.data) + len(message_bytes) > self.max_part_size:
                 raise MultiPartException(f"Part exceeded maximum size of {int(self.max_part_size / 1024)}KB.")
             self._current_part.data.extend(message_bytes)
         else:
-            self._file_parts_to_write.append((self._current_part, message_bytes))
+            self._file_parts_to_write.append((file_part, message_bytes))
 
     def on_part_end(self) -> None:
-        if self._current_part.file is None:
+        file_part = self._current_part.file_part
+        if file_part is None:
             self.items.append(
                 (
                     self._current_part.field_name,
@@ -196,11 +203,11 @@ class MultiPartParser:
                 )
             )
         else:
-            self._file_parts_to_finish.append(self._current_part)
+            self._file_parts_to_finish.append(file_part)
             # The file can be added to the items right now even though it's not
             # finished yet, because it will be finished in the `parse()` method, before
             # self.items is used in the return value.
-            self.items.append((self._current_part.field_name, self._current_part.file))
+            self.items.append((self._current_part.field_name, file_part.upload))
 
     def on_header_field(self, data: bytes, start: int, end: int) -> None:
         self._current_partial_header_name += data[start:end]
@@ -229,17 +236,19 @@ class MultiPartParser:
             filename = _user_safe_decode(options[b"filename"], self._charset)
             tempfile = SpooledTemporaryFile(max_size=self.spool_max_size)
             self._files_to_close_on_error.append(tempfile)
-            self._current_part.file = UploadFile(
-                file=tempfile,  # type: ignore[arg-type]
-                size=0,
-                filename=filename,
-                headers=Headers(raw=self._current_part.item_headers),
+            self._current_part.file_part = MultipartFilePart(
+                upload=UploadFile(
+                    file=tempfile,  # type: ignore[arg-type]
+                    size=0,
+                    filename=filename,
+                    headers=Headers(raw=self._current_part.item_headers),
+                )
             )
         else:
             self._current_fields += 1
             if self._current_fields > self.max_fields:
                 raise MultiPartException(f"Too many fields. Maximum number of fields is {self.max_fields}.")
-            self._current_part.file = None
+            self._current_part.file_part = None
 
     def on_end(self) -> None:
         pass
@@ -279,12 +288,10 @@ class MultiPartParser:
                 # otherwise, if they were called directly in the callback methods above
                 # (regular, non-async functions), that would block the event loop in
                 # the main thread.
-                for part, data in self._file_parts_to_write:
-                    assert part.file  # for type checkers
-                    await part.file.write(data)
-                for part in self._file_parts_to_finish:
-                    assert part.file  # for type checkers
-                    await part.file.seek(0)
+                for file_part, data in self._file_parts_to_write:
+                    await file_part.upload.write(data)
+                for file_part in self._file_parts_to_finish:
+                    await file_part.upload.seek(0)
                 self._file_parts_to_write.clear()
                 self._file_parts_to_finish.clear()
             parser.finalize()

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -34,17 +34,12 @@ class FormMessage(Enum):
 
 
 @dataclass
-class MultipartFilePart:
-    upload: UploadFile
-    data: bytearray = field(default_factory=bytearray)
-
-
-@dataclass
 class MultipartPart:
     content_disposition: bytes | None = None
     field_name: str = ""
     data: bytearray = field(default_factory=bytearray)
-    file_part: MultipartFilePart | None = None
+    file: UploadFile | None = None
+    file_data: bytearray | None = None
     item_headers: list[tuple[bytes, bytes]] = field(default_factory=list)
 
 
@@ -177,8 +172,8 @@ class MultiPartParser:
         self._current_partial_header_value: bytes = b""
         self._current_part = MultipartPart()
         self._charset = ""
-        self._file_parts_to_write: list[tuple[MultipartFilePart, bytes]] = []
-        self._file_parts_to_finish: list[MultipartFilePart] = []
+        self._file_parts_to_write: list[tuple[MultipartPart, bytes]] = []
+        self._file_parts_to_finish: list[MultipartPart] = []
         self._files_to_close_on_error: list[SpooledTemporaryFile[bytes]] = []
         self.max_part_size = max_part_size
 
@@ -187,21 +182,21 @@ class MultiPartParser:
 
     def on_part_data(self, data: bytes, start: int, end: int) -> None:
         message_bytes = data[start:end]
-        file_part = self._current_part.file_part
-        if file_part is None:
+        if self._current_part.file is None:
             if len(self._current_part.data) + len(message_bytes) > self.max_part_size:
                 raise MultiPartException(f"Part exceeded maximum size of {int(self.max_part_size / 1024)}KB.")
             self._current_part.data.extend(message_bytes)
         else:
-            self._file_parts_to_write.append((file_part, message_bytes))
+            self._file_parts_to_write.append((self._current_part, message_bytes))
 
-    async def _flush_file_data(self, file_part: MultipartFilePart) -> None:
-        await file_part.upload.write(file_part.data)
-        file_part.data.clear()
+    async def _flush_file_data(self, part: MultipartPart) -> None:
+        assert part.file is not None
+        assert part.file_data is not None
+        await part.file.write(part.file_data)
+        part.file_data.clear()
 
     def on_part_end(self) -> None:
-        file_part = self._current_part.file_part
-        if file_part is None:
+        if self._current_part.file is None:
             self.items.append(
                 (
                     self._current_part.field_name,
@@ -209,11 +204,11 @@ class MultiPartParser:
                 )
             )
         else:
-            self._file_parts_to_finish.append(file_part)
+            self._file_parts_to_finish.append(self._current_part)
             # The file can be added to the items right now even though it's not
             # finished yet, because it will be finished in the `parse()` method, before
             # self.items is used in the return value.
-            self.items.append((self._current_part.field_name, file_part.upload))
+            self.items.append((self._current_part.field_name, self._current_part.file))
 
     def on_header_field(self, data: bytes, start: int, end: int) -> None:
         self._current_partial_header_name += data[start:end]
@@ -242,19 +237,18 @@ class MultiPartParser:
             filename = _user_safe_decode(options[b"filename"], self._charset)
             tempfile = SpooledTemporaryFile(max_size=self.spool_max_size)
             self._files_to_close_on_error.append(tempfile)
-            self._current_part.file_part = MultipartFilePart(
-                upload=UploadFile(
-                    file=tempfile,  # type: ignore[arg-type]
-                    size=0,
-                    filename=filename,
-                    headers=Headers(raw=self._current_part.item_headers),
-                )
+            self._current_part.file = UploadFile(
+                file=tempfile,  # type: ignore[arg-type]
+                size=0,
+                filename=filename,
+                headers=Headers(raw=self._current_part.item_headers),
             )
+            self._current_part.file_data = bytearray()
         else:
             self._current_fields += 1
             if self._current_fields > self.max_fields:
                 raise MultiPartException(f"Too many fields. Maximum number of fields is {self.max_fields}.")
-            self._current_part.file_part = None
+            self._current_part.file = None
 
     def on_end(self) -> None:
         pass
@@ -294,19 +288,22 @@ class MultiPartParser:
                 # otherwise, if they were called directly in the callback methods above
                 # (regular, non-async functions), that would block the event loop in
                 # the main thread.
-                for file_part, data in self._file_parts_to_write:
-                    if file_part.data and len(file_part.data) + len(data) > self._file_write_size:
-                        await self._flush_file_data(file_part)
-                    if file_part.data or (not file_part.upload._in_memory and len(data) < self._file_write_size):
-                        file_part.data.extend(data)
-                        if len(file_part.data) >= self._file_write_size:
-                            await self._flush_file_data(file_part)
+                for part, data in self._file_parts_to_write:
+                    assert part.file is not None
+                    assert part.file_data is not None
+                    if part.file_data and len(part.file_data) + len(data) > self._file_write_size:
+                        await self._flush_file_data(part)
+                    if part.file_data or (not part.file._in_memory and len(data) < self._file_write_size):
+                        part.file_data.extend(data)
+                        if len(part.file_data) >= self._file_write_size:
+                            await self._flush_file_data(part)
                     else:
-                        await file_part.upload.write(data)
-                for file_part in self._file_parts_to_finish:
-                    if file_part.data:
-                        await self._flush_file_data(file_part)
-                    await file_part.upload.seek(0)
+                        await part.file.write(data)
+                for part in self._file_parts_to_finish:
+                    assert part.file is not None
+                    if part.file_data:
+                        await self._flush_file_data(part)
+                    await part.file.seek(0)
                 self._file_parts_to_write.clear()
                 self._file_parts_to_finish.clear()
             parser.finalize()

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -39,8 +39,7 @@ class MultipartPart:
     field_name: str = ""
     data: bytearray = field(default_factory=bytearray)
     file: UploadFile | None = None
-    file_data: list[bytes] | None = None
-    file_data_size: int = 0
+    file_data: bytearray | None = None
     item_headers: list[tuple[bytes, bytes]] = field(default_factory=list)
 
 
@@ -193,10 +192,8 @@ class MultiPartParser:
     async def _flush_file_data(self, part: MultipartPart) -> None:
         assert part.file is not None
         assert part.file_data is not None
-        data = b"".join(part.file_data)
+        await part.file.write(part.file_data)
         part.file_data.clear()
-        part.file_data_size = 0
-        await part.file.write(data)
 
     def on_part_end(self) -> None:
         if self._current_part.file is None:
@@ -246,7 +243,7 @@ class MultiPartParser:
                 filename=filename,
                 headers=Headers(raw=self._current_part.item_headers),
             )
-            self._current_part.file_data = []
+            self._current_part.file_data = bytearray()
         else:
             self._current_fields += 1
             if self._current_fields > self.max_fields:
@@ -294,12 +291,11 @@ class MultiPartParser:
                 for part, data in self._file_parts_to_write:
                     assert part.file is not None
                     assert part.file_data is not None
-                    if part.file_data and part.file_data_size + len(data) > self._file_write_size:
+                    if part.file_data and len(part.file_data) + len(data) > self._file_write_size:
                         await self._flush_file_data(part)
                     if part.file_data or (not part.file._in_memory and len(data) < self._file_write_size):
-                        part.file_data.append(data)
-                        part.file_data_size += len(data)
-                        if part.file_data_size >= self._file_write_size:
+                        part.file_data.extend(data)
+                        if len(part.file_data) >= self._file_write_size:
                             await self._flush_file_data(part)
                     else:
                         await part.file.write(data)

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -39,7 +39,6 @@ class MultipartPart:
     field_name: str = ""
     data: bytearray = field(default_factory=bytearray)
     file: UploadFile | None = None
-    file_data: bytearray | None = None
     item_headers: list[tuple[bytes, bytes]] = field(default_factory=list)
 
 
@@ -189,12 +188,6 @@ class MultiPartParser:
         else:
             self._file_parts_to_write.append((self._current_part, message_bytes))
 
-    async def _flush_file_data(self, part: MultipartPart) -> None:
-        assert part.file is not None
-        assert part.file_data is not None
-        await part.file.write(part.file_data)
-        part.file_data.clear()
-
     def on_part_end(self) -> None:
         if self._current_part.file is None:
             self.items.append(
@@ -243,7 +236,6 @@ class MultiPartParser:
                 filename=filename,
                 headers=Headers(raw=self._current_part.item_headers),
             )
-            self._current_part.file_data = bytearray()
         else:
             self._current_fields += 1
             if self._current_fields > self.max_fields:
@@ -290,19 +282,21 @@ class MultiPartParser:
                 # the main thread.
                 for part, data in self._file_parts_to_write:
                     assert part.file is not None
-                    assert part.file_data is not None
-                    if part.file_data and len(part.file_data) + len(data) > self._file_write_size:
-                        await self._flush_file_data(part)
-                    if part.file_data or (not part.file._in_memory and len(data) < self._file_write_size):
-                        part.file_data.extend(data)
-                        if len(part.file_data) >= self._file_write_size:
-                            await self._flush_file_data(part)
+                    if part.data and len(part.data) + len(data) > self._file_write_size:
+                        await part.file.write(part.data)
+                        part.data.clear()
+                    if part.data or (not part.file._in_memory and len(data) < self._file_write_size):
+                        part.data.extend(data)
+                        if len(part.data) >= self._file_write_size:
+                            await part.file.write(part.data)
+                            part.data.clear()
                     else:
                         await part.file.write(data)
                 for part in self._file_parts_to_finish:
                     assert part.file is not None
-                    if part.file_data:
-                        await self._flush_file_data(part)
+                    if part.data:
+                        await part.file.write(part.data)
+                        part.data.clear()
                     await part.file.seek(0)
                 self._file_parts_to_write.clear()
                 self._file_parts_to_finish.clear()

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -18,7 +18,7 @@ from starlette.formparsers import FormParser, MultiPartException, MultiPartParse
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Mount
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from tests.types import TestClientFactory
 
 
@@ -363,6 +363,38 @@ def test_multipart_request_large_file_rollover_in_background_thread(
     # Ensure the app thread was not the same as the rollover one and that a rollover thread exists
     assert app_thread_ident not in ThreadTrackingSpooledTemporaryFile.rollover_threads
     assert len(ThreadTrackingSpooledTemporaryFile.rollover_threads) == 1
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("chunk_mode", ["64KiB", "mixed"])
+async def test_multipart_spooled_file_from_chunks(chunk_mode: str) -> None:
+    boundary = b"starlette-test-boundary"
+    content = b"x" * (3 * 1024 * 1024)
+    header = b"--" + boundary + b'\r\nContent-Disposition: form-data; name="file"; filename="file.bin"\r\n\r\n'
+    body = header + content + b"\r\n--" + boundary + b"--\r\n"
+    if chunk_mode == "64KiB":
+        chunks = tuple(body[offset : offset + 64 * 1024] for offset in range(0, len(body), 64 * 1024))
+    else:
+        first_chunk_size = len(header) + 1024 * 1024 + len(boundary) + 16
+        second_chunk_size = first_chunk_size + 64 * 1024
+        chunks = (body[:first_chunk_size], body[first_chunk_size:second_chunk_size], body[second_chunk_size:])
+    chunk_index = 0
+
+    async def receive() -> Message:
+        nonlocal chunk_index
+        chunk = chunks[chunk_index]
+        chunk_index += 1
+        return {"type": "http.request", "body": chunk, "more_body": chunk_index < len(chunks)}
+
+    scope: Scope = {
+        "type": "http",
+        "headers": [(b"content-type", b"multipart/form-data; boundary=" + boundary)],
+    }
+    request = Request(scope, receive)
+    async with request.form() as form:
+        upload = form["file"]
+        assert isinstance(upload, UploadFile)
+        assert await upload.read() == content
 
 
 def test_multipart_request_with_charset_for_filename(tmpdir: Path, test_client_factory: TestClientFactory) -> None:

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -366,8 +366,18 @@ def test_multipart_request_large_file_rollover_in_background_thread(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("chunk_mode", ["64KiB", "mixed"])
+@pytest.mark.parametrize("chunk_mode", ["64KiB", "mixed", "adjacent"])
 async def test_multipart_spooled_file_from_chunks(chunk_mode: str) -> None:
+    write_sizes: list[int] = []
+
+    class RecordingSpooledTemporaryFile(SpooledTemporaryFile[bytes]):
+        _rolled: bool
+
+        def write(self, data: Any) -> int:
+            if self._rolled:
+                write_sizes.append(len(data))
+            return super().write(data)
+
     boundary = b"starlette-test-boundary"
     content = b"x" * (3 * 1024 * 1024)
     header = b"--" + boundary + b'\r\nContent-Disposition: form-data; name="file"; filename="file.bin"\r\n\r\n'
@@ -376,8 +386,17 @@ async def test_multipart_spooled_file_from_chunks(chunk_mode: str) -> None:
         chunks = tuple(body[offset : offset + 64 * 1024] for offset in range(0, len(body), 64 * 1024))
     else:
         first_chunk_size = len(header) + 1024 * 1024 + len(boundary) + 16
-        second_chunk_size = first_chunk_size + 64 * 1024
-        chunks = (body[:first_chunk_size], body[first_chunk_size:second_chunk_size], body[second_chunk_size:])
+        second_chunk_size = first_chunk_size + (64 * 1024 if chunk_mode == "mixed" else 900 * 1024)
+        if chunk_mode == "mixed":
+            chunks = (body[:first_chunk_size], body[first_chunk_size:second_chunk_size], body[second_chunk_size:])
+        else:
+            third_chunk_size = second_chunk_size + 900 * 1024
+            chunks = (
+                body[:first_chunk_size],
+                body[first_chunk_size:second_chunk_size],
+                body[second_chunk_size:third_chunk_size],
+                body[third_chunk_size:],
+            )
     chunk_index = 0
 
     async def receive() -> Message:
@@ -391,10 +410,14 @@ async def test_multipart_spooled_file_from_chunks(chunk_mode: str) -> None:
         "headers": [(b"content-type", b"multipart/form-data; boundary=" + boundary)],
     }
     request = Request(scope, receive)
-    async with request.form() as form:
-        upload = form["file"]
-        assert isinstance(upload, UploadFile)
-        assert await upload.read() == content
+    with mock.patch("starlette.formparsers.SpooledTemporaryFile", RecordingSpooledTemporaryFile):
+        async with request.form() as form:
+            upload = form["file"]
+            assert isinstance(upload, UploadFile)
+            assert await upload.read() == content
+
+    if chunk_mode == "adjacent":
+        assert max(write_sizes) <= 1024 * 1024
 
 
 def test_multipart_request_with_charset_for_filename(tmpdir: Path, test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
## Summary

Batch small multipart file writes after the temporary file rolls to disk. Flush at approximately 1 MiB while keeping in-memory and already-large writes immediate.

This reduces thread-pool submissions without increasing peak memory for in-memory files or large ASGI messages. It follows the bottleneck identified in [discussion #2927](https://github.com/Kludex/starlette/discussions/2927#discussioncomment-13601605) and uses the baselines added by [PR #3450](https://github.com/Kludex/starlette/pull/3450).

For a local 10 MiB upload delivered in 64 KiB chunks, thread-pool calls decreased from 147 to 12, runtime decreased from approximately 13 ms to 4.1 ms, and peak memory remained approximately 1.27 MiB.

## Tests

- `scripts/test`
- `uv run pytest benchmarks/multipart_benchmark.py --codspeed`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



