### PR TITLE
Add `excluded_urls` to `OpenTelemetryMiddleware`

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -105,6 +105,36 @@ app = OpenTelemetryMiddleware(Starlette())
 
 Multiple native middleware instances on the same request create only one span.
 
+### Exclude URLs
+
+```python
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.opentelemetry import OpenTelemetryMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+
+async def homepage(request: Request) -> PlainTextResponse:
+    return PlainTextResponse("Hello, world!")
+
+
+app = Starlette(
+    routes=[Route("/", homepage), Route("/health", homepage)],
+    middleware=[
+        Middleware(
+            OpenTelemetryMiddleware,
+            excluded_urls=[r"/health$"],
+        )
+    ],
+)
+```
+
+Pass a sequence of regular expressions in `excluded_urls`. If any expression matches the full
+request URL, the middleware does not create a span. This is useful for health checks, readiness
+probes, and other high-volume endpoints that you do not need to trace.
+
 ## CORSMiddleware
 
 Adds appropriate [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) to outgoing responses in order to allow cross-origin requests from browsers.

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -125,15 +125,15 @@ app = Starlette(
     middleware=[
         Middleware(
             OpenTelemetryMiddleware,
-            excluded_urls=[r"/health$"],
+            excluded_urls=r"/health$,/readiness$",
         )
     ],
 )
 ```
 
-Pass a sequence of regular expressions in `excluded_urls`. If any expression matches the full
-request URL, the middleware does not create a span. This is useful for health checks, readiness
-probes, and other high-volume endpoints that you do not need to trace.
+Pass a comma-separated string or a sequence of regular expressions in `excluded_urls`. If any
+expression matches the full request URL, the middleware does not create a span. This is useful for
+health checks, readiness probes, and other high-volume endpoints that you do not need to trace.
 
 ## CORSMiddleware
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -107,6 +107,10 @@ Multiple native middleware instances on the same request create only one span.
 
 ### Exclude URLs
 
+Pass a comma-separated string or a sequence of regular expressions in `excluded_urls`. If any
+expression matches the full request URL, the middleware does not create a span. This is useful for
+health checks, readiness probes, and other high-volume endpoints that you do not need to trace.
+
 ```python
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -130,10 +134,6 @@ app = Starlette(
     ],
 )
 ```
-
-Pass a comma-separated string or a sequence of regular expressions in `excluded_urls`. If any
-expression matches the full request URL, the middleware does not create a span. This is useful for
-health checks, readiness probes, and other high-volume endpoints that you do not need to trace.
 
 ## CORSMiddleware
 

--- a/starlette/middleware/opentelemetry.py
+++ b/starlette/middleware/opentelemetry.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import re
+from collections.abc import Sequence
+
 try:
     from opentelemetry import propagate, trace
     from opentelemetry.trace import SpanKind, Status, StatusCode
@@ -15,8 +18,11 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 class OpenTelemetryMiddleware:
     """Create OpenTelemetry server spans for incoming HTTP requests."""
 
-    def __init__(self, app: ASGIApp) -> None:
+    def __init__(self, app: ASGIApp, *, excluded_urls: Sequence[str] = ()) -> None:
+        if isinstance(excluded_urls, str):
+            raise TypeError("`excluded_urls` must be a sequence of URL patterns, not a string")
         self.app = app
+        self._excluded_urls = tuple(re.compile(pattern) for pattern in excluded_urls)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or scope.get("starlette.opentelemetry"):
@@ -26,6 +32,10 @@ class OpenTelemetryMiddleware:
         if isinstance(tracer_provider, (trace.NoOpTracerProvider, trace.ProxyTracerProvider)):
             return await self.app(scope, receive, send)
 
+        url = URL(scope=scope)
+        if any(pattern.search(str(url)) for pattern in self._excluded_urls):
+            return await self.app(scope, receive, send)
+
         original_method = scope.get("method", "")
         method = original_method.upper()
 
@@ -33,7 +43,6 @@ class OpenTelemetryMiddleware:
         for name, value in scope.get("headers", []):
             headers.setdefault(name.decode("latin-1").lower(), []).append(value.decode("latin-1"))
 
-        url = URL(scope=scope)
         attributes: dict[str, str | int] = {
             "http.request.method": method,
             "url.path": scope.get("path", ""),

--- a/starlette/middleware/opentelemetry.py
+++ b/starlette/middleware/opentelemetry.py
@@ -34,7 +34,11 @@ class OpenTelemetryMiddleware:
 
         url = URL(scope=scope)
         if any(pattern.search(str(url)) for pattern in self._excluded_urls):
-            return await self.app(scope, receive, send)
+            scope["starlette.opentelemetry"] = True
+            try:
+                return await self.app(scope, receive, send)
+            finally:
+                del scope["starlette.opentelemetry"]
 
         original_method = scope.get("method", "")
         method = original_method.upper()

--- a/starlette/middleware/opentelemetry.py
+++ b/starlette/middleware/opentelemetry.py
@@ -22,88 +22,95 @@ class OpenTelemetryMiddleware:
         self.app = app
         if isinstance(excluded_urls, str):
             excluded_urls = [pattern.strip() for pattern in excluded_urls.split(",")] if excluded_urls else ()
-        self._excluded_urls = tuple(re.compile(pattern) for pattern in excluded_urls)
+        patterns = tuple(re.compile(pattern) for pattern in excluded_urls)
+        self._responder = OpenTelemetryResponder(app, patterns)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or scope.get("starlette.opentelemetry"):
             return await self.app(scope, receive, send)
 
+        scope["starlette.opentelemetry"] = True
+        try:
+            await self._responder(scope, receive, send)
+        finally:
+            del scope["starlette.opentelemetry"]
+
+
+class OpenTelemetryResponder:
+    def __init__(self, app: ASGIApp, excluded_urls: tuple[re.Pattern[str], ...]) -> None:
+        self.app = app
+        self._excluded_urls = excluded_urls
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         tracer_provider = trace.get_tracer_provider()
         if isinstance(tracer_provider, (trace.NoOpTracerProvider, trace.ProxyTracerProvider)):
             return await self.app(scope, receive, send)
 
         url = URL(scope=scope)
-        excluded = any(pattern.search(str(url)) for pattern in self._excluded_urls)
-        if not excluded:
-            original_method = scope.get("method", "")
-            method = original_method.upper()
+        if any(pattern.search(str(url)) for pattern in self._excluded_urls):
+            return await self.app(scope, receive, send)
 
-            headers: dict[str, list[str]] = {}
-            for name, value in scope.get("headers", []):
-                headers.setdefault(name.decode("latin-1").lower(), []).append(value.decode("latin-1"))
+        original_method = scope.get("method", "")
+        method = original_method.upper()
 
-            attributes: dict[str, str | int] = {
-                "http.request.method": method,
-                "url.path": scope.get("path", ""),
-                "url.scheme": scope.get("scheme", "http"),
-            }
-            if original_method != method:
-                attributes["http.request.method_original"] = original_method
-            if url.query:
-                attributes["url.query"] = url.query
-            if url.hostname is not None:
-                attributes["server.address"] = url.hostname
-                server = scope.get("server")
-                server_port = url.port if url.port is not None else server[1] if server is not None else None
-                if server_port is not None:
-                    attributes["server.port"] = server_port
-            if scope.get("http_version"):
-                attributes["network.protocol.version"] = scope["http_version"]
-            if scope.get("client") is not None:
-                attributes["client.address"] = scope["client"][0]
-            if headers.get("user-agent"):
-                attributes["user_agent.original"] = headers["user-agent"][0]
+        headers: dict[str, list[str]] = {}
+        for name, value in scope.get("headers", []):
+            headers.setdefault(name.decode("latin-1").lower(), []).append(value.decode("latin-1"))
 
-        scope["starlette.opentelemetry"] = True
+        attributes: dict[str, str | int] = {
+            "http.request.method": method,
+            "url.path": scope.get("path", ""),
+            "url.scheme": scope.get("scheme", "http"),
+        }
+        if original_method != method:
+            attributes["http.request.method_original"] = original_method
+        if url.query:
+            attributes["url.query"] = url.query
+        if url.hostname is not None:
+            attributes["server.address"] = url.hostname
+            server = scope.get("server")
+            server_port = url.port if url.port is not None else server[1] if server is not None else None
+            if server_port is not None:
+                attributes["server.port"] = server_port
+        if scope.get("http_version"):
+            attributes["network.protocol.version"] = scope["http_version"]
+        if scope.get("client") is not None:
+            attributes["client.address"] = scope["client"][0]
+        if headers.get("user-agent"):
+            attributes["user_agent.original"] = headers["user-agent"][0]
 
-        try:
-            if excluded:
-                return await self.app(scope, receive, send)
+        with tracer_provider.get_tracer("starlette", __version__).start_as_current_span(
+            method,
+            context=propagate.extract(headers),
+            kind=SpanKind.SERVER,
+            attributes=attributes,
+        ) as span:
 
-            with tracer_provider.get_tracer("starlette", __version__).start_as_current_span(
-                method,
-                context=propagate.extract(headers),
-                kind=SpanKind.SERVER,
-                attributes=attributes,
-            ) as span:
+            async def send_with_telemetry(message: Message) -> None:
+                if message["type"] == "http.response.start":
+                    status_code = message["status"]
+                    span.set_attribute("http.response.status_code", status_code)
+                    if status_code >= 500:
+                        span.set_attribute("error.type", str(status_code))
+                        span.set_status(Status(StatusCode.ERROR))
+                await send(message)
 
-                async def send_with_telemetry(message: Message) -> None:
-                    if message["type"] == "http.response.start":
-                        status_code = message["status"]
-                        span.set_attribute("http.response.status_code", status_code)
-                        if status_code >= 500:
-                            span.set_attribute("error.type", str(status_code))
-                            span.set_status(Status(StatusCode.ERROR))
-                    await send(message)
-
-                try:
-                    await self.app(scope, receive, send_with_telemetry)
-                except Exception as exc:
-                    span.set_attribute("error.type", type(exc).__qualname__)
-                    raise
-                finally:
-                    route = scope.get("route")
-                    if isinstance(route, Mount):
-                        route_path = scope.get("root_path") or "/"
-                    else:
-                        path_format = getattr(route, "path_format", None)
-                        route_path = (
-                            scope.get("root_path", "").rstrip("/") + path_format or "/"
-                            if isinstance(path_format, str)
-                            else None
-                        )
-                    if route_path is not None:
-                        span.update_name(f"{method} {route_path}")
-                        span.set_attribute("http.route", route_path)
-        finally:
-            del scope["starlette.opentelemetry"]
+            try:
+                await self.app(scope, receive, send_with_telemetry)
+            except Exception as exc:
+                span.set_attribute("error.type", type(exc).__qualname__)
+                raise
+            finally:
+                route = scope.get("route")
+                if isinstance(route, Mount):
+                    route_path = scope.get("root_path") or "/"
+                else:
+                    path_format = getattr(route, "path_format", None)
+                    route_path = (
+                        scope.get("root_path", "").rstrip("/") + path_format or "/"
+                        if isinstance(path_format, str)
+                        else None
+                    )
+                if route_path is not None:
+                    span.update_name(f"{method} {route_path}")
+                    span.set_attribute("http.route", route_path)

--- a/starlette/middleware/opentelemetry.py
+++ b/starlette/middleware/opentelemetry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
+from dataclasses import KW_ONLY, InitVar, dataclass, field
 
 try:
     from opentelemetry import propagate, trace
@@ -20,10 +21,7 @@ class OpenTelemetryMiddleware:
 
     def __init__(self, app: ASGIApp, *, excluded_urls: str | Sequence[str] = ()) -> None:
         self.app = app
-        if isinstance(excluded_urls, str):
-            excluded_urls = [pattern.strip() for pattern in excluded_urls.split(",")] if excluded_urls else ()
-        patterns = tuple(re.compile(pattern) for pattern in excluded_urls)
-        self._responder = OpenTelemetryResponder(app, patterns)
+        self._responder = OpenTelemetryResponder(app, excluded_urls=excluded_urls)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or scope.get("starlette.opentelemetry"):
@@ -36,10 +34,17 @@ class OpenTelemetryMiddleware:
             del scope["starlette.opentelemetry"]
 
 
+@dataclass(frozen=True)
 class OpenTelemetryResponder:
-    def __init__(self, app: ASGIApp, excluded_urls: tuple[re.Pattern[str], ...]) -> None:
-        self.app = app
-        self._excluded_urls = excluded_urls
+    app: ASGIApp
+    _: KW_ONLY
+    excluded_urls: InitVar[str | Sequence[str]] = ()
+    _excluded_urls: tuple[re.Pattern[str], ...] = field(init=False)
+
+    def __post_init__(self, excluded_urls: str | Sequence[str]) -> None:
+        if isinstance(excluded_urls, str):
+            excluded_urls = [pattern.strip() for pattern in excluded_urls.split(",")] if excluded_urls else ()
+        object.__setattr__(self, "_excluded_urls", tuple(re.compile(pattern) for pattern in excluded_urls))
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         tracer_provider = trace.get_tracer_provider()

--- a/starlette/middleware/opentelemetry.py
+++ b/starlette/middleware/opentelemetry.py
@@ -19,9 +19,9 @@ class OpenTelemetryMiddleware:
     """Create OpenTelemetry server spans for incoming HTTP requests."""
 
     def __init__(self, app: ASGIApp, *, excluded_urls: str | Sequence[str] = ()) -> None:
+        self.app = app
         if isinstance(excluded_urls, str):
             excluded_urls = [pattern.strip() for pattern in excluded_urls.split(",")] if excluded_urls else ()
-        self.app = app
         self._excluded_urls = tuple(re.compile(pattern) for pattern in excluded_urls)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/starlette/middleware/opentelemetry.py
+++ b/starlette/middleware/opentelemetry.py
@@ -33,45 +33,43 @@ class OpenTelemetryMiddleware:
             return await self.app(scope, receive, send)
 
         url = URL(scope=scope)
-        if any(pattern.search(str(url)) for pattern in self._excluded_urls):
-            scope["starlette.opentelemetry"] = True
-            try:
-                return await self.app(scope, receive, send)
-            finally:
-                del scope["starlette.opentelemetry"]
+        excluded = any(pattern.search(str(url)) for pattern in self._excluded_urls)
+        if not excluded:
+            original_method = scope.get("method", "")
+            method = original_method.upper()
 
-        original_method = scope.get("method", "")
-        method = original_method.upper()
+            headers: dict[str, list[str]] = {}
+            for name, value in scope.get("headers", []):
+                headers.setdefault(name.decode("latin-1").lower(), []).append(value.decode("latin-1"))
 
-        headers: dict[str, list[str]] = {}
-        for name, value in scope.get("headers", []):
-            headers.setdefault(name.decode("latin-1").lower(), []).append(value.decode("latin-1"))
-
-        attributes: dict[str, str | int] = {
-            "http.request.method": method,
-            "url.path": scope.get("path", ""),
-            "url.scheme": scope.get("scheme", "http"),
-        }
-        if original_method != method:
-            attributes["http.request.method_original"] = original_method
-        if url.query:
-            attributes["url.query"] = url.query
-        if url.hostname is not None:
-            attributes["server.address"] = url.hostname
-            server = scope.get("server")
-            server_port = url.port if url.port is not None else server[1] if server is not None else None
-            if server_port is not None:
-                attributes["server.port"] = server_port
-        if scope.get("http_version"):
-            attributes["network.protocol.version"] = scope["http_version"]
-        if scope.get("client") is not None:
-            attributes["client.address"] = scope["client"][0]
-        if headers.get("user-agent"):
-            attributes["user_agent.original"] = headers["user-agent"][0]
+            attributes: dict[str, str | int] = {
+                "http.request.method": method,
+                "url.path": scope.get("path", ""),
+                "url.scheme": scope.get("scheme", "http"),
+            }
+            if original_method != method:
+                attributes["http.request.method_original"] = original_method
+            if url.query:
+                attributes["url.query"] = url.query
+            if url.hostname is not None:
+                attributes["server.address"] = url.hostname
+                server = scope.get("server")
+                server_port = url.port if url.port is not None else server[1] if server is not None else None
+                if server_port is not None:
+                    attributes["server.port"] = server_port
+            if scope.get("http_version"):
+                attributes["network.protocol.version"] = scope["http_version"]
+            if scope.get("client") is not None:
+                attributes["client.address"] = scope["client"][0]
+            if headers.get("user-agent"):
+                attributes["user_agent.original"] = headers["user-agent"][0]
 
         scope["starlette.opentelemetry"] = True
 
         try:
+            if excluded:
+                return await self.app(scope, receive, send)
+
             with tracer_provider.get_tracer("starlette", __version__).start_as_current_span(
                 method,
                 context=propagate.extract(headers),

--- a/starlette/middleware/opentelemetry.py
+++ b/starlette/middleware/opentelemetry.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
-from dataclasses import KW_ONLY, InitVar, dataclass, field
 
 try:
     from opentelemetry import propagate, trace
@@ -21,7 +20,10 @@ class OpenTelemetryMiddleware:
 
     def __init__(self, app: ASGIApp, *, excluded_urls: str | Sequence[str] = ()) -> None:
         self.app = app
-        self._responder = OpenTelemetryResponder(app, excluded_urls=excluded_urls)
+        if isinstance(excluded_urls, str):
+            excluded_urls = [pattern.strip() for pattern in excluded_urls.split(",")] if excluded_urls else ()
+        patterns = tuple(re.compile(pattern) for pattern in excluded_urls)
+        self._responder = OpenTelemetryResponder(app, patterns)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or scope.get("starlette.opentelemetry"):
@@ -34,17 +36,10 @@ class OpenTelemetryMiddleware:
             del scope["starlette.opentelemetry"]
 
 
-@dataclass(frozen=True)
 class OpenTelemetryResponder:
-    app: ASGIApp
-    _: KW_ONLY
-    excluded_urls: InitVar[str | Sequence[str]] = ()
-    _excluded_urls: tuple[re.Pattern[str], ...] = field(init=False)
-
-    def __post_init__(self, excluded_urls: str | Sequence[str]) -> None:
-        if isinstance(excluded_urls, str):
-            excluded_urls = [pattern.strip() for pattern in excluded_urls.split(",")] if excluded_urls else ()
-        object.__setattr__(self, "_excluded_urls", tuple(re.compile(pattern) for pattern in excluded_urls))
+    def __init__(self, app: ASGIApp, excluded_urls: tuple[re.Pattern[str], ...]) -> None:
+        self.app = app
+        self._excluded_urls = excluded_urls
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         tracer_provider = trace.get_tracer_provider()

--- a/starlette/middleware/opentelemetry.py
+++ b/starlette/middleware/opentelemetry.py
@@ -18,9 +18,9 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 class OpenTelemetryMiddleware:
     """Create OpenTelemetry server spans for incoming HTTP requests."""
 
-    def __init__(self, app: ASGIApp, *, excluded_urls: Sequence[str] = ()) -> None:
+    def __init__(self, app: ASGIApp, *, excluded_urls: str | Sequence[str] = ()) -> None:
         if isinstance(excluded_urls, str):
-            raise TypeError("`excluded_urls` must be a sequence of URL patterns, not a string")
+            excluded_urls = [pattern.strip() for pattern in excluded_urls.split(",")] if excluded_urls else ()
         self.app = app
         self._excluded_urls = tuple(re.compile(pattern) for pattern in excluded_urls)
 

--- a/tests/middleware/test_opentelemetry.py
+++ b/tests/middleware/test_opentelemetry.py
@@ -55,6 +55,32 @@ def test_noop_provider_skips_instrumentation(
     assert test_client_factory(app).get("/").status_code == 200
 
 
+def test_excluded_urls_are_not_traced(
+    test_client_factory: TestClientFactory,
+    tracer_provider: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    _, exporter = tracer_provider
+    app = Starlette(
+        routes=[Route("/", homepage), Route("/health", homepage)],
+        middleware=[
+            Middleware(
+                OpenTelemetryMiddleware,
+                excluded_urls=[r"/health(?:\?.*)?$"],
+            )
+        ],
+    )
+
+    assert test_client_factory(app).get("/health?full=true").status_code == 200
+    assert exporter.get_finished_spans() == ()
+    assert test_client_factory(app).get("/").status_code == 200
+    assert get_span(exporter).name == "GET /"
+
+
+def test_excluded_urls_rejects_string() -> None:
+    with pytest.raises(TypeError, match="must be a sequence of URL patterns"):
+        OpenTelemetryMiddleware(PlainTextResponse("OK"), excluded_urls="/health")
+
+
 def test_multiple_native_middlewares_do_not_create_duplicate_span(
     test_client_factory: TestClientFactory,
     tracer_provider: tuple[TracerProvider, InMemorySpanExporter],

--- a/tests/middleware/test_opentelemetry.py
+++ b/tests/middleware/test_opentelemetry.py
@@ -129,6 +129,24 @@ def test_multiple_native_middlewares_do_not_create_duplicate_span(
     assert get_span(exporter).name == "GET /"
 
 
+def test_exclusion_propagates_to_nested_native_middleware(
+    test_client_factory: TestClientFactory,
+    tracer_provider: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    _, exporter = tracer_provider
+    mounted_app = Starlette(
+        routes=[Route("/health", homepage)],
+        middleware=[Middleware(OpenTelemetryMiddleware)],
+    )
+    app = Starlette(
+        routes=[Mount("/api", app=mounted_app)],
+        middleware=[Middleware(OpenTelemetryMiddleware, excluded_urls=[r"/api/health$"])],
+    )
+
+    assert test_client_factory(app).get("/api/health").status_code == 200
+    assert exporter.get_finished_spans() == ()
+
+
 def test_provider_configured_after_middleware_stack_is_built(
     monkeypatch: pytest.MonkeyPatch,
     test_client_factory: TestClientFactory,

--- a/tests/middleware/test_opentelemetry.py
+++ b/tests/middleware/test_opentelemetry.py
@@ -55,9 +55,14 @@ def test_noop_provider_skips_instrumentation(
     assert test_client_factory(app).get("/").status_code == 200
 
 
+@pytest.mark.parametrize(
+    "excluded_urls",
+    ([r"/health(?:\?.*)?$"], r"/health(?:\?.*)?$"),
+)
 def test_excluded_urls_are_not_traced(
     test_client_factory: TestClientFactory,
     tracer_provider: tuple[TracerProvider, InMemorySpanExporter],
+    excluded_urls: str | list[str],
 ) -> None:
     _, exporter = tracer_provider
     app = Starlette(
@@ -65,7 +70,7 @@ def test_excluded_urls_are_not_traced(
         middleware=[
             Middleware(
                 OpenTelemetryMiddleware,
-                excluded_urls=[r"/health(?:\?.*)?$"],
+                excluded_urls=excluded_urls,
             )
         ],
     )
@@ -76,9 +81,38 @@ def test_excluded_urls_are_not_traced(
     assert get_span(exporter).name == "GET /"
 
 
-def test_excluded_urls_rejects_string() -> None:
-    with pytest.raises(TypeError, match="must be a sequence of URL patterns"):
-        OpenTelemetryMiddleware(PlainTextResponse("OK"), excluded_urls="/health")
+def test_empty_excluded_urls_traces_request(
+    test_client_factory: TestClientFactory,
+    tracer_provider: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    _, exporter = tracer_provider
+    app = Starlette(
+        routes=[Route("/", homepage)],
+        middleware=[Middleware(OpenTelemetryMiddleware, excluded_urls="")],
+    )
+
+    assert test_client_factory(app).get("/").status_code == 200
+    assert get_span(exporter).name == "GET /"
+
+
+def test_excluded_urls_accepts_comma_separated_string(
+    test_client_factory: TestClientFactory,
+    tracer_provider: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    _, exporter = tracer_provider
+    app = Starlette(
+        routes=[Route("/health", homepage), Route("/metrics", homepage)],
+        middleware=[
+            Middleware(
+                OpenTelemetryMiddleware,
+                excluded_urls=r"/health$, /metrics$",
+            )
+        ],
+    )
+
+    assert test_client_factory(app).get("/health").status_code == 200
+    assert test_client_factory(app).get("/metrics").status_code == 200
+    assert exporter.get_finished_spans() == ()
 
 
 def test_multiple_native_middlewares_do_not_create_duplicate_span(

--- a/tests/middleware/test_opentelemetry.py
+++ b/tests/middleware/test_opentelemetry.py
@@ -56,63 +56,32 @@ def test_noop_provider_skips_instrumentation(
 
 
 @pytest.mark.parametrize(
-    "excluded_urls",
-    ([r"/health(?:\?.*)?$"], r"/health(?:\?.*)?$"),
+    ("excluded_urls", "excluded_paths"),
+    [
+        ([r"^http://testserver/health(?:\?.*)?$"], ("/health?full=true",)),
+        (r"/health(?:\?.*)?$", ("/health?full=true",)),
+        (r"/health$, /metrics$", ("/health", "/metrics")),
+        ("", ()),
+    ],
 )
-def test_excluded_urls_are_not_traced(
+def test_excluded_urls(
     test_client_factory: TestClientFactory,
     tracer_provider: tuple[TracerProvider, InMemorySpanExporter],
     excluded_urls: str | list[str],
+    excluded_paths: tuple[str, ...],
 ) -> None:
     _, exporter = tracer_provider
     app = Starlette(
-        routes=[Route("/", homepage), Route("/health", homepage)],
-        middleware=[
-            Middleware(
-                OpenTelemetryMiddleware,
-                excluded_urls=excluded_urls,
-            )
-        ],
+        routes=[Route("/", homepage), Route("/health", homepage), Route("/metrics", homepage)],
+        middleware=[Middleware(OpenTelemetryMiddleware, excluded_urls=excluded_urls)],
     )
+    client = test_client_factory(app)
 
-    assert test_client_factory(app).get("/health?full=true").status_code == 200
+    for path in excluded_paths:
+        assert client.get(path).status_code == 200
     assert exporter.get_finished_spans() == ()
-    assert test_client_factory(app).get("/").status_code == 200
+    assert client.get("/").status_code == 200
     assert get_span(exporter).name == "GET /"
-
-
-def test_empty_excluded_urls_traces_request(
-    test_client_factory: TestClientFactory,
-    tracer_provider: tuple[TracerProvider, InMemorySpanExporter],
-) -> None:
-    _, exporter = tracer_provider
-    app = Starlette(
-        routes=[Route("/", homepage)],
-        middleware=[Middleware(OpenTelemetryMiddleware, excluded_urls="")],
-    )
-
-    assert test_client_factory(app).get("/").status_code == 200
-    assert get_span(exporter).name == "GET /"
-
-
-def test_excluded_urls_accepts_comma_separated_string(
-    test_client_factory: TestClientFactory,
-    tracer_provider: tuple[TracerProvider, InMemorySpanExporter],
-) -> None:
-    _, exporter = tracer_provider
-    app = Starlette(
-        routes=[Route("/health", homepage), Route("/metrics", homepage)],
-        middleware=[
-            Middleware(
-                OpenTelemetryMiddleware,
-                excluded_urls=r"/health$, /metrics$",
-            )
-        ],
-    )
-
-    assert test_client_factory(app).get("/health").status_code == 200
-    assert test_client_factory(app).get("/metrics").status_code == 200
-    assert exporter.get_finished_spans() == ()
 
 
 def test_multiple_native_middlewares_do_not_create_duplicate_span(


### PR DESCRIPTION
## Summary

- add an `excluded_urls` parameter to `OpenTelemetryMiddleware`
- accept a sequence of regular expressions or a comma-separated string
- compile each expression once when constructing the middleware
- skip spans when an expression matches the full request URL
- document exclusions for health checks and similar endpoints

## Validation

- `./scripts/check`
- `uv run pytest tests/middleware/test_opentelemetry.py`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
