### PR TITLE
Add route candidate index API

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -291,10 +291,7 @@ async def homepage(request):
 
 
 routes = [Route("/", homepage)]
-index = RouteIndex(
-    routes,
-    lambda route: RoutePattern(route.path, route.param_convertors),
-)
+index = RouteIndex(routes, RoutePattern.from_route)
 
 scope = {"type": "http", "method": "GET", "path": "/", "headers": []}
 for route in index.candidates(scope["path"]):
@@ -306,8 +303,10 @@ for route in index.candidates(scope["path"]):
 Return `None` from the pattern callback when a route may match paths outside its
 declared pattern. The index always returns that route as a candidate.
 
-The initial implementation returns every route in registration order. This
-keeps the API independent from a specific indexing algorithm.
+`Router` uses `RoutePattern.from_route()` to keep routes with custom `matches()`
+implementations as candidates for every path. The initial `RouteIndex`
+implementation returns every route in registration order. This keeps dispatch
+behavior unchanged and the API independent from a specific indexing algorithm.
 
 ## Working with Router instances
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -307,6 +307,7 @@ declared pattern. The index always returns that route as a candidate.
 implementations as candidates for every path. The initial `RouteIndex`
 implementation returns every route in registration order. This keeps dispatch
 behavior unchanged and the API independent from a specific indexing algorithm.
