### PR TITLE
Stabilize CodSpeed benchmark state

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,8 @@ jobs:
   benchmarks:
     name: Run benchmarks
     runs-on: ubuntu-latest
+    env:
+      PYTHONHASHSEED: "0"
 
     steps:
       - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1

--- a/benchmarks/multipart_benchmark.py
+++ b/benchmarks/multipart_benchmark.py
@@ -30,15 +30,16 @@ class BenchmarkCase:
     max_fields: int = 1000
     max_part_size: int = MiB
     expected_error: str | None = None
+    warmup: bool = False
 
 
 CASES = (
     BenchmarkCase("fields-1000", fields=1000),
-    BenchmarkCase("file-512KiB", file_sizes=(512 * KiB,)),
+    BenchmarkCase("file-512KiB", file_sizes=(512 * KiB,), warmup=True),
     BenchmarkCase("file-10MiB-single", file_sizes=(10 * MiB,), chunk_size=None),
     BenchmarkCase("file-10MiB-64KiB", file_sizes=(10 * MiB,)),
-    BenchmarkCase("mixed", fields=100, file_sizes=(512 * KiB,)),
-    BenchmarkCase("boundary-like-file", file_sizes=(MiB,), boundary_like=True),
+    BenchmarkCase("mixed", fields=100, file_sizes=(512 * KiB,), warmup=True),
+    BenchmarkCase("boundary-like-file", file_sizes=(MiB,), boundary_like=True, warmup=True),
     BenchmarkCase(
         "malformed-after-spooled-file",
         file_sizes=(2 * MiB,),
@@ -186,7 +187,10 @@ def warm_multipart(asgi_runner: ASGIRunner) -> None:
 def test_multipart(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
     body = make_body(case)
     chunks = make_chunks(body, case.chunk_size)
-    messages = benchmark.pedantic(dispatch, args=(asgi_runner, MultipartApp(case), chunks), rounds=1)
+    app = MultipartApp(case)
+    if case.warmup:
+        dispatch(asgi_runner, app, chunks)
+    messages = benchmark.pedantic(dispatch, args=(asgi_runner, app, chunks), rounds=1)
 
     if case.expected_error is None:
         expected_status = 200

--- a/benchmarks/urlencoded_benchmark.py
+++ b/benchmarks/urlencoded_benchmark.py
@@ -25,12 +25,13 @@ class BenchmarkCase:
     max_fields: int = 1000
     max_part_size: int = MiB
     expected_error: str | None = None
+    warmup: bool = False
 
 
 CASES = (
     BenchmarkCase("fields-1000", fields=1000, field_size=8),
     BenchmarkCase("field-1MiB-single", fields=1, field_size=MiB, chunk_size=None, max_part_size=2 * MiB),
-    BenchmarkCase("field-1MiB-64KiB", fields=1, field_size=MiB, max_part_size=2 * MiB),
+    BenchmarkCase("field-1MiB-64KiB", fields=1, field_size=MiB, max_part_size=2 * MiB, warmup=True),
     BenchmarkCase("percent-encoded", fields=100, field_size=8, percent_encoded=True),
     BenchmarkCase(
         "max-fields",
@@ -119,7 +120,10 @@ def test_urlencoded_form(asgi_runner: ASGIRunner, benchmark: BenchmarkFixture, c
     fields = make_fields(case)
     body = urlencode(fields).encode()
     chunks = make_chunks(body, case.chunk_size)
-    messages = benchmark.pedantic(dispatch, args=(asgi_runner, FormApp(case), chunks), rounds=1)
+    app = FormApp(case)
+    if case.warmup:
+        dispatch(asgi_runner, app, chunks)
+    messages = benchmark.pedantic(dispatch, args=(asgi_runner, app, chunks), rounds=1)
 
     if case.expected_error is None:
         expected_status = 200


### PR DESCRIPTION
## Summary

Keep all CodSpeed suites in one pytest process while reducing sensitivity to process state.

- Pin `PYTHONHASHSEED` for deterministic hash-table behavior.
- Warm the exact multipart cases that have produced unstable reports immediately before measurement.
- Warm the chunked 1 MiB URL-encoded case immediately before measurement.

Payload and chunk preparation remain outside the measured region. Each reported benchmark still measures one public ASGI dispatch, so the benchmark semantics remain unchanged.

## Tests

- `scripts/check`
- `PYTHONHASHSEED=0 uv run pytest benchmarks/multipart_benchmark.py benchmarks/urlencoded_benchmark.py --codspeed -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

