### PR TITLE
Run CodSpeed benchmarks in one process

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,9 +42,6 @@ jobs:
             benchmarks/response_benchmark.py
             benchmarks/routing_benchmark.py
             benchmarks/json_benchmark.py
-            --codspeed
-            &&
-            uv run pytest
             benchmarks/file_response_benchmark.py
             benchmarks/streaming_response_benchmark.py
             benchmarks/urlencoded_benchmark.py


### PR DESCRIPTION
## Summary

Run all CodSpeed benchmarks in one pytest process again.

The suites were split while investigating multipart measurement instability. The regressions persisted after isolation and were addressed with a representative warm-up instead, so the extra process no longer serves a purpose.

## Tests

- `scripts/check`
- `uv run pytest benchmarks/gzip_benchmark.py benchmarks/multipart_benchmark.py benchmarks/request_benchmark.py benchmarks/response_benchmark.py benchmarks/routing_benchmark.py benchmarks/json_benchmark.py benchmarks/file_response_benchmark.py benchmarks/streaming_response_benchmark.py benchmarks/urlencoded_benchmark.py benchmarks/websocket_benchmark.py --codspeed -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