+The index rebuilds automatically when the candidate sequence changes.
 
 ## Working with Router instances
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -276,6 +276,39 @@ routes = [
 ]
 ```
 
+## Candidate indexes
+
+`RouteIndex` lets a router select a safe superset of routes that may match a
+path. You must still call `matches()` on every returned candidate.
+
+```python
+from starlette.responses import PlainTextResponse
+from starlette.routing import Match, Route, RouteIndex, RoutePattern
+
+
+async def homepage(request):
+    return PlainTextResponse("Homepage")
+
+
+routes = [Route("/", homepage)]
+index = RouteIndex(
+    routes,
+    lambda route: RoutePattern(route.path, route.param_convertors),
+)
+
+scope = {"type": "http", "method": "GET", "path": "/", "headers": []}
+for route in index.candidates(scope["path"]):
+    match, child_scope = route.matches(scope)
+    if match == Match.FULL:
+        break
+```
+
+Return `None` from the pattern callback when a route may match paths outside its
+declared pattern. The index always returns that route as a candidate.
+
+The initial implementation returns every route in registration order. This
+keeps the API independent from a specific indexing algorithm.
+
 ## Working with Router instances
 
 If you're working at a low-level you might want to use a plain `Router`

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -74,14 +74,20 @@ class RouteIndex(Generic[_RouteT]):
         candidates: Sequence[_RouteT],
         get_pattern: Callable[[_RouteT], RoutePattern | None],
     ) -> None:
-        self._candidates = list(candidates)
-        self._patterns = [get_pattern(candidate) for candidate in candidates]
-
-    def is_stale(self, candidates: Sequence[_RouteT]) -> bool:
-        return self._candidates != candidates
+        self._source = candidates
+        self._get_pattern = get_pattern
+        self._candidates: list[_RouteT] = []
+        self._patterns: list[RoutePattern | None] = []
+        self._rebuild()
 
     def candidates(self, path: str) -> list[_RouteT]:
+        if self._candidates != self._source:
+            self._rebuild()
         return self._candidates.copy()
+
+    def _rebuild(self) -> None:
+        self._candidates = list(self._source)
+        self._patterns = [self._get_pattern(candidate) for candidate in self._source]
 
 
 def request_response(
@@ -725,9 +731,6 @@ class Router:
         if scope["type"] == "lifespan":
             await self.lifespan(scope, receive, send)
             return
-
-        if self._route_index.is_stale(self.routes):
-            self._route_index = RouteIndex(self.routes, RoutePattern.from_route)
 
         partial = None
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -716,11 +716,6 @@ class Router:
         """
         await self.middleware_stack(scope, receive, send)
 
-    def _candidate_routes(self, scope: Scope) -> list[BaseRoute]:
-        if self._route_index.is_stale(self.routes):
-            self._route_index = RouteIndex(self.routes, RoutePattern.from_route)
-        return self._route_index.candidates(get_route_path(scope))
-
     async def app(self, scope: Scope, receive: Receive, send: Send) -> None:
         assert scope["type"] in ("http", "websocket", "lifespan")
 
@@ -731,9 +726,12 @@ class Router:
             await self.lifespan(scope, receive, send)
             return
 
+        if self._route_index.is_stale(self.routes):
+            self._route_index = RouteIndex(self.routes, RoutePattern.from_route)
+
         partial = None
 
-        for route in self._candidate_routes(scope):
+        for route in self._route_index.candidates(get_route_path(scope)):
             # Determine if any route matches the incoming scope,
             # and hand over to the matching route if found.
             match, child_scope = route.matches(scope)
@@ -763,7 +761,7 @@ class Router:
             else:
                 redirect_scope["path"] = redirect_scope["path"] + "/"
 
-            for route in self._candidate_routes(redirect_scope):
+            for route in self._route_index.candidates(get_route_path(redirect_scope)):
                 match, child_scope = route.matches(redirect_scope)
                 if match != Match.NONE:
                     redirect_url = URL(scope=redirect_scope)

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -7,11 +7,12 @@ import re
 import traceback
 import types
 import warnings
-from collections.abc import Awaitable, Callable, Collection, Generator, Sequence
+from collections.abc import Awaitable, Callable, Collection, Generator, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, AbstractContextManager, asynccontextmanager
+from dataclasses import dataclass
 from enum import Enum
 from re import Pattern
-from typing import Any, TypeVar
+from typing import Any, Generic, TypeVar
 
 from starlette._exception_handler import wrap_app_handling_exceptions
 from starlette._utils import get_route_path, is_async_callable, parse_host_header
@@ -42,6 +43,31 @@ class Match(Enum):
     NONE = 0
     PARTIAL = 1
     FULL = 2
+
+
+@dataclass(frozen=True)
+class RoutePattern:
+    """Describe a declared route path that may be used to narrow candidates."""
+
+    path: str
+    param_convertors: Mapping[str, Convertor[Any]]
+
+
+_RouteT = TypeVar("_RouteT")
+
+
+class RouteIndex(Generic[_RouteT]):
+    """Return a safe superset of route candidates for a path."""
+
+    def __init__(
+        self,
+        candidates: Sequence[_RouteT],
+        get_pattern: Callable[[_RouteT], RoutePattern | None],
+    ) -> None:
+        self._entries = [(candidate, get_pattern(candidate)) for candidate in candidates]
+
+    def candidates(self, path: str) -> list[_RouteT]:
+        return [candidate for candidate, _ in self._entries]
 
 
 def request_response(

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -52,6 +52,16 @@ class RoutePattern:
     path: str
     param_convertors: Mapping[str, Convertor[Any]]
 
+    @classmethod
+    def from_route(cls, route: BaseRoute) -> RoutePattern | None:
+        if isinstance(route, Route) and type(route).matches is Route.matches:
+            return cls(route.path, route.param_convertors)
+        if isinstance(route, WebSocketRoute) and type(route).matches is WebSocketRoute.matches:
+            return cls(route.path, route.param_convertors)
+        if isinstance(route, Mount) and type(route).matches is Mount.matches:
+            return cls(route.path + "/{path:path}", route.param_convertors)
+        return None
+
 
 _RouteT = TypeVar("_RouteT")
 
@@ -64,10 +74,14 @@ class RouteIndex(Generic[_RouteT]):
         candidates: Sequence[_RouteT],
         get_pattern: Callable[[_RouteT], RoutePattern | None],
     ) -> None:
-        self._entries = [(candidate, get_pattern(candidate)) for candidate in candidates]
+        self._candidates = list(candidates)
+        self._patterns = [get_pattern(candidate) for candidate in candidates]
+
+    def is_stale(self, candidates: Sequence[_RouteT]) -> bool:
+        return self._candidates != candidates
 
     def candidates(self, path: str) -> list[_RouteT]:
-        return [candidate for candidate, _ in self._entries]
+        return self._candidates.copy()
 
 
 def request_response(
@@ -616,6 +630,7 @@ class Router:
         max_body_size: int | None = None,
     ) -> None:
         self.routes = [] if routes is None else list(routes)
+        self._route_index = RouteIndex(self.routes, RoutePattern.from_route)
         self.redirect_slashes = redirect_slashes
         self.default = self.not_found if default is None else default
 
@@ -701,6 +716,11 @@ class Router:
         """
         await self.middleware_stack(scope, receive, send)
 
+    def _candidate_routes(self, scope: Scope) -> list[BaseRoute]:
+        if self._route_index.is_stale(self.routes):
+            self._route_index = RouteIndex(self.routes, RoutePattern.from_route)
+        return self._route_index.candidates(get_route_path(scope))
+
     async def app(self, scope: Scope, receive: Receive, send: Send) -> None:
         assert scope["type"] in ("http", "websocket", "lifespan")
 
@@ -713,7 +733,7 @@ class Router:
 
         partial = None
 
-        for route in self.routes:
+        for route in self._candidate_routes(scope):
             # Determine if any route matches the incoming scope,
             # and hand over to the matching route if found.
             match, child_scope = route.matches(scope)
@@ -743,7 +763,7 @@ class Router:
             else:
                 redirect_scope["path"] = redirect_scope["path"] + "/"
 
-            for route in self.routes:
+            for route in self._candidate_routes(redirect_scope):
                 match, child_scope = route.matches(redirect_scope)
                 if match != Match.NONE:
                     redirect_url = URL(scope=redirect_scope)

--- a/tests/test_route_index.py
+++ b/tests/test_route_index.py
@@ -6,7 +6,7 @@ from starlette.routing import Host, Mount, Route, RouteIndex, RoutePattern, WebS
 endpoint = PlainTextResponse("ok")
 
 
-def test_route_index_snapshots_candidates_and_patterns() -> None:
+def test_route_index_refreshes_candidates_and_patterns() -> None:
     candidates = ["first", "second", "fallback"]
     patterns = {
         "first": RoutePattern("/first", {}),
@@ -19,13 +19,12 @@ def test_route_index_snapshots_candidates_and_patterns() -> None:
         return patterns.get(candidate)
 
     index = RouteIndex(candidates, get_pattern)
-    assert not index.is_stale(candidates)
+    assert indexed == ["first", "second", "fallback"]
     candidates.reverse()
 
-    assert indexed == ["first", "second", "fallback"]
-    assert index.is_stale(candidates)
-    assert index.candidates("/first") == ["first", "second", "fallback"]
-    assert index.candidates("/missing") == ["first", "second", "fallback"]
+    assert index.candidates("/first") == ["fallback", "second", "first"]
+    assert indexed == ["first", "second", "fallback", "fallback", "second", "first"]
+    assert index.candidates("/missing") == ["fallback", "second", "first"]
 
 
 def test_route_index_returns_a_new_candidate_list() -> None:

--- a/tests/test_route_index.py
+++ b/tests/test_route_index.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from starlette.routing import RouteIndex, RoutePattern
+
+
+def test_route_index_snapshots_candidates_and_patterns() -> None:
+    candidates = ["first", "second", "fallback"]
+    patterns = {
+        "first": RoutePattern("/first", {}),
+        "second": RoutePattern("/second/{value}", {}),
+    }
+    indexed: list[str] = []
+
+    def get_pattern(candidate: str) -> RoutePattern | None:
+        indexed.append(candidate)
+        return patterns.get(candidate)
+
+    index = RouteIndex(candidates, get_pattern)
+    candidates.reverse()
+
+    assert indexed == ["first", "second", "fallback"]
+    assert index.candidates("/first") == ["first", "second", "fallback"]
+    assert index.candidates("/missing") == ["first", "second", "fallback"]
+
+
+def test_route_index_returns_a_new_candidate_list() -> None:
+    index = RouteIndex(["first"], lambda candidate: None)
+
+    candidates = index.candidates("/first")
+    candidates.clear()
+
+    assert index.candidates("/first") == ["first"]

--- a/tests/test_route_index.py
+++ b/tests/test_route_index.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from starlette.routing import RouteIndex, RoutePattern
+from starlette.responses import PlainTextResponse
+from starlette.routing import Host, Mount, Route, RouteIndex, RoutePattern, WebSocketRoute
+
+endpoint = PlainTextResponse("ok")
 
 
 def test_route_index_snapshots_candidates_and_patterns() -> None:
@@ -16,9 +19,11 @@ def test_route_index_snapshots_candidates_and_patterns() -> None:
         return patterns.get(candidate)
 
     index = RouteIndex(candidates, get_pattern)
+    assert not index.is_stale(candidates)
     candidates.reverse()
 
     assert indexed == ["first", "second", "fallback"]
+    assert index.is_stale(candidates)
     assert index.candidates("/first") == ["first", "second", "fallback"]
     assert index.candidates("/missing") == ["first", "second", "fallback"]
 
@@ -30,3 +35,16 @@ def test_route_index_returns_a_new_candidate_list() -> None:
     candidates.clear()
 
     assert index.candidates("/first") == ["first"]
+
+
+def test_route_pattern_from_builtin_routes() -> None:
+    route = Route("/{value}", endpoint)
+    websocket_route = WebSocketRoute("/ws/{value}", endpoint)
+    mount = Mount("/mounted", app=PlainTextResponse("mounted"))
+
+    assert RoutePattern.from_route(route) == RoutePattern(route.path, route.param_convertors)
+    assert RoutePattern.from_route(websocket_route) == RoutePattern(
+        websocket_route.path, websocket_route.param_convertors
+    )
+    assert RoutePattern.from_route(mount) == RoutePattern(mount.path + "/{path:path}", mount.param_convertors)
+    assert RoutePattern.from_route(Host("example.org", app=PlainTextResponse("hosted"))) is None

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -15,7 +15,7 @@ from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response
-from starlette.routing import Host, Mount, NoMatchFound, Route, Router, WebSocketRoute
+from starlette.routing import Host, Match, Mount, NoMatchFound, Route, Router, WebSocketRoute
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect
@@ -296,6 +296,32 @@ def test_router_add_route(client: TestClient) -> None:
     response = client.get("/func")
     assert response.status_code == 200
     assert response.text == "Hello, world!"
+
+
+def test_router_rebuilds_route_index_after_routes_replaced(test_client_factory: TestClientFactory) -> None:
+    router = Router(routes=[Route("/first", endpoint=homepage), Route("/second", endpoint=homepage)])
+    client = test_client_factory(router)
+    assert client.get("/first").status_code == 200
+
+    router.routes[0] = Route("/replacement", endpoint=homepage)
+    assert client.get("/replacement").status_code == 200
+
+    router.routes.reverse()
+    assert client.get("/second").status_code == 200
+
+
+def test_router_preserves_custom_route_matching(test_client_factory: TestClientFactory) -> None:
+    class CustomRoute(Route):
+        def matches(self, scope: Scope) -> tuple[Match, Scope]:
+            if scope["path"] == "/alias":
+                return Match.FULL, {}
+            return super().matches(scope)
+
+    router = Router(routes=[CustomRoute("/declared", endpoint=PlainTextResponse("custom"))])
+    client = test_client_factory(router)
+
+    assert client.get("/alias").text == "custom"
+    assert client.get("/declared").text == "custom"
 
 
 def test_router_duplicate_path(client: TestClient) -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -298,7 +298,7 @@ def test_router_add_route(client: TestClient) -> None:
     assert response.text == "Hello, world!"
 
 
-def test_router_rebuilds_route_index_after_routes_replaced(test_client_factory: TestClientFactory) -> None:
+def test_router_rebuilds_route_index_after_routes_change(test_client_factory: TestClientFactory) -> None:
     router = Router(routes=[Route("/first", endpoint=homepage), Route("/second", endpoint=homepage)])
     client = test_client_factory(router)
     assert client.get("/first").status_code == 200


### PR DESCRIPTION
## Summary

Add public `RoutePattern` and generic `RouteIndex` APIs for routing frameworks to describe candidates that can be narrowed by declared path.

Wire `Router` dispatch and slash redirects through `RouteIndex`. The index rebuilds when `router.routes` changes. Its initial implementation returns every candidate in registration order, so behavior remains unchanged without coupling this proposal to the trie implementation.

`RoutePattern.from_route()` returns `None` for routes with custom `matches()` implementations. Those routes remain candidates for every path when the index is optimized later.

## Validation

- `scripts/check`
- `scripts/test`
- `uv run zensical build`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
