### PR TITLE
Index routes by exact path and static prefix

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -276,6 +276,10 @@ routes = [
 ]
 ```
 
+A `Route`, `WebSocketRoute`, or `Mount` subclass may narrow matching or add
+values to the child scope. It must not match paths outside its declared `path`.
+Implement `BaseRoute` directly when you need independent path-matching behavior.
+
 ## Working with Router instances
 
 If you're working at a low-level you might want to use a plain `Router`

--- a/starlette/_route_index.py
+++ b/starlette/_route_index.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import heapq
+from collections.abc import Iterable, Sequence
+
+
+class RouteIndex:
+    """Find route candidates in O(N) worst-case time."""
+
+    def __init__(self, routes: Sequence[object] | None = None) -> None:
+        self._routes = None if routes is None else list(routes)
+        self._exact: dict[str, list[int]] = {}
+        self._prefix: dict[str, list[int]] = {}
+        self._fallback: list[int] = []
+
+    def is_stale(self, routes: Sequence[object]) -> bool:
+        return self._routes != routes
+
+    def add_exact(self, index: int, path: str) -> None:
+        self._exact.setdefault(path, []).append(index)
+
+    def add_prefix(self, index: int, path: str) -> None:
+        segment = path.lstrip("/").partition("/")[0]
+        if not segment or "{" in segment:
+            self._fallback.append(index)
+        else:
+            self._prefix.setdefault(segment, []).append(index)
+
+    def add_fallback(self, index: int) -> None:
+        self._fallback.append(index)
+
+    def match(self, path: str) -> Iterable[int]:
+        groups: list[list[int]] = []
+        exact = self._exact.get(path)
+        if exact is not None:
+            groups.append(exact)
+
+        segment = path.lstrip("/").partition("/")[0]
+        prefix = self._prefix.get(segment)
+        if prefix is not None:
+            groups.append(prefix)
+        if self._fallback:
+            groups.append(self._fallback)
+
+        if len(groups) == 1:
+            return groups[0]
+        return heapq.merge(*groups)

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -7,13 +7,14 @@ import re
 import traceback
 import types
 import warnings
-from collections.abc import Awaitable, Callable, Collection, Generator, Sequence
+from collections.abc import Awaitable, Callable, Collection, Generator, Iterator, Sequence
 from contextlib import AbstractAsyncContextManager, AbstractContextManager, asynccontextmanager
 from enum import Enum
 from re import Pattern
 from typing import Any, TypeVar
 
 from starlette._exception_handler import wrap_app_handling_exceptions
+from starlette._route_index import RouteIndex
 from starlette._utils import get_route_path, is_async_callable
 from starlette.concurrency import run_in_threadpool
 from starlette.convertors import CONVERTOR_TYPES, Convertor
@@ -584,6 +585,7 @@ class Router:
         max_body_size: int | None = None,
     ) -> None:
         self.routes = [] if routes is None else list(routes)
+        self._route_index = RouteIndex()
         self.redirect_slashes = redirect_slashes
         self.default = self.not_found if default is None else default
 
@@ -669,6 +671,26 @@ class Router:
         """
         await self.middleware_stack(scope, receive, send)
 
+    def _candidate_routes(self, scope: Scope) -> Iterator[BaseRoute]:
+        routes = self.routes
+        if self._route_index.is_stale(routes):
+            route_index = RouteIndex(routes)
+            for index, route in enumerate(routes):
+                if isinstance(route, (Route, WebSocketRoute)):
+                    if route.param_convertors:
+                        route_index.add_prefix(index, route.path)
+                    else:
+                        route_index.add_exact(index, route.path)
+                elif isinstance(route, Mount):
+                    route_index.add_prefix(index, route.path)
+                else:
+                    route_index.add_fallback(index)
+            self._route_index = route_index
+        candidates = self._route_index.match(get_route_path(scope))
+        if isinstance(candidates, Sequence) and len(candidates) == len(routes):
+            return iter(routes)
+        return (routes[index] for index in candidates)
+
     async def app(self, scope: Scope, receive: Receive, send: Send) -> None:
         assert scope["type"] in ("http", "websocket", "lifespan")
 
@@ -681,7 +703,7 @@ class Router:
 
         partial = None
 
-        for route in self.routes:
+        for route in self._candidate_routes(scope):
             # Determine if any route matches the incoming scope,
             # and hand over to the matching route if found.
             match, child_scope = route.matches(scope)
@@ -711,7 +733,7 @@ class Router:
             else:
                 redirect_scope["path"] = redirect_scope["path"] + "/"
 
-            for route in self.routes:
+            for route in self._candidate_routes(redirect_scope):
                 match, child_scope = route.matches(redirect_scope)
                 if match != Match.NONE:
                     redirect_url = URL(scope=redirect_scope)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -15,7 +15,7 @@ from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response
-from starlette.routing import Host, Mount, NoMatchFound, Route, Router, WebSocketRoute
+from starlette.routing import Host, Match, Mount, NoMatchFound, Route, Router, WebSocketRoute
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect
@@ -298,6 +298,43 @@ def test_router_add_route(client: TestClient) -> None:
     assert response.text == "Hello, world!"
 
 
+def test_router_rebuilds_route_index_after_routes_change(test_client_factory: TestClientFactory) -> None:
+    router = Router(routes=[Route("/first", endpoint=homepage), Route("/second", endpoint=homepage)])
+    client = test_client_factory(router)
+    assert client.get("/first").status_code == 200
+
+    router.routes[0] = Route("/replacement", endpoint=homepage)
+    assert client.get("/replacement").status_code == 200
+
+    router.routes.reverse()
+    assert client.get("/second").status_code == 200
+
+
+def test_router_preserves_order_across_index_groups(test_client_factory: TestClientFactory) -> None:
+    router = Router(
+        routes=[
+            Host("testserver", app=PlainTextResponse("fallback")),
+            Route("/resource/{name}", endpoint=PlainTextResponse("prefix")),
+            Route("/resource/item", endpoint=PlainTextResponse("exact")),
+        ]
+    )
+    assert test_client_factory(router).get("/resource/item").text == "fallback"
+
+
+def test_route_subclass_uses_declared_path(test_client_factory: TestClientFactory) -> None:
+    class AnnotatingRoute(Route):
+        def matches(self, scope: Scope) -> tuple[Match, Scope]:
+            match, child_scope = super().matches(scope)
+            child_scope["route"] = self
+            return match, child_scope
+
+    def endpoint(request: Request) -> PlainTextResponse:
+        return PlainTextResponse(type(request.scope["route"]).__name__)
+
+    router = Router(routes=[AnnotatingRoute("/annotated", endpoint=endpoint)])
+    assert test_client_factory(router).get("/annotated").text == "AnnotatingRoute"
+
+
 def test_router_duplicate_path(client: TestClient) -> None:
     response = client.post("/func")
     assert response.status_code == 200
@@ -305,6 +342,8 @@ def test_router_duplicate_path(client: TestClient) -> None:
 
 
 def test_router_add_websocket_route(client: TestClient) -> None:
+    assert client.get("/ws").status_code == 404
+
     with client.websocket_connect("/ws") as session:
         text = session.receive_text()
         assert text == "Hello, world!"


### PR DESCRIPTION
## Summary

Provides an O(N) alternative to the segment trie in [#3339](https://github.com/Kludex/starlette/pull/3339). The index keeps three disjoint groups:

- Exact static paths
- Dynamic routes and mounts grouped by their first static segment
- Routes without a static first segment

Each group is built in registration order. A lookup combines at most three groups with `heapq.merge`, so it preserves first-registered-wins without sorting the complete candidate set. Matching remains lazy and stops after the first full match.

Routes that follow the declared-path contract are indexed automatically. `Host` and custom `BaseRoute` implementations remain candidates for every path. A shallow route-list snapshot rebuilds the index lazily after mutations.

## Complexity

Lookup is O(N) in the worst case. In ordinary cases it is O(C), where C is the number of routes in the exact, prefix, and fallback groups selected for the request.

## Benchmarks

The benchmark dispatches requests through the public `Router` ASGI application and includes response construction and both ASGI sends. Results are median microseconds across four processes on Python 3.14.3. Each process ran nine rounds of 3,000 requests per scenario.

### 500 static routes with distinct first segments

| Scenario | `main` | Route index | Trie [#3339](https://github.com/Kludex/starlette/pull/3339) |
|---|---:|---:|---:|
| First route | 2.80 us | 3.65 us | 3.61 us |
| Last route | 103.47 us | 3.63 us | 3.56 us |
| 404 miss | 182.26 us | 3.46 us | 2.73 us |
| 405 | 101.94 us | 3.02 us | 2.94 us |

### 500 dynamic routes sharing the same first segment

| Scenario | `main` | Route index | Trie [#3339](https://github.com/Kludex/starlette/pull/3339) |
|---|---:|---:|---:|
| First route | 3.06 us | 3.83 us | 4.20 us |
| Last route | 118.23 us | 116.91 us | 4.23 us |
| 404 miss | 217.31 us | 218.89 us | 3.28 us |
| 405 | 115.32 us | 116.20 us | 3.58 us |

The route index matches the trie for distinct prefixes with less code and an O(N) worst-case bound. The trie is substantially more selective when many dynamic routes share a prefix.

## Tests

- `scripts/test` - 1106 passed, 2 skipped, 2 xfailed
- 100% coverage

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

