### PR TITLE
fix(base): run inner app background tasks after the response is fully sent

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -132,6 +132,12 @@ class BaseHTTPMiddleware:
             async def send_no_error(message: Message) -> None:
                 try:
                     await send_stream.send(message)
+                    if message["type"] == "http.response.body" and not message.get("more_body", False):
+                        # Hold the inner application until the response has
+                        # actually been sent, so background tasks it attaches
+                        # only run once the last byte has reached the client,
+                        # as documented in starlette.io/background.
+                        await response_sent.wait()
                 except anyio.BrokenResourceError:
                     # recv_stream has been closed, i.e. response_sent has been set.
                     return

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1316,3 +1316,52 @@ def test_error_context_propagation(test_client_factory: TestClientFactory) -> No
     assert str(ctx.value) == "Outer exception"
     assert ctx.value.__cause__ is not None
     assert str(ctx.value.__cause__) == "Inner exception"
+
+
+# https://github.com/encode/starlette/issues/3458
+@pytest.mark.anyio
+async def test_background_task_runs_after_response_fully_sent() -> None:
+    """A background task attached by the inner app must run only after the last
+    byte of the response has been sent, even with BaseHTTPMiddleware stacked."""
+
+    async def bg() -> None:
+        events.append("background-done")
+
+    events: list[str] = []
+
+    async def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("hello", background=BackgroundTask(bg))
+
+    async def passthrough(
+        request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        return await call_next(request)
+
+    app: ASGIApp = Starlette(routes=[Route("/", homepage)])
+    app = BaseHTTPMiddleware(app, dispatch=passthrough)
+
+    async def receive() -> Message:
+        return {"type": "http.request"}
+
+    async def send(message: Message) -> None:
+        # A deliberately slow client: without the fix, the inner app's
+        # background task runs while the response is still being streamed.
+        await anyio.sleep(0.05)
+        events.append(str(message["type"]))
+
+    scope: Scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+        "query_string": b"",
+        "root_path": "",
+    }
+    await app(scope, receive, send)  # type: ignore[arg-type]
+
+    assert events == [
+        "http.response.start",
+        "http.response.body",
+        "http.response.body",
+        "background-done",
+    ]


### PR DESCRIPTION
## Description

With `BaseHTTPMiddleware` anywhere in the stack, a `BackgroundTask` attached by the inner application starts running **before the last byte of the response has been sent** to the client, violating the documented contract that background tasks "run only once the response has been sent".

Deterministic repro (slow client simulates delivery latency):

```
http.response.start             @t+0.000
http.response.body(more=True)   @t+0.155
background-done                 @t+0.155   <-- task finished here
http.response.body(more=False)  @t+0.310   <-- last byte only here
```

### Cause

`BaseHTTPMiddleware.coro()` runs the inner app to completion — including its background tasks — as soon as its messages have been handed off into the internal memory stream, independently of when `_StreamingResponse` actually forwards them to the server.

### Fix

In `send_no_error`, after handing off the final body message (`more_body: false`), hold the inner application until `response_sent` is set. This serializes: inner app finishes sending → outer response fully streamed → inner app's background tasks run. There is no deadlock: `response_sent` is set by the outer flow after `await response(...)` returns, which does not depend on the inner app completing.

## Testing

New test `test_background_task_runs_after_response_fully_sent` drives the raw ASGI callable with a deliberately slow `send` and asserts the exact event ordering (start, chunk, final body, then background-done).

- Red/green verified: the test fails on unpatched `main` (`'background-done' != 'http.response.body'` at index 1) and passes with the fix.
- Full `tests/middleware/test_base.py`: **61 passed, 2 xfailed** — no regressions.

Fixes #3458

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

