### PR TITLE
Document `WebSocketException` code as required

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -144,6 +144,6 @@ app = Starlette(routes=[WebSocketRoute("/ws", websocket_endpoint)])
 
 You can use the `WebSocketException` class to raise errors inside of WebSocket endpoints.
 
-* `WebSocketException(code=1008, reason=None)`
+* `WebSocketException(code, reason=None)`
 
 You can set any code valid as defined [in the specification](https://tools.ietf.org/html/rfc6455#section-7.4.1).


### PR DESCRIPTION
# Summary

Document that `WebSocketException.code` is required, matching its constructor signature.

Closes #3460.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] This documentation-only change does not require a test.
- [x] I've updated the documentation accordingly.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

