### PR TITLE
Run class-keyed exception handlers after the response has started

### DIFF
--- a/starlette/_exception_handler.py
+++ b/starlette/_exception_handler.py
@@ -53,7 +53,13 @@ def wrap_app_handling_exceptions(app: ASGIApp, conn: Request | WebSocket) -> ASG
                 raise exc
 
             if response_started:
-                raise RuntimeError("Caught handled exception, but response already started.") from exc
+                if not scope.get("starlette.exception_handler_called"):
+                    scope["starlette.exception_handler_called"] = True
+                    if is_async_callable(handler):
+                        await handler(conn, exc)  # type: ignore[arg-type]
+                    else:
+                        await run_in_threadpool(handler, conn, exc)  # type: ignore[arg-type]
+                raise exc
 
             if is_async_callable(handler):
                 response = await handler(conn, exc)  # type: ignore[arg-type]

--- a/tests/middleware/test_errors.py
+++ b/tests/middleware/test_errors.py
@@ -103,3 +103,35 @@ def test_background_task(test_client_factory: TestClientFactory) -> None:
     response = client.get("/")
     assert response.status_code == 204
     assert accessed_error_handler
+
+
+def test_class_keyed_handler_after_background_task(test_client_factory: TestClientFactory) -> None:
+    seen: list[Exception] = []
+
+    class Boom(Exception):
+        pass
+
+    def boom_handler(request: Request, exc: Exception) -> JSONResponse:
+        seen.append(exc)
+        return JSONResponse({"detail": "handled"}, status_code=500)
+
+    def fail() -> None:
+        raise Boom("task blew up")
+
+    async def endpoint(request: Request) -> Response:
+        return Response(status_code=204, background=BackgroundTask(fail))
+
+    app = Starlette(
+        routes=[Route("/", endpoint=endpoint)],
+        exception_handlers={Boom: boom_handler},
+    )
+
+    client = test_client_factory(app, raise_server_exceptions=False)
+    response = client.get("/")
+    assert response.status_code == 204
+    assert len(seen) == 1
+    assert isinstance(seen[0], Boom)
+
+    with pytest.raises(Boom, match="task blew up"):
+        test_client_factory(app).get("/")
+    assert len(seen) == 2

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -113,9 +113,10 @@ def test_websockets_should_raise(client: TestClient) -> None:
 
 def test_handled_exc_after_response(test_client_factory: TestClientFactory, client: TestClient) -> None:
     # A 406 HttpException is raised *after* the response has already been sent.
-    # The exception middleware should raise a RuntimeError.
-    with pytest.raises(RuntimeError, match="Caught handled exception, but response already started."):
+    # The handler still runs; the original exception is re-raised.
+    with pytest.raises(HTTPException) as exc_info:
         client.get("/handled_exc_after_response")
+    assert exc_info.value.status_code == 406
 
     # If `raise_server_exceptions=False` then the test client will still allow
     # us to see the response as it will have been seen by the client.


### PR DESCRIPTION
Background tasks that raise a custom exception never reached a handler registered as `{Boom: handler}`. ExceptionMiddleware found the handler, then bailed out with `RuntimeError: Caught handled exception, but response already started` before calling it. Handlers keyed as `Exception` or `500` go through ServerErrorMiddleware instead, which is why those appeared to work.

This runs the handler anyway (its response is dropped, same as the docs describe for `Exception`/`500`) and re-raises the original error so TestClient / the server still see `Boom` rather than that RuntimeError wrapper.

Router and ExceptionMiddleware both wrap the app, so the handler is only invoked once per exception via a flag on the scope.

Fixes #3459


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

