### PR TITLE
Avoid replacing placeholders inside path parameter values

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -90,22 +90,23 @@ def get_name(endpoint: Callable[..., Any]) -> str:
     return getattr(endpoint, "__name__", endpoint.__class__.__name__)
 
 
+# Match parameters in URL paths, eg. '{param}', and '{param:int}'
+PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?}")
+
+
 def replace_params(
     path: str,
     param_convertors: dict[str, Convertor[Any]],
     path_params: dict[str, str],
 ) -> tuple[str, dict[str, str]]:
+    replacements = {}
     for key, value in list(path_params.items()):
         if "{" + key + "}" in path:
             convertor = param_convertors[key]
-            value = convertor.to_string(value)
-            path = path.replace("{" + key + "}", value)
+            replacements[key] = convertor.to_string(value)
             path_params.pop(key)
+    path = PARAM_REGEX.sub(lambda match: replacements.get(match.group(1), match.group(0)), path)
     return path, path_params
-
-
-# Match parameters in URL paths, eg. '{param}', and '{param:int}'
-PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?}")
 
 
 def compile_path(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -272,6 +272,20 @@ def test_url_path_for() -> None:
         app.url_path_for("user", username="")
 
 
+@pytest.mark.parametrize(
+    ("path", "path_params", "expected"),
+    [
+        ("/{category}/{id}", {"category": "{id}", "id": "42"}, "/{id}/42"),
+        ("/{category}/{id}", {"id": "42", "category": "{id}"}, "/{id}/42"),
+        ("/{a}/{b}/{c}", {"a": "{b}", "b": "{c}", "c": "final"}, "/{b}/{c}/final"),
+    ],
+)
+def test_url_path_for_preserves_parameter_values(path: str, path_params: dict[str, str], expected: str) -> None:
+    route = Route(path, endpoint=homepage, name="route")
+
+    assert route.url_path_for("route", **path_params) == expected
+
+
 def test_url_for() -> None:
     assert app.url_path_for("homepage").make_absolute_url(base_url="https://example.org") == "https://example.org/"
     assert (


### PR DESCRIPTION
# Summary

Fix replace_params() so a path parameter value that resembles another placeholder is not interpreted again while generating a URL.

The previous loop repeatedly applied str.replace() to an already-mutated path. This change converts the provided values first, then substitutes only placeholders from the original template in one regex pass. It preserves converter order and the existing removal of consumed path parameters.

Regression coverage includes both keyword argument orders and a three-placeholder chain.

Related discussion: https://github.com/Kludex/starlette/discussions/3479

# Validation

- Complete suite: 1195 passed, 2 xfailed
- Coverage: 100%
- Ruff format and check: passed
- mypy: passed

# Checklist

- [x] I understand that this PR may be closed if there was no previous discussion.
- [x] I added regression tests and kept the change atomic.
- [x] Documentation is unchanged because this fixes existing behavior without changing the public API.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

