### PR TITLE
Add response, form, and WebSocket benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,5 +42,9 @@ jobs:
             benchmarks/response_benchmark.py
             benchmarks/routing_benchmark.py
             benchmarks/json_benchmark.py
+            benchmarks/file_response_benchmark.py
+            benchmarks/streaming_response_benchmark.py
+            benchmarks/urlencoded_benchmark.py
+            benchmarks/websocket_benchmark.py
             --codspeed
           mode: simulation,memory

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,6 +42,9 @@ jobs:
             benchmarks/response_benchmark.py
             benchmarks/routing_benchmark.py
             benchmarks/json_benchmark.py
+            --codspeed
+            &&
+            uv run pytest
             benchmarks/file_response_benchmark.py
             benchmarks/streaming_response_benchmark.py
             benchmarks/urlencoded_benchmark.py

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -50,6 +50,55 @@ Run it locally with:
 uv run pytest benchmarks/json_benchmark.py --codspeed
 ```
 
+## URL-encoded forms
+
+The URL-encoded benchmark measures `Request.form()` with 1,000 fields, a large
+field, percent-encoded data, and field-count and part-size limit failures. The
+large field is delivered as a single ASGI message and in 64 KiB chunks.
+
+Run it locally with:
+
+```console
+uv run pytest benchmarks/urlencoded_benchmark.py --codspeed
+```
+
+## Streaming responses
+
+The streaming benchmark measures `StreamingResponse` with 1 KiB and 1 MiB
+bodies. The large body uses 1 KiB, 64 KiB, and single-chunk delivery to expose
+the per-chunk dispatch cost.
+
+Run it locally with:
+
+```console
+uv run pytest benchmarks/streaming_response_benchmark.py --codspeed
+```
+
+## File responses
+
+The file benchmark measures `FileResponse` with fallback reads,
+`http.response.pathsend`, and a single byte range. File creation happens outside
+the measured region, while response construction, stat, and delivery happen
+inside it.
+
+Run it locally with:
+
+```console
+uv run pytest benchmarks/file_response_benchmark.py --codspeed
+```
+
+## WebSockets
+
+The WebSocket benchmark measures complete text, bytes, and JSON echo exchanges
+through the public `WebSocket` API. Each dispatch includes connect, accept,
+receive, send, and close state transitions.
+
+Run it locally with:
+
+```console
+uv run pytest benchmarks/websocket_benchmark.py --codspeed
+```
+
 ## Multipart forms
 
 The multipart benchmark measures `Request.form()` with field-heavy, in-memory

--- a/benchmarks/_utils.py
+++ b/benchmarks/_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
-from starlette.types import ASGIApp, Message, Receive, Scope
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 async def unreadable_receive() -> Message:
@@ -24,6 +24,11 @@ class ChunkedReceive:
             "body": chunk,
             "more_body": self.index < len(self.chunks),
         }
+
+
+async def send_result(send: Send, status: int, body: bytes) -> None:
+    await send({"type": "http.response.start", "status": status, "headers": []})
+    await send({"type": "http.response.body", "body": body})
 
 
 async def run_asgi(app: ASGIApp, scope: Scope, receive: Receive = unreadable_receive) -> list[Message]:

--- a/benchmarks/file_response_benchmark.py
+++ b/benchmarks/file_response_benchmark.py
@@ -67,10 +67,16 @@ def dispatch(runner: ASGIRunner, app: FileApp, case: BenchmarkCase) -> list[Mess
 @pytest.fixture(scope="module", autouse=True)
 def warm_file_response(asgi_runner: ASGIRunner, tmp_path_factory: pytest.TempPathFactory) -> None:
     path = tmp_path_factory.mktemp("file-response-warm") / "file.bin"
-    path.write_bytes(b"x")
-    case = BenchmarkCase("warm", 1)
-    for _ in range(100):
-        dispatch(asgi_runner, FileApp(path), case)
+    path.write_bytes(b"x" * KiB)
+    app = FileApp(path)
+    cases = (
+        BenchmarkCase("warm-fallback", KiB),
+        BenchmarkCase("warm-pathsend", KiB, pathsend=True),
+        BenchmarkCase("warm-range", KiB, range_header=b"bytes=0-0", expected_size=1),
+    )
+    for case in cases:
+        for _ in range(100):
+            dispatch(asgi_runner, app, case)
 
 
 @pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)

--- a/benchmarks/file_response_benchmark.py
+++ b/benchmarks/file_response_benchmark.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from pytest_codspeed.plugin import BenchmarkFixture
+
+from benchmarks._utils import ASGIRunner
+from starlette.datastructures import Headers
+from starlette.responses import FileResponse
+from starlette.types import Message, Receive, Scope, Send
+
+KiB = 1024
+MiB = 1024 * KiB
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    id: str
+    file_size: int
+    pathsend: bool = False
+    range_header: bytes | None = None
+    expected_size: int | None = None
+
+
+CASES = (
+    BenchmarkCase("fallback-1KiB", KiB),
+    BenchmarkCase("fallback-10MiB", 10 * MiB),
+    BenchmarkCase("pathsend-10MiB", 10 * MiB, pathsend=True),
+    BenchmarkCase("range-64KiB", 10 * MiB, range_header=b"bytes=262144-327679", expected_size=64 * KiB),
+)
+
+
+class FileApp:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await FileResponse(self.path, media_type="application/octet-stream")(scope, receive, send)
+
+
+def http_scope(case: BenchmarkCase) -> Scope:
+    headers = [] if case.range_header is None else [(b"range", case.range_header)]
+    extensions: dict[str, dict[str, object]] = {"http.response.pathsend": {}} if case.pathsend else {}
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.5"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "root_path": "",
+        "query_string": b"",
+        "headers": headers,
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 80),
+        "extensions": extensions,
+    }
+
+
+def dispatch(runner: ASGIRunner, app: FileApp, case: BenchmarkCase) -> list[Message]:
+    return runner.run(app, http_scope(case))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def warm_file_response(asgi_runner: ASGIRunner, tmp_path_factory: pytest.TempPathFactory) -> None:
+    path = tmp_path_factory.mktemp("file-response-warm") / "file.bin"
+    path.write_bytes(b"x")
+    case = BenchmarkCase("warm", 1)
+    for _ in range(100):
+        dispatch(asgi_runner, FileApp(path), case)
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=1)
+def test_file_response(
+    tmp_path: Path,
+    asgi_runner: ASGIRunner,
+    benchmark: BenchmarkFixture,
+    case: BenchmarkCase,
+) -> None:
+    path = tmp_path / "file.bin"
+    path.write_bytes(b"x" * case.file_size)
+    messages = benchmark.pedantic(dispatch, args=(asgi_runner, FileApp(path), case), rounds=1)
+
+    expected_status = 206 if case.range_header is not None else 200
+    assert messages[0]["type"] == "http.response.start"
+    assert messages[0]["status"] == expected_status
+    headers = Headers(raw=messages[0]["headers"])
+    expected_size = case.expected_size or case.file_size
+    assert headers["content-length"] == str(expected_size)
+
+    if case.pathsend:
+        assert messages[1:] == [{"type": "http.response.pathsend", "path": str(path)}]
+    else:
+        body_messages = messages[1:]
+        assert sum(len(message.get("body", b"")) for message in body_messages) == expected_size
+        assert body_messages[-1].get("more_body") is False
+
+    if case.range_header is not None:
+        assert headers["content-range"] == f"bytes 262144-327679/{case.file_size}"
+
+    benchmark.extra_info["file_bytes"] = case.file_size
+    benchmark.extra_info["response_bytes"] = expected_size
+    benchmark.extra_info["pathsend"] = case.pathsend

--- a/benchmarks/multipart_benchmark.py
+++ b/benchmarks/multipart_benchmark.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
-from benchmarks._utils import ASGIRunner, ChunkedReceive
+from benchmarks._utils import ASGIRunner, ChunkedReceive, send_result
 from starlette.datastructures import UploadFile
 from starlette.formparsers import MultiPartException
 from starlette.requests import Request
@@ -95,11 +95,6 @@ class MultipartApp:
             return
 
         await send_result(send, 200, f"{fields}:{files}:{file_bytes}".encode())
-
-
-async def send_result(send: Send, status: int, body: bytes) -> None:
-    await send({"type": "http.response.start", "status": status, "headers": []})
-    await send({"type": "http.response.body", "body": body})
 
 
 def http_scope() -> Scope:

--- a/benchmarks/multipart_benchmark.py
+++ b/benchmarks/multipart_benchmark.py
@@ -30,16 +30,15 @@ class BenchmarkCase:
     max_fields: int = 1000
     max_part_size: int = MiB
     expected_error: str | None = None
-    rounds: int = 1
 
 
 CASES = (
     BenchmarkCase("fields-1000", fields=1000),
-    BenchmarkCase("file-512KiB", file_sizes=(512 * KiB,), rounds=5),
+    BenchmarkCase("file-512KiB", file_sizes=(512 * KiB,)),
     BenchmarkCase("file-10MiB-single", file_sizes=(10 * MiB,), chunk_size=None),
     BenchmarkCase("file-10MiB-64KiB", file_sizes=(10 * MiB,)),
-    BenchmarkCase("mixed", fields=100, file_sizes=(512 * KiB,), rounds=5),
-    BenchmarkCase("boundary-like-file", file_sizes=(MiB,), boundary_like=True, rounds=5),
+    BenchmarkCase("mixed", fields=100, file_sizes=(512 * KiB,)),
+    BenchmarkCase("boundary-like-file", file_sizes=(MiB,), boundary_like=True),
     BenchmarkCase(
         "malformed-after-spooled-file",
         file_sizes=(2 * MiB,),
@@ -183,11 +182,11 @@ def warm_multipart(asgi_runner: ASGIRunner) -> None:
 
 
 @pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
-@pytest.mark.benchmark(max_time=0.5, max_rounds=5)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=1)
 def test_multipart(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
     body = make_body(case)
     chunks = make_chunks(body, case.chunk_size)
-    messages = benchmark.pedantic(dispatch, args=(asgi_runner, MultipartApp(case), chunks), rounds=case.rounds)
+    messages = benchmark.pedantic(dispatch, args=(asgi_runner, MultipartApp(case), chunks), rounds=1)
 
     if case.expected_error is None:
         expected_status = 200

--- a/benchmarks/multipart_benchmark.py
+++ b/benchmarks/multipart_benchmark.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
-from benchmarks._utils import ASGIRunner, ChunkedReceive, send_result
+from benchmarks._utils import ASGIRunner, ChunkedReceive
 from starlette.datastructures import UploadFile
 from starlette.formparsers import MultiPartException
 from starlette.requests import Request
@@ -30,15 +30,16 @@ class BenchmarkCase:
     max_fields: int = 1000
     max_part_size: int = MiB
     expected_error: str | None = None
+    rounds: int = 1
 
 
 CASES = (
     BenchmarkCase("fields-1000", fields=1000),
-    BenchmarkCase("file-512KiB", file_sizes=(512 * KiB,)),
+    BenchmarkCase("file-512KiB", file_sizes=(512 * KiB,), rounds=5),
     BenchmarkCase("file-10MiB-single", file_sizes=(10 * MiB,), chunk_size=None),
     BenchmarkCase("file-10MiB-64KiB", file_sizes=(10 * MiB,)),
-    BenchmarkCase("mixed", fields=100, file_sizes=(512 * KiB,)),
-    BenchmarkCase("boundary-like-file", file_sizes=(MiB,), boundary_like=True),
+    BenchmarkCase("mixed", fields=100, file_sizes=(512 * KiB,), rounds=5),
+    BenchmarkCase("boundary-like-file", file_sizes=(MiB,), boundary_like=True, rounds=5),
     BenchmarkCase(
         "malformed-after-spooled-file",
         file_sizes=(2 * MiB,),
@@ -94,6 +95,11 @@ class MultipartApp:
             return
 
         await send_result(send, 200, f"{fields}:{files}:{file_bytes}".encode())
+
+
+async def send_result(send: Send, status: int, body: bytes) -> None:
+    await send({"type": "http.response.start", "status": status, "headers": []})
+    await send({"type": "http.response.body", "body": body})
 
 
 def http_scope() -> Scope:
@@ -174,13 +180,19 @@ def warm_multipart(asgi_runner: ASGIRunner) -> None:
     chunks = make_chunks(make_body(spooled_case), spooled_case.chunk_size)
     dispatch(asgi_runner, MultipartApp(spooled_case), chunks)
 
+    boundary_case = BenchmarkCase("warm-boundary-like", file_sizes=(64 * KiB,), boundary_like=True)
+    chunks = make_chunks(make_body(boundary_case), boundary_case.chunk_size)
+    app = MultipartApp(boundary_case)
+    for _ in range(10):
+        dispatch(asgi_runner, app, chunks)
+
 
 @pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
-@pytest.mark.benchmark(max_time=0.5, max_rounds=1)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=5)
 def test_multipart(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
     body = make_body(case)
     chunks = make_chunks(body, case.chunk_size)
-    messages = benchmark.pedantic(dispatch, args=(asgi_runner, MultipartApp(case), chunks), rounds=1)
+    messages = benchmark.pedantic(dispatch, args=(asgi_runner, MultipartApp(case), chunks), rounds=case.rounds)
 
     if case.expected_error is None:
         expected_status = 200

--- a/benchmarks/multipart_benchmark.py
+++ b/benchmarks/multipart_benchmark.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
-from benchmarks._utils import ASGIRunner, ChunkedReceive
+from benchmarks._utils import ASGIRunner, ChunkedReceive, send_result
 from starlette.datastructures import UploadFile
 from starlette.formparsers import MultiPartException
 from starlette.requests import Request
@@ -94,11 +94,6 @@ class MultipartApp:
             return
 
         await send_result(send, 200, f"{fields}:{files}:{file_bytes}".encode())
-
-
-async def send_result(send: Send, status: int, body: bytes) -> None:
-    await send({"type": "http.response.start", "status": status, "headers": []})
-    await send({"type": "http.response.body", "body": body})
 
 
 def http_scope() -> Scope:

--- a/benchmarks/streaming_response_benchmark.py
+++ b/benchmarks/streaming_response_benchmark.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+
+import pytest
+from pytest_codspeed.plugin import BenchmarkFixture
+
+from benchmarks._utils import ASGIRunner
+from starlette.responses import StreamingResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+KiB = 1024
+MiB = 1024 * KiB
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    id: str
+    body_size: int
+    chunk_size: int
+
+
+CASES = (
+    BenchmarkCase("1KiB-single", KiB, KiB),
+    BenchmarkCase("1MiB-1KiB", MiB, KiB),
+    BenchmarkCase("1MiB-64KiB", MiB, 64 * KiB),
+    BenchmarkCase("1MiB-single", MiB, MiB),
+)
+
+
+class StreamingApp:
+    def __init__(self, chunks: tuple[bytes, ...]) -> None:
+        self.chunks = chunks
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await StreamingResponse(iter_chunks(self.chunks))(scope, receive, send)
+
+
+async def iter_chunks(chunks: tuple[bytes, ...]) -> AsyncIterator[bytes]:
+    for chunk in chunks:
+        yield chunk
+
+
+def make_chunks(body_size: int, chunk_size: int) -> tuple[bytes, ...]:
+    payload = b"x" * body_size
+    return tuple(payload[offset : offset + chunk_size] for offset in range(0, body_size, chunk_size))
+
+
+def http_scope() -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.5"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "root_path": "",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 80),
+    }
+
+
+def dispatch(runner: ASGIRunner, app: ASGIApp) -> list[Message]:
+    return runner.run(app, http_scope())
+
+
+@pytest.fixture(scope="module", autouse=True)
+def warm_streaming(asgi_runner: ASGIRunner) -> None:
+    app = StreamingApp((b"x",))
+    for _ in range(100):
+        dispatch(asgi_runner, app)
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=1)
+def test_streaming_response(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
+    chunks = make_chunks(case.body_size, case.chunk_size)
+    messages = benchmark.pedantic(dispatch, args=(asgi_runner, StreamingApp(chunks)), rounds=1)
+
+    assert messages[0] == {"type": "http.response.start", "status": 200, "headers": []}
+    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
+    assert len(messages) == len(chunks) + 2
+    assert sum(len(message.get("body", b"")) for message in messages[1:]) == case.body_size
+    assert all(message.get("more_body") is True for message in messages[1:-1])
+    benchmark.extra_info["body_bytes"] = case.body_size
+    benchmark.extra_info["chunk_bytes"] = case.chunk_size
+    benchmark.extra_info["chunks"] = len(chunks)

--- a/benchmarks/urlencoded_benchmark.py
+++ b/benchmarks/urlencoded_benchmark.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+import pytest
+from pytest_codspeed.plugin import BenchmarkFixture
+
+from benchmarks._utils import ASGIRunner, ChunkedReceive
+from starlette.formparsers import MultiPartException
+from starlette.requests import Request
+from starlette.types import Message, Receive, Scope, Send
+
+KiB = 1024
+MiB = 1024 * KiB
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    id: str
+    fields: int
+    field_size: int
+    chunk_size: int | None = 64 * KiB
+    percent_encoded: bool = False
+    max_fields: int = 1000
+    max_part_size: int = MiB
+    expected_error: str | None = None
+
+
+CASES = (
+    BenchmarkCase("fields-1000", fields=1000, field_size=8),
+    BenchmarkCase("field-1MiB-single", fields=1, field_size=MiB, chunk_size=None, max_part_size=2 * MiB),
+    BenchmarkCase("field-1MiB-64KiB", fields=1, field_size=MiB, max_part_size=2 * MiB),
+    BenchmarkCase("percent-encoded", fields=100, field_size=8, percent_encoded=True),
+    BenchmarkCase(
+        "max-fields",
+        fields=101,
+        field_size=8,
+        max_fields=100,
+        expected_error="Too many fields. Maximum number of fields is 100.",
+    ),
+    BenchmarkCase(
+        "max-part-size",
+        fields=1,
+        field_size=2 * KiB,
+        max_part_size=KiB,
+        expected_error="Field exceeded maximum size of 1KB.",
+    ),
+)
+
+
+class FormApp:
+    def __init__(self, case: BenchmarkCase) -> None:
+        self.case = case
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        request = Request(scope, receive)
+        try:
+            async with request.form(
+                max_fields=self.case.max_fields,
+                max_part_size=self.case.max_part_size,
+            ) as form:
+                value_size = 0
+                for value in form.values():
+                    assert isinstance(value, str)
+                    value_size += len(value)
+                result = f"{len(form)}:{value_size}".encode()
+        except MultiPartException as exc:
+            await send_result(send, 400, exc.message.encode())
+            return
+
+        await send_result(send, 200, result)
+
+
+async def send_result(send: Send, status: int, body: bytes) -> None:
+    await send({"type": "http.response.start", "status": status, "headers": []})
+    await send({"type": "http.response.body", "body": body})
+
+
+def make_fields(case: BenchmarkCase) -> list[tuple[str, str]]:
+    if case.percent_encoded:
+        return [(f"field {index}", f"café / {index}" * case.field_size) for index in range(case.fields)]
+    return [(f"field{index}", "x" * case.field_size) for index in range(case.fields)]
+
+
+def make_chunks(body: bytes, chunk_size: int | None) -> tuple[bytes, ...]:
+    if chunk_size is None:
+        return (body,)
+    return tuple(body[offset : offset + chunk_size] for offset in range(0, len(body), chunk_size))
+
+
+def http_scope() -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.5"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "root_path": "",
+        "query_string": b"",
+        "headers": [(b"content-type", b"application/x-www-form-urlencoded")],
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 80),
+    }
+
+
+def dispatch(runner: ASGIRunner, app: FormApp, chunks: tuple[bytes, ...]) -> list[Message]:
+    return runner.run(app, http_scope(), ChunkedReceive(chunks))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def warm_form(asgi_runner: ASGIRunner) -> None:
+    case = BenchmarkCase("warm", fields=1, field_size=1)
+    body = urlencode(make_fields(case)).encode()
+    for _ in range(100):
+        dispatch(asgi_runner, FormApp(case), (body,))
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=1)
+def test_urlencoded_form(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
+    fields = make_fields(case)
+    body = urlencode(fields).encode()
+    chunks = make_chunks(body, case.chunk_size)
+    messages = benchmark.pedantic(dispatch, args=(asgi_runner, FormApp(case), chunks), rounds=1)
+
+    if case.expected_error is None:
+        expected_status = 200
+        expected_body = f"{case.fields}:{sum(len(value) for _, value in fields)}".encode()
+    else:
+        expected_status = 400
+        expected_body = case.expected_error.encode()
+
+    assert messages == [
+        {"type": "http.response.start", "status": expected_status, "headers": []},
+        {"type": "http.response.body", "body": expected_body},
+    ]
+    benchmark.extra_info["body_bytes"] = len(body)
+    benchmark.extra_info["chunk_bytes"] = case.chunk_size or len(body)
+    benchmark.extra_info["chunks"] = len(chunks)
+    benchmark.extra_info["fields"] = case.fields

--- a/benchmarks/urlencoded_benchmark.py
+++ b/benchmarks/urlencoded_benchmark.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
-from benchmarks._utils import ASGIRunner, ChunkedReceive
+from benchmarks._utils import ASGIRunner, ChunkedReceive, send_result
 from starlette.formparsers import MultiPartException
 from starlette.requests import Request
 from starlette.types import Message, Receive, Scope, Send
@@ -70,11 +70,6 @@ class FormApp:
             return
 
         await send_result(send, 200, result)
-
-
-async def send_result(send: Send, status: int, body: bytes) -> None:
-    await send({"type": "http.response.start", "status": status, "headers": []})
-    await send({"type": "http.response.body", "body": body})
 
 
 def make_fields(case: BenchmarkCase) -> list[tuple[str, str]]:

--- a/benchmarks/websocket_benchmark.py
+++ b/benchmarks/websocket_benchmark.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+from pytest_codspeed.plugin import BenchmarkFixture
+
+from benchmarks._utils import ASGIRunner
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from starlette.websockets import WebSocket
+
+TEXT = "x" * 1024
+BYTES = b"x" * 1024
+JSON_CONTENT = {"items": [{"id": index, "name": f"item-{index}"} for index in range(25)]}
+JSON_TEXT = json.dumps(JSON_CONTENT, ensure_ascii=False, separators=(",", ":"))
+
+
+class TextEchoApp:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive, send)
+        await websocket.accept()
+        await websocket.send_text(await websocket.receive_text())
+        await websocket.close()
+
+
+class BytesEchoApp:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive, send)
+        await websocket.accept()
+        await websocket.send_bytes(await websocket.receive_bytes())
+        await websocket.close()
+
+
+class JSONEchoApp:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive, send)
+        await websocket.accept()
+        await websocket.send_json(await websocket.receive_json())
+        await websocket.close()
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    id: str
+    app: ASGIApp
+    incoming: Message
+    outgoing: Message
+
+
+CASES = (
+    BenchmarkCase(
+        "text", TextEchoApp(), {"type": "websocket.receive", "text": TEXT}, {"type": "websocket.send", "text": TEXT}
+    ),
+    BenchmarkCase(
+        "bytes",
+        BytesEchoApp(),
+        {"type": "websocket.receive", "bytes": BYTES},
+        {"type": "websocket.send", "bytes": BYTES},
+    ),
+    BenchmarkCase(
+        "json",
+        JSONEchoApp(),
+        {"type": "websocket.receive", "text": JSON_TEXT},
+        {"type": "websocket.send", "text": JSON_TEXT},
+    ),
+)
+
+
+class WebSocketReceive:
+    def __init__(self, incoming: Message) -> None:
+        self.messages: tuple[Message, ...] = ({"type": "websocket.connect"}, incoming)
+        self.index = 0
+
+    async def __call__(self) -> Message:
+        if self.index >= len(self.messages):
+            raise AssertionError("The benchmark app read beyond the WebSocket message")
+        message = self.messages[self.index]
+        self.index += 1
+        return message
+
+
+def websocket_scope() -> Scope:
+    return {
+        "type": "websocket",
+        "asgi": {"version": "3.0", "spec_version": "2.5"},
+        "scheme": "ws",
+        "path": "/",
+        "raw_path": b"/",
+        "root_path": "",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 80),
+        "subprotocols": [],
+    }
+
+
+def dispatch(runner: ASGIRunner, case: BenchmarkCase) -> list[Message]:
+    return runner.run(case.app, websocket_scope(), WebSocketReceive(case.incoming))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def warm_websockets(asgi_runner: ASGIRunner) -> None:
+    for case in CASES:
+        for _ in range(100):
+            dispatch(asgi_runner, case)
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=20)
+def test_websocket_echo(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
+    messages = benchmark(dispatch, asgi_runner, case)
+
+    assert messages == [
+        {"type": "websocket.accept", "subprotocol": None, "headers": []},
+        case.outgoing,
+        {"type": "websocket.close", "code": 1000, "reason": ""},
+    ]
+    benchmark.extra_info["mode"] = case.id


### PR DESCRIPTION
## Summary

Add public-API CodSpeed benchmarks for four remaining performance paths:

- URL-encoded `Request.form()` parsing, including large, field-heavy, encoded, and limit-failure cases.
- `StreamingResponse` delivery across 1 KiB, 64 KiB, and single-chunk workloads.
- `FileResponse` fallback reads, byte ranges, and `http.response.pathsend`.
- WebSocket text, bytes, and JSON echo exchanges.

Payload and file preparation remain outside the measured regions. The new suites run in a separate pytest process to preserve the existing benchmarks' execution environment.

## Tests

- `scripts/test`
- `uv run pytest benchmarks/file_response_benchmark.py benchmarks/streaming_response_benchmark.py benchmarks/urlencoded_benchmark.py benchmarks/websocket_benchmark.py --codspeed -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


