### PR TITLE
Support IPv6 hosts in `TrustedHostMiddleware`

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -290,8 +290,9 @@ app = Starlette(routes=routes, middleware=middleware)
 The following arguments are supported:
 
 * `allowed_hosts` - A list of domain names that should be allowed as hostnames. Wildcard
-domains such as `*.example.com` are supported for matching subdomains. To allow any
-hostname either use `allowed_hosts=["*"]` or omit the middleware.
+domains such as `*.example.com` are supported for matching subdomains. Use bracketed
+notation for IPv6 addresses, such as `allowed_hosts=["[::1]"]`. To allow any hostname,
+use `allowed_hosts=["*"]` or omit the middleware.
 * `www_redirect` - If set to True, requests to non-www versions of the allowed hosts will be redirected to their www counterparts. Defaults to `True`.
 
 If an incoming request does not validate correctly then a 400 response will be sent.

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import re
 import sys
 from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -29,6 +30,9 @@ if sys.version_info < (3, 11):  # pragma: no cover
 
 T = TypeVar("T")
 AwaitableCallable = Callable[..., Awaitable[T]]
+
+# Reject characters that could make a Host header change the URL path or authority.
+_HOST_RE = re.compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9.:]+\])(?::[0-9]+)?$", re.IGNORECASE)
 
 
 @overload
