### PR TITLE
Reject malformed Host authorities consistently

### DIFF
--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -5,6 +5,7 @@ import re
 import sys
 from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from dataclasses import dataclass
 from ipaddress import AddressValueError, IPv6Address
 from typing import Any, Generic, Protocol, TypeVar, overload
 
@@ -33,7 +34,28 @@ T = TypeVar("T")
 AwaitableCallable = Callable[..., Awaitable[T]]
 
 # Reject characters that could make a Host header change the URL path or authority.
-_HOST_RE = re.compile(r"^([a-z0-9._~%!$&'()*+,;=-]+|\[[a-f0-9]*:[a-f0-9.:]+\])(?::([0-9]+))?$", re.IGNORECASE)
+_HOST_RE = re.compile(
+    r"^(?P<host>[a-z0-9._~%!$&'()*+,;=-]+|\[(?:(?P<ipv6>[a-f0-9]*:[a-f0-9.:]+)|"
+    r"(?-i:v)[a-f0-9]+\.[a-z0-9._~!$&'()*+,;=:-]+)\])(?::(?P<port>[0-9]+))?$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ParsedHost:
+    host: str
+    port: str | None
+
+    @property
+    def authority(self) -> str:
+        return self.host if self.port is None else f"{self.host}:{self.port}"
+
+    @property
+    def is_valid_port(self) -> bool:
+        if self.port is None:
+            return True
+        port = self.port.lstrip("0")
+        return len(port) <= 5 and int(port or "0") <= 65535
 
 
 @overload
@@ -98,29 +120,29 @@ async def create_collapsing_task_group() -> AsyncGenerator[anyio.abc.TaskGroup, 
         raise exc from exc.__cause__ or context
 
 
-def parse_host_header(host_header: str) -> str | None:
-    """Parse `host_header` into its host component.
+def parse_host_header(host_header: str | None) -> ParsedHost | None:
+    """Parse `host_header` into its host and port components.
 
-    The result excludes the port and preserves brackets around IPv6 addresses.
-    Invalid headers produce `None`.
+    The host preserves brackets around IP literals. Invalid headers produce `None`.
     """
+    if host_header is None:
+        return None
+
     match = _HOST_RE.fullmatch(host_header)
     if match is None:
         return None
 
-    host, port = match.groups()
-    if port is not None:
-        port = port.lstrip("0")
-        if len(port) > 5 or int(port or "0") > 65535:
-            return None
+    host = match["host"]
+    port = match["port"]
 
-    if host.startswith("["):
+    ipv6 = match["ipv6"]
+    if ipv6 is not None:
         try:
-            IPv6Address(host[1:-1])
+            IPv6Address(ipv6)
         except AddressValueError:
             return None
 
-    return host
+    return ParsedHost(host, port)
 
 
 def get_route_path(scope: Scope) -> str:

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -132,9 +132,6 @@ def parse_host_header(host_header: str | None) -> ParsedHost | None:
     if match is None:
         return None
 
-    host = match["host"]
-    port = match["port"]
-
     ipv6 = match["ipv6"]
     if ipv6 is not None:
         try:
@@ -142,7 +139,7 @@ def parse_host_header(host_header: str | None) -> ParsedHost | None:
         except AddressValueError:
             return None
 
-    return ParsedHost(host, port)
+    return ParsedHost(match["host"], match["port"])
 
 
 def get_route_path(scope: Scope) -> str:

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -109,8 +109,10 @@ def parse_host_header(host_header: str) -> str | None:
         return None
 
     host, port = match.groups()
-    if port is not None and (len(port) > 5 or int(port) > 65535):
-        return None
+    if port is not None:
+        port = port.lstrip("0")
+        if len(port) > 5 or int(port or "0") > 65535:
+            return None
 
     if host.startswith("["):
         try:

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -41,7 +41,7 @@ _HOST_RE = re.compile(
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ParsedHost:
     host: str
     port: str | None

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -5,6 +5,7 @@ import re
 import sys
 from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from ipaddress import AddressValueError, IPv6Address
 from typing import Any, Generic, Protocol, TypeVar, overload
 
 import anyio.abc
@@ -32,7 +33,7 @@ T = TypeVar("T")
 AwaitableCallable = Callable[..., Awaitable[T]]
 
 # Reject characters that could make a Host header change the URL path or authority.
-_HOST_RE = re.compile(r"^([a-z0-9._~%!$&'()*+,;=-]+|\[[a-f0-9]*:[a-f0-9.:]+\])(?::[0-9]+)?$", re.IGNORECASE)
+_HOST_RE = re.compile(r"^([a-z0-9._~%!$&'()*+,;=-]+|\[[a-f0-9]*:[a-f0-9.:]+\])(?::([0-9]+))?$", re.IGNORECASE)
 
 
 @overload
@@ -104,7 +105,20 @@ def parse_host_header(host_header: str) -> str | None:
     Invalid headers produce `None`.
     """
     match = _HOST_RE.fullmatch(host_header)
-    return match.group(1) if match is not None else None
+    if match is None:
+        return None
+
+    host, port = match.groups()
+    if port is not None and (len(port) > 5 or int(port) > 65535):
+        return None
+
+    if host.startswith("["):
+        try:
+            IPv6Address(host[1:-1])
+        except AddressValueError:
+            return None
+
+    return host
 
 
 def get_route_path(scope: Scope) -> str:

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -47,6 +47,8 @@ class URL:
                 netloc = host_header
             elif server is not None:
                 host, port = server
+                if ":" in host and not host.startswith("["):
+                    host = f"[{host}]"
                 default_port = {"http": 80, "https": 443, "ws": 80, "wss": 443}[scheme]
                 netloc = host if port == default_port else f"{host}:{port}"
             else:

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -43,8 +43,9 @@ class URL:
                     host_header = value.decode("latin-1")
                     break
 
-            if host_header is not None and parse_host_header(host_header) is not None:
-                netloc = host_header
+            parsed_host = parse_host_header(host_header)
+            if parsed_host is not None and parsed_host.is_valid_port:
+                netloc = parsed_host.authority
             elif server is not None:
                 host, port = server
                 if ":" in host and not host.startswith("["):

--- a/starlette/middleware/httpsredirect.py
+++ b/starlette/middleware/httpsredirect.py
@@ -1,5 +1,5 @@
 from starlette.datastructures import URL
-from starlette.responses import RedirectResponse
+from starlette.responses import PlainTextResponse, RedirectResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 
@@ -10,6 +10,9 @@ class HTTPSRedirectMiddleware:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] in ("http", "websocket") and scope["scheme"] in ("http", "ws"):
             url = URL(scope=scope)
+            if not url.netloc:
+                await PlainTextResponse("Invalid host header", status_code=400)(scope, receive, send)
+                return
             redirect_scheme = {"http": "https", "ws": "wss"}[url.scheme]
             netloc = url.hostname if url.port in (80, 443) else url.netloc
             url = url.replace(scheme=redirect_scheme, netloc=netloc)

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -38,7 +38,7 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        parsed_host = parse_host_header(headers.get("host", ""))
+        parsed_host = parse_host_header(headers.get("host"))
         if parsed_host is None:
             await PlainTextResponse("Invalid host header", status_code=400)(scope, receive, send)
             return

--- a/starlette/middleware/trustedhost.py
+++ b/starlette/middleware/trustedhost.py
@@ -38,10 +38,11 @@ class TrustedHostMiddleware:
             return
 
         headers = Headers(scope=scope)
-        host = parse_host_header(headers.get("host", ""))
-        if host is None:
+        parsed_host = parse_host_header(headers.get("host", ""))
+        if parsed_host is None:
             await PlainTextResponse("Invalid host header", status_code=400)(scope, receive, send)
             return
+        host = parsed_host.host
 
         is_valid_host = False
         found_www_redirect = False

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -155,10 +155,8 @@ def compile_path(
     if is_host:
         # Align with `Host.matches()` behavior, which ignores port.
         hostname = path[idx:]
-        if path.startswith("[") and "]" in hostname:
-            hostname = hostname[: hostname.index("]") + 1]
-        else:
-            hostname = hostname.split(":", 1)[0]
+        if not hostname.endswith("]"):
+            hostname = hostname.rsplit(":", 1)[0]
         path_regex += re.escape(hostname) + "$"
     else:
         path_regex += re.escape(path[idx:]) + "$"

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -480,7 +480,7 @@ class Host(BaseRoute):
     def matches(self, scope: Scope) -> tuple[Match, Scope]:
         if scope["type"] in ("http", "websocket"):  # pragma:no branch
             headers = Headers(scope=scope)
-            parsed_host = parse_host_header(headers.get("host", ""))
+            parsed_host = parse_host_header(headers.get("host"))
             if parsed_host is None:
                 return Match.NONE, {}
             host = parsed_host.host

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -14,7 +14,7 @@ from re import Pattern
 from typing import Any, TypeVar
 
 from starlette._exception_handler import wrap_app_handling_exceptions
-from starlette._utils import get_route_path, is_async_callable
+from starlette._utils import get_route_path, is_async_callable, parse_host_header
 from starlette.concurrency import run_in_threadpool
 from starlette.convertors import CONVERTOR_TYPES, Convertor
 from starlette.datastructures import URL, Headers, URLPath
@@ -154,7 +154,11 @@ def compile_path(
 
     if is_host:
         # Align with `Host.matches()` behavior, which ignores port.
-        hostname = path[idx:].split(":")[0]
+        hostname = path[idx:]
+        if path.startswith("[") and "]" in hostname:
+            hostname = hostname[: hostname.index("]") + 1]
+        else:
+            hostname = hostname.split(":", 1)[0]
         path_regex += re.escape(hostname) + "$"
     else:
         path_regex += re.escape(path[idx:]) + "$"
@@ -478,7 +482,10 @@ class Host(BaseRoute):
     def matches(self, scope: Scope) -> tuple[Match, Scope]:
         if scope["type"] in ("http", "websocket"):  # pragma:no branch
             headers = Headers(scope=scope)
-            host = headers.get("host", "").split(":")[0]
+            host = parse_host_header(headers.get("host", ""))
+            if host is None:
+                return Match.NONE, {}
+
             match = self.host_regex.match(host)
             if match:
                 matched_params = match.groupdict()

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -482,9 +482,10 @@ class Host(BaseRoute):
     def matches(self, scope: Scope) -> tuple[Match, Scope]:
         if scope["type"] in ("http", "websocket"):  # pragma:no branch
             headers = Headers(scope=scope)
-            host = parse_host_header(headers.get("host", ""))
-            if host is None:
+            parsed_host = parse_host_header(headers.get("host", ""))
+            if parsed_host is None:
                 return Match.NONE, {}
+            host = parsed_host.host
 
             match = self.host_regex.match(host)
             if match:

--- a/tests/middleware/test_https_redirect.py
+++ b/tests/middleware/test_https_redirect.py
@@ -43,6 +43,10 @@ def test_https_redirect_middleware(test_client_factory: TestClientFactory) -> No
     assert response.headers["location"] == "https://testserver:123/"
 
     client = test_client_factory(app)
+    response = client.get("/", headers={"host": "testserver:000080"}, follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://testserver/"
+
     response = client.get("/", headers={"host": "testserver:65536"}, follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "https://testserver/"

--- a/tests/middleware/test_https_redirect.py
+++ b/tests/middleware/test_https_redirect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
@@ -39,3 +41,17 @@ def test_https_redirect_middleware(test_client_factory: TestClientFactory) -> No
     response = client.get("/", follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "https://testserver:123/"
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"host": "testserver:65536"}, follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://testserver/"
+
+    response = client.get("/", headers={"host": "[:::]"}, follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://testserver/"
+
+    client = test_client_factory(app, base_url="http://[::1]")
+    response = client.get("/", headers={"host": "[:::]"}, follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://[::1]/"

--- a/tests/middleware/test_https_redirect.py
+++ b/tests/middleware/test_https_redirect.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import pytest
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
+from starlette.types import Receive, Scope, Send
 from tests.types import TestClientFactory
 
 
@@ -59,3 +62,17 @@ def test_https_redirect_middleware(test_client_factory: TestClientFactory) -> No
     response = client.get("/", headers={"host": "[:::]"}, follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "https://[::1]/"
+
+
+@pytest.mark.parametrize("host", ["testserver:65536", "[:::]"])
+def test_https_redirect_middleware_without_server(test_client_factory: TestClientFactory, host: str) -> None:
+    middleware = HTTPSRedirectMiddleware(PlainTextResponse("OK"))
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        scope.pop("server", None)
+        await middleware(scope, receive, send)
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"host": host}, follow_redirects=False)
+    assert response.status_code == 400
+    assert response.text == "Invalid host header"

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -48,6 +48,7 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
         ("[::1]:evil", 400),
         ("[::1]:", 400),
         ("api_service", 200),
+        ("api_service:000080", 200),
         ("api_service:65535", 200),
         ("api_service:65536", 400),
         ("api_service:100000", 400),

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -38,6 +38,7 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
     [
         ("[::1]", 200),
         ("[::1]:8000", 200),
+        ("[v1.foo]", 200),
         ("[:::]", 400),
         ("[::ffff:999.999.999.999]", 400),
         ("[2001:db8::1]", 400),
@@ -50,8 +51,8 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
         ("api_service", 200),
         ("api_service:000080", 200),
         ("api_service:65535", 200),
-        ("api_service:65536", 400),
-        ("api_service:100000", 400),
+        ("api_service:65536", 200),
+        ("api_service:100000", 200),
         ("api_service:8000", 200),
         ("api_service/evil", 400),
         ("api_service?evil", 400),
@@ -66,7 +67,9 @@ def test_trusted_host_middleware_ipv6(test_client_factory: TestClientFactory, ho
 
     app = Starlette(
         routes=[Route("/", endpoint=homepage)],
-        middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]", "api_service", "*.example.com"])],
+        middleware=[
+            Middleware(TrustedHostMiddleware, allowed_hosts=["[::1]", "[v1.foo]", "api_service", "*.example.com"])
+        ],
     )
 
     client = test_client_factory(app)

--- a/tests/middleware/test_trusted_host.py
+++ b/tests/middleware/test_trusted_host.py
@@ -38,6 +38,8 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
     [
         ("[::1]", 200),
         ("[::1]:8000", 200),
+        ("[:::]", 400),
+        ("[::ffff:999.999.999.999]", 400),
         ("[2001:db8::1]", 400),
         ("[::1", 400),
         ("[::1]evil.example.com", 400),
@@ -46,6 +48,9 @@ def test_trusted_host_middleware(test_client_factory: TestClientFactory) -> None
         ("[::1]:evil", 400),
         ("[::1]:", 400),
         ("api_service", 200),
+        ("api_service:65535", 200),
+        ("api_service:65536", 400),
+        ("api_service:100000", 400),
         ("api_service:8000", 200),
         ("api_service/evil", 400),
         ("api_service?evil", 400),

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 from tempfile import SpooledTemporaryFile
 from typing import BinaryIO
@@ -179,6 +181,10 @@ def test_url_from_scope() -> None:
         pytest.param(b"user@foo", id="at-sign"),
         pytest.param(b"foo\\bar", id="backslash"),
         pytest.param(b"foo bar", id="space"),
+        pytest.param(b"foo:65536", id="port-out-of-range"),
+        pytest.param(b"foo:100000", id="port-too-long"),
+        pytest.param(b"[:::]", id="invalid-ipv6"),
+        pytest.param(b"[::ffff:999.999.999.999]", id="invalid-ipv4-mapped-ipv6"),
     ],
 )
 def test_url_from_scope_with_invalid_host(host: bytes) -> None:
@@ -194,6 +200,27 @@ def test_url_from_scope_with_invalid_host(host: bytes) -> None:
     )
     assert u.path == "/admin"
     assert u.netloc == "example.com"
+
+
+@pytest.mark.parametrize(
+    ("server", "expected_netloc"),
+    [
+        (("::1", 80), "[::1]"),
+        (("::1", 8000), "[::1]:8000"),
+    ],
+)
+def test_url_from_scope_with_ipv6_server(server: tuple[str, int], expected_netloc: str) -> None:
+    u = URL(
+        scope={
+            "scheme": "http",
+            "server": server,
+            "path": "/admin",
+            "query_string": b"",
+            "headers": [(b"host", b"[:::]")],
+        }
+    )
+    assert u.hostname == "::1"
+    assert u.netloc == expected_netloc
 
 
 @pytest.mark.parametrize(

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -171,6 +171,17 @@ def test_url_from_scope() -> None:
     assert u == "http://example.com:8000/some/path?query=string"
     assert repr(u) == "URL('http://example.com:8000/some/path?query=string')"
 
+    u = URL(
+        scope={
+            "scheme": "http",
+            "path": "/some/path",
+            "query_string": b"",
+            "headers": [(b"host", b"example.com:000080")],
+        }
+    )
+    assert u == "http://example.com:000080/some/path"
+    assert u.port == 80
+
 
 @pytest.mark.parametrize(
     "host",

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -196,6 +196,7 @@ def test_url_from_scope() -> None:
         pytest.param(b"foo:100000", id="port-too-long"),
         pytest.param(b"[:::]", id="invalid-ipv6"),
         pytest.param(b"[::ffff:999.999.999.999]", id="invalid-ipv4-mapped-ipv6"),
+        pytest.param(b"[V1.foo]", id="uppercase-ipvfuture"),
     ],
 )
 def test_url_from_scope_with_invalid_host(host: bytes) -> None:
@@ -232,6 +233,19 @@ def test_url_from_scope_with_ipv6_server(server: tuple[str, int], expected_netlo
     )
     assert u.hostname == "::1"
     assert u.netloc == expected_netloc
+
+
+def test_url_from_scope_with_ipvfuture() -> None:
+    u = URL(
+        scope={
+            "scheme": "http",
+            "path": "/admin",
+            "query_string": b"",
+            "headers": [(b"host", b"[v1.foo]")],
+        }
+    )
+    assert u.hostname == "v1.foo"
+    assert u.netloc == "[v1.foo]"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -491,6 +491,12 @@ def test_host_routing_rejects_invalid_hosts(test_client_factory: TestClientFacto
     assert response.status_code == 404
 
 
+def test_host_routing_accepts_zero_padded_port(test_client_factory: TestClientFactory) -> None:
+    client = test_client_factory(mixed_hosts_app, base_url="https://api.example.org/")
+    response = client.get("/users", headers={"host": "api.example.org:000080"})
+    assert response.status_code == 200
+
+
 def test_host_routing_ipv6(test_client_factory: TestClientFactory) -> None:
     app = Router(
         routes=[

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -476,6 +476,38 @@ def test_host_routing(test_client_factory: TestClientFactory) -> None:
     assert response.status_code == 200
 
 
+@pytest.mark.parametrize(
+    "host",
+    [
+        "api.example.org:evil",
+        "api.example.org:65536",
+        "api.example.org:100000",
+        "[:::]",
+    ],
+)
+def test_host_routing_rejects_invalid_hosts(test_client_factory: TestClientFactory, host: str) -> None:
+    client = test_client_factory(mixed_hosts_app, base_url="https://api.example.org/")
+    response = client.get("/users", headers={"host": host})
+    assert response.status_code == 404
+
+
+def test_host_routing_ipv6(test_client_factory: TestClientFactory) -> None:
+    app = Router(
+        routes=[
+            Host("[::1]", app=PlainTextResponse("loopback")),
+            Host("[2001:db8::1]", app=PlainTextResponse("documentation")),
+        ]
+    )
+
+    client = test_client_factory(app, base_url="https://[::1]/")
+    response = client.get("/")
+    assert response.text == "loopback"
+
+    client = test_client_factory(app, base_url="https://[2001:db8::1]/")
+    response = client.get("/")
+    assert response.text == "documentation"
+
+
 def test_host_reverse_urls() -> None:
     assert mixed_hosts_app.url_path_for("homepage").make_absolute_url("https://whatever") == "https://www.example.org/"
     assert (

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -480,8 +480,6 @@ def test_host_routing(test_client_factory: TestClientFactory) -> None:
     "host",
     [
         "api.example.org:evil",
-        "api.example.org:65536",
-        "api.example.org:100000",
         "[:::]",
     ],
 )
@@ -491,17 +489,19 @@ def test_host_routing_rejects_invalid_hosts(test_client_factory: TestClientFacto
     assert response.status_code == 404
 
 
-def test_host_routing_accepts_zero_padded_port(test_client_factory: TestClientFactory) -> None:
+@pytest.mark.parametrize("host", ["api.example.org:000080", "api.example.org:65536", "api.example.org:100000"])
+def test_host_routing_ignores_port(host: str, test_client_factory: TestClientFactory) -> None:
     client = test_client_factory(mixed_hosts_app, base_url="https://api.example.org/")
-    response = client.get("/users", headers={"host": "api.example.org:000080"})
+    response = client.get("/users", headers={"host": host})
     assert response.status_code == 200
 
 
-def test_host_routing_ipv6(test_client_factory: TestClientFactory) -> None:
+def test_host_routing_ip_literals(test_client_factory: TestClientFactory) -> None:
     app = Router(
         routes=[
             Host("[::1]", app=PlainTextResponse("loopback")),
             Host("[2001:db8::1]", app=PlainTextResponse("documentation")),
+            Host("[v1.foo]", app=PlainTextResponse("future")),
         ]
     )
 
@@ -512,6 +512,10 @@ def test_host_routing_ipv6(test_client_factory: TestClientFactory) -> None:
     client = test_client_factory(app, base_url="https://[2001:db8::1]/")
     response = client.get("/")
     assert response.text == "documentation"
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"host": "[v1.foo]"})
+    assert response.text == "future"
 
 
 def test_host_reverse_urls() -> None:


### PR DESCRIPTION
## Summary

- Parse `Host` headers into host and port components for consistent handling across URL construction, `TrustedHostMiddleware`, and host routing.
- Validate bracketed IPv6 addresses and lowercase IPvFuture literals before using them as URL authorities.
- Preserve zero-padded numeric ports while preventing out-of-range ports from raising during URL parsing.
- Keep port handling specific to each consumer: `TrustedHostMiddleware` and `Host.matches()` ignore ports, while `URL` checks whether a port is usable.
- Fall back to the ASGI server tuple when a `Host` authority cannot be used to construct a URL.
- Format IPv6 server tuple addresses with brackets when constructing URLs.
- Return a `400` response from `HTTPSRedirectMiddleware` when no usable authority is available.

This PR hardens behavior for malformed request data. It does not address a demonstrated security vulnerability.

## Testing

- 1,186 tests passed with 100% branch coverage
- `mypy starlette tests benchmarks`
- `ruff check starlette tests benchmarks`
- `ruff format --check starlette tests benchmarks`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
