### PR TITLE
Raise WebSocketDisconnect when send() is called after disconnect

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -95,7 +95,7 @@ class WebSocket(HTTPConnection[StateT]):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            raise WebSocketDisconnect(code=1000)
 
     async def accept(
         self,

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -488,7 +488,7 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/"):
             pass  # pragma: no cover
 


### PR DESCRIPTION
## Problem
When a WebSocket connection has already sent a close message / disconnected, subsequent calls to `send()` (such as duplicate `close()` calls in concurrent handler/cleanup tasks) raised a generic `RuntimeError('Cannot call "send" once a close message has been sent.')`.

In asynchronous WebSocket applications where multiple coroutines interact with the same connection (e.g. background sender + error recovery/cleanup task), this caused unexpected runtime errors instead of standard disconnect exception handling.

## Solution
- Update `WebSocket.send()` to raise `WebSocketDisconnect(code=1000)` when called after `application_state` is in the disconnected state.
- Update `test_duplicate_close` to assert that `WebSocketDisconnect` is raised.

Fixes #2766

## Checklist
- [x] I have read the [Contribution Guidelines](https://github.com/encode/starlette/blob/master/CONTRIBUTING.md)
- [x] Unit tests covering the change have been updated and pass cleanly

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

