### PR TITLE
Fix WebSocketException requiring code argument

### DIFF
--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -21,7 +21,7 @@ class HTTPException(Exception):
 
 
 class WebSocketException(Exception):
-    def __init__(self, code: int, reason: str | None = None) -> None:
+    def __init__(self, code: int = 1008, reason: str | None = None) -> None:
         self.code = code
         self.reason = reason or ""
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -164,11 +164,15 @@ def test_http_repr() -> None:
 
 
 def test_websocket_str() -> None:
+    assert str(WebSocketException()) == "1008: "
     assert str(WebSocketException(1008)) == "1008: "
     assert str(WebSocketException(1008, "Policy Violation")) == "1008: Policy Violation"
 
 
 def test_websocket_repr() -> None:
+    assert repr(WebSocketException(reason="Policy Violation")) == (
+        "WebSocketException(code=1008, reason='Policy Violation')"
+    )
     assert repr(WebSocketException(1008, reason="Policy Violation")) == (
         "WebSocketException(code=1008, reason='Policy Violation')"
     )


### PR DESCRIPTION
Fixes #3460

The `WebSocketException` was requiring the `code` positional argument although the docs documented it with a default value of 1008. This PR adds the default `code: int = 1008` to the `__init__` signature to conform to the documentation and expected natural behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

