### PR TITLE
Fix grammar in Starlette application docstring

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -18,7 +18,7 @@ P = ParamSpec("P")
 
 
 class Starlette:
-    """Creates an Starlette application."""
+    """Creates a Starlette application."""
 
     def __init__(
         self: AppType,


### PR DESCRIPTION
Summary

Corrected the grammatical error in the Starlette application class docstring.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

