### PR TITLE
Normalize glibc string operations in CodSpeed benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       PYTHONHASHSEED: "0"
       # https://sourceware.org/glibc/manual/latest/html_node/Hardware-Capability-Tunables.html
-      GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX512F,-AVX512VL,-AVX512BW"
+      GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX512F,-AVX512VL,-AVX512BW,-ERMS,-FSRM"
 
     steps:
       - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1


### PR DESCRIPTION
## Summary

Disable glibc's ERMS and FSRM dispatch during CodSpeed runs. This avoids vendor-specific `REP MOVSB` thresholds after Intel and AMD runners produced different simulated costs in `__memcpy_avx_unaligned_erms` for identical multipart workloads.

This intentionally shifts the simulation baseline once. It keeps allocation and copy costs in the benchmarks instead of excluding them from measurement.

## Tests

- `scripts/check`
- Workflow YAML parsing with PyYAML

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