@@ -91,6 +95,11 @@ async def create_collapsing_task_group() -> AsyncGenerator[anyio.abc.TaskGroup, 
         exc = excs.exceptions[0]
         context = None if exc.__suppress_context__ else exc.__context__
         raise exc from exc.__cause__ or context
+
+
+def parse_host_header(host_header: str) -> str | None:
+    match = _HOST_RE.fullmatch(host_header)
+    return match.group(1) if match is not None else None
 
 
 def get_route_path(scope: Scope) -> str:

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -98,10 +98,10 @@ async def create_collapsing_task_group() -> AsyncGenerator[anyio.abc.TaskGroup, 
 
 
 def parse_host_header(host_header: str) -> str | None:
-    """Return the host in `host_header`.
+    """Parse `host_header` into its host component.
 
-    The return value excludes the port and preserves brackets around IPv6
-    addresses. Return `None` if `host_header` is invalid.
+    The result excludes the port and preserves brackets around IPv6 addresses.
+    Invalid headers produce `None`.
     """
     match = _HOST_RE.fullmatch(host_header)
     return match.group(1) if match is not None else None

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -97,8 +97,12 @@ async def create_collapsing_task_group() -> AsyncGenerator[anyio.abc.TaskGroup, 
         raise exc from exc.__cause__ or context
 
 
-def get_host_from_header(host_header: str) -> str | None:
-    """Return the host without its port, or `None` if the header is invalid."""
+def parse_host_header(host_header: str) -> str | None:
+    """Return the host in `host_header`.
+
+    The return value excludes the port and preserves brackets around IPv6
+    addresses. Return `None` if `host_header` is invalid.
+    """
     match = _HOST_RE.fullmatch(host_header)
     return match.group(1) if match is not None else None
 

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -97,7 +97,8 @@ async def create_collapsing_task_group() -> AsyncGenerator[anyio.abc.TaskGroup, 
         raise exc from exc.__cause__ or context
 
 
-def parse_host_header(host_header: str) -> str | None:
+def get_host_from_header(host_header: str) -> str | None:
+    """Return the host without its port, or `None` if the header is invalid."""
     match = _HOST_RE.fullmatch(host_header)
     return match.group(1) if match is not None else None
 

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -32,7 +32,7 @@ T = TypeVar("T")
 AwaitableCallable = Callable[..., Awaitable[T]]
 
 # Reject characters that could make a Host header change the URL path or authority.
-_HOST_RE = re.compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9.:]+\])(?::[0-9]+)?$", re.IGNORECASE)
+_HOST_RE = re.compile(r"^([a-z0-9._~%!$&'()*+,;=-]+|\[[a-f0-9]*:[a-f0-9.:]+\])(?::[0-9]+)?$", re.IGNORECASE)
 
 
 @overload

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import re
 from collections.abc import ItemsView, Iterable, Iterator, KeysView, Mapping, MutableMapping, Sequence, ValuesView
 from shlex import shlex
 from typing import Any, BinaryIO, Literal, NamedTuple, TypeVar, cast
 from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit
 
+from starlette._utils import parse_host_header
 from starlette.concurrency import run_in_threadpool
 from starlette.types import Scope
 
@@ -20,9 +20,6 @@ _KeyType = TypeVar("_KeyType")
 # you can only read them
 # that is, you can't do `Mapping[str, Animal]()["fido"] = Dog()`
 _CovariantValueType = TypeVar("_CovariantValueType", covariant=True)
-
-# Rejects Host header chars (/, ?, #, @, ...) that would let urlsplit produce a path differing from scope["path"].
-_HOST_RE = re.compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9.:]+\])(?::[0-9]+)?$", re.IGNORECASE)
 
 
 class URL:
@@ -46,7 +43,7 @@ class URL:
                     host_header = value.decode("latin-1")
                     break
 
-            if host_header is not None and _HOST_RE.fullmatch(host_header):
+            if host_header is not None and parse_host_header(host_header) is not None:
                 netloc = host_header
             elif server is not None:
                 host, port = server

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -5,7 +5,7 @@ from shlex import shlex
 from typing import Any, BinaryIO, Literal, NamedTuple, TypeVar, cast
 from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit
 
-from starlette._utils import parse_host_header
+from starlette._utils import get_host_from_header
 from starlette.concurrency import run_in_threadpool
 from starlette.types import Scope
 
@@ -43,7 +43,7 @@ class URL:
                     host_header = value.decode("latin-1")
                     break
 
-            if host_header is not None and parse_host_header(host_header) is not None:
+            if host_header is not None and get_host_from_header(host_header) is not None:
                 netloc = host_header
             elif server is not None:
                 host, port = server

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -5,7 +5,7 @@ from shlex import shlex
 from typing import Any, BinaryIO, Literal, NamedTuple, TypeVar, cast
 from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit
 
-from starlette._utils import get_host_from_header
+from starlette._utils import parse_host_header
 from starlette.concurrency import run_in_threadpool
 from starlette.types import Scope
 
@@ -43,7 +43,7 @@ class URL:
                     host_header = value.decode("latin-1")
                     break
 
-            if host_header is not None and get_host_from_header(host_header) is not None:
+            if host_header is not None and parse_host_header(host_header) is not None:
                 netloc = host_header
             elif server is not None:
                 host, port = server

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from starlette._utils import parse_host_header
+from starlette._utils import get_host_from_header
 from starlette.datastructures import URL, Headers
 from starlette.responses import PlainTextResponse, RedirectResponse, Response
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -38,7 +38,7 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = parse_host_header(headers.get("host", ""))
+        host = get_host_from_header(headers.get("host", ""))
         if host is None:
             await PlainTextResponse("Invalid host header", status_code=400)(scope, receive, send)
             return

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from starlette._utils import get_host_from_header
+from starlette._utils import parse_host_header
 from starlette.datastructures import URL, Headers
 from starlette.responses import PlainTextResponse, RedirectResponse, Response
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -38,7 +38,7 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = get_host_from_header(headers.get("host", ""))
+        host = parse_host_header(headers.get("host", ""))
         if host is None:
             await PlainTextResponse("Invalid host header", status_code=400)(scope, receive, send)
             return

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from starlette._utils import parse_host_header
 from starlette.datastructures import URL, Headers
 from starlette.responses import PlainTextResponse, RedirectResponse, Response
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -37,7 +38,11 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = headers.get("host", "").split(":")[0]
+        host = parse_host_header(headers.get("host", ""))
+        if host is None:
+            await PlainTextResponse("Invalid host header", status_code=400)(scope, receive, send)
+            return
+
         is_valid_host = False
         found_www_redirect = False
         for pattern in self.allowed_hosts:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -224,27 +224,21 @@ class _TestClientTransport(httpx.BaseTransport):
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         scheme = request.url.scheme
-        netloc = request.url.netloc.decode(encoding="ascii")
+        host = request.url.raw_host.decode(encoding="ascii")
         path = request.url.path
         raw_path = request.url.raw_path
         query = request.url.query.decode(encoding="ascii")
 
         default_port = {"http": 80, "ws": 80, "https": 443, "wss": 443}[scheme]
-
-        if ":" in netloc:
-            host, port_string = netloc.split(":", 1)
-            port = int(port_string)
-        else:
-            host = netloc
+        port = request.url.port
+        if port is None:
             port = default_port
 
         # Include the 'host' header.
         if "host" in request.headers:
             headers: list[tuple[bytes, bytes]] = []
-        elif port == default_port:  # pragma: no cover
-            headers = [(b"host", host.encode())]
         else:  # pragma: no cover
-            headers = [(b"host", (f"{host}:{port}").encode())]
+            headers = [(b"host", request.url.netloc)]
 
         # Include other request headers.
         headers += [(key.lower().encode(), value.encode()) for key, value in request.headers.multi_items()]

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import pytest
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
@@ -27,6 +31,34 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
     client = test_client_factory(app, base_url="http://invalidhost")
     response = client.get("/")
     assert response.status_code == 400
+
+
+@pytest.mark.parametrize(
+    ("host", "status_code"),
+    [
+        ("[::1]", 200),
+        ("[::1]:8000", 200),
+        ("[2001:db8::1]", 400),
+        ("[::1", 400),
+        ("[::1]evil.example.com", 400),
+        ("[::1]@attacker", 400),
+        ("[::1].", 400),
+        ("[::1]:evil", 400),
+        ("[::1]:", 400),
+    ],
+)
+def test_trusted_host_middleware_ipv6(test_client_factory: TestClientFactory, host: str, status_code: int) -> None:
+    def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("OK")
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]", "*.example.com"])],
+    )
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"host": host})
+    assert response.status_code == status_code
 
 
 def test_default_allowed_hosts() -> None:

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -45,6 +45,13 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
         ("[::1].", 400),
         ("[::1]:evil", 400),
         ("[::1]:", 400),
+        ("api_service", 200),
+        ("api_service:8000", 200),
+        ("api_service/evil", 400),
+        ("api_service?evil", 400),
+        ("api_service#evil", 400),
+        ("api_service@attacker", 400),
+        ("api service", 400),
     ],
 )
 def test_trusted_host_middleware_ipv6(test_client_factory: TestClientFactory, host: str, status_code: int) -> None:
@@ -53,7 +60,7 @@ def test_trusted_host_middleware_ipv6(test_client_factory: TestClientFactory, ho
 
     app = Starlette(
         routes=[Route("/", endpoint=homepage)],
-        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]", "*.example.com"])],
+        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]", "api_service", "*.example.com"])],
     )
 
     client = test_client_factory(app)

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -450,6 +450,26 @@ def test_raw_path_with_querystring(test_client_factory: TestClientFactory) -> No
     assert response.content == b"/hello-world"
 
 
+@pytest.mark.parametrize(
+    ("base_url", "server", "host"),
+    [
+        ("http://[::1]", ["::1", 80], "[::1]"),
+        ("http://[::1]:8000", ["::1", 8000], "[::1]:8000"),
+        ("http://[::1]:0", ["::1", 0], "[::1]:0"),
+    ],
+)
+def test_ipv6_base_url(
+    test_client_factory: TestClientFactory, base_url: str, server: list[str | int], host: str
+) -> None:
+    def homepage(request: Request) -> JSONResponse:
+        return JSONResponse({"server": request.scope["server"], "host": request.headers["host"]})
+
+    app = Starlette(routes=[Route("/", endpoint=homepage)])
+    client = test_client_factory(app, base_url=base_url)
+    response = client.get("/")
+    assert response.json() == {"server": server, "host": host}
+
+
 def test_websocket_raw_path_without_params(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         websocket = WebSocket(scope, receive=receive, send=send)


### PR DESCRIPTION
# Summary

Support bracketed IPv6 addresses in `TrustedHostMiddleware` and `TestClient`.

Host header parsing now lives in the private `_utils` module, so `URL` and `TrustedHostMiddleware` share validation without exposing a new public API. Malformed bracketed hosts are rejected before allowlist matching, and `TestClient` delegates host and port parsing to its URL implementation.

Closes #3357.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

