### PR TITLE
fix: ensure background tasks run after response is sent in BaseHTTPMiddleware

### DIFF
--- a/starlette/_exception_handler.py
+++ b/starlette/_exception_handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from starlette._utils import is_async_callable
+from starlette.background import forward_background_deferral
 from starlette.concurrency import run_in_threadpool
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
@@ -37,6 +38,8 @@ def wrap_app_handling_exceptions(app: ASGIApp, conn: Request | WebSocket) -> ASG
             if message["type"] == "http.response.start":
                 response_started = True
             await send(message)
+
+        forward_background_deferral(send, sender)
 
         try:
             await app(scope, receive, sender)

--- a/starlette/background.py
+++ b/starlette/background.py
@@ -5,6 +5,7 @@ from typing import Any, ParamSpec
 
 from starlette._utils import is_async_callable
 from starlette.concurrency import run_in_threadpool
+from starlette.types import Send
 
 P = ParamSpec("P")
 
@@ -34,3 +35,20 @@ class BackgroundTasks(BackgroundTask):
     async def __call__(self) -> None:
         for task in self.tasks:
             await task()
+
+
+async def run_or_defer_background(send: Send, background: BackgroundTask | None) -> None:
+    if background is None:
+        return
+    defer = getattr(send, "defer_background", None)
+    if defer is not None:
+        defer(background)
+    else:
+        await background()
+
+
+def forward_background_deferral(send: Send, wrapped_send: Send) -> Send:
+    defer_background = getattr(send, "defer_background", None)
+    if defer_background is not None:
+        wrapped_send.defer_background = defer_background  # type: ignore[attr-defined]
+    return wrapped_send

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -6,6 +6,7 @@ from typing import Any, TypeVar
 import anyio
 
 from starlette._utils import create_collapsing_task_group
+from starlette.background import BackgroundTask, run_or_defer_background
 from starlette.requests import ClientDisconnect, Request
 from starlette.responses import Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -15,6 +16,26 @@ DispatchFunction = Callable[[Request, RequestResponseEndpoint], Awaitable[Respon
 BodyStreamGenerator = AsyncGenerator[bytes | MutableMapping[str, Any], None]
 AsyncContentStream = AsyncIterable[str | bytes | memoryview | MutableMapping[str, Any]]
 T = TypeVar("T")
+
+
+class _BackgroundDeferringSend:
+    def __init__(self, send: Send) -> None:
+        self._send = send
+        self.background: BackgroundTask | None = None
+        self.app_complete = anyio.Event()
+
+    async def __call__(self, message: Message) -> None:
+        try:
+            await self._send(message)
+        except anyio.BrokenResourceError:
+            # recv_stream has been closed, i.e. response_sent has been set.
+            return
+
+    def defer_background(self, background: BackgroundTask) -> None:
+        self.background = background
+
+    def mark_app_complete(self) -> None:
+        self.app_complete.set()
 
 
 class _CachedRequest(Request):
@@ -129,21 +150,19 @@ class BaseHTTPMiddleware:
 
                 return message
 
-            async def send_no_error(message: Message) -> None:
-                try:
-                    await send_stream.send(message)
-                except anyio.BrokenResourceError:
-                    # recv_stream has been closed, i.e. response_sent has been set.
-                    return
+            deferring_send = _BackgroundDeferringSend(send_stream.send)
 
             async def coro() -> None:
                 nonlocal app_exc
 
-                with send_stream:
-                    try:
-                        await self.app(scope, receive_or_disconnect, send_no_error)
-                    except Exception as exc:
-                        app_exc = exc
+                try:
+                    with send_stream:
+                        try:
+                            await self.app(scope, receive_or_disconnect, deferring_send)
+                        except Exception as exc:
+                            app_exc = exc
+                finally:
+                    deferring_send.mark_app_complete()
 
             task_group.start_soon(coro)
 
@@ -182,7 +201,12 @@ class BaseHTTPMiddleware:
                     if not message.get("more_body", False):
                         break
 
-            response = _StreamingResponse(status_code=message["status"], content=body_stream(), info=info)
+            response = _StreamingResponse(
+                status_code=message["status"],
+                content=body_stream(),
+                info=info,
+                background_holder=deferring_send,
+            )
             response.raw_headers = message["headers"]
             return response
 
@@ -209,6 +233,7 @@ class _StreamingResponse(Response):
         headers: Mapping[str, str] | None = None,
         media_type: str | None = None,
         info: Mapping[str, Any] | None = None,
+        background_holder: _BackgroundDeferringSend | None = None,
     ) -> None:
         self.info = info
         self.body_iterator = content
@@ -216,6 +241,7 @@ class _StreamingResponse(Response):
         self.media_type = media_type
         self.init_headers(headers)
         self.background = None
+        self._background_holder = background_holder
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if self.info is not None:
@@ -240,5 +266,10 @@ class _StreamingResponse(Response):
         if should_close_body:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
 
-        if self.background:
+        if self.background is not None:
             await self.background()
+
+        if self._background_holder is not None:
+            await self._background_holder.app_complete.wait()
+            if self._background_holder.background is not None:
+                await run_or_defer_background(send, self._background_holder.background)

--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -6,6 +6,7 @@ import sys
 import traceback
 
 from starlette._utils import is_async_callable
+from starlette.background import forward_background_deferral
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, PlainTextResponse, Response
@@ -159,6 +160,8 @@ class ServerErrorMiddleware:
             if message["type"] == "http.response.start":
                 response_started = True
             await send(message)
+
+        forward_background_deferral(send, _send)
 
         try:
             await self.app(scope, receive, _send)

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -19,7 +19,7 @@ import anyio
 import anyio.to_thread
 
 from starlette._utils import create_collapsing_task_group
-from starlette.background import BackgroundTask
+from starlette.background import BackgroundTask, run_or_defer_background
 from starlette.concurrency import iterate_in_threadpool
 from starlette.datastructures import URL, Headers, MutableHeaders
 from starlette.requests import ClientDisconnect
@@ -166,8 +166,7 @@ class Response:
         await send({"type": "http.response.start", "status": self.status_code, "headers": self.raw_headers})
         await send({"type": "http.response.body", "body": self.body})
 
-        if self.background is not None:
-            await self.background()
+        await run_or_defer_background(send, self.background)
 
 
 class HTMLResponse(Response):
@@ -258,8 +257,7 @@ class StreamingResponse(Response):
         if scope["type"] == "websocket":
             send = self._wrap_websocket_denial_send(send)
             await self.stream_response(send)
-            if self.background is not None:
-                await self.background()
+            await run_or_defer_background(send, self.background)
             return
 
         spec_version = tuple(map(int, scope.get("asgi", {}).get("spec_version", "2.0").split(".")))
@@ -279,8 +277,7 @@ class StreamingResponse(Response):
                 task_group.start_soon(wrap, partial(self.stream_response, send))
                 await wrap(partial(self.listen_for_disconnect, receive))
 
-        if self.background is not None:
-            await self.background()
+        await run_or_defer_background(send, self.background)
 
 
 class MalformedRangeHeader(Exception):
@@ -381,8 +378,7 @@ class FileResponse(Response):
             else:
                 await self._handle_multiple_ranges(send, ranges, stat_result.st_size, send_header_only)
 
-        if self.background is not None:
-            await self.background()
+        await run_or_defer_background(send, self.background)
 
     async def _handle_simple(self, send: Send, send_header_only: bool, send_pathsend: bool) -> None:
         await send({"type": "http.response.start", "status": self.status_code, "headers": self.raw_headers})

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -412,6 +412,46 @@ async def test_do_not_block_on_background_tasks() -> None:
 
 
 @pytest.mark.anyio
+async def test_background_task_runs_after_response_sent_with_slow_client() -> None:
+    events: list[tuple[str, float]] = []
+
+    async def bg() -> None:
+        events.append(("background-done", anyio.current_time()))
+
+    async def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("hello", background=BackgroundTask(bg))
+
+    async def passthrough(request: Request, call_next: RequestResponseEndpoint) -> Response:
+        return await call_next(request)
+
+    app = Starlette(
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=passthrough)],
+        routes=[Route("/", homepage)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+    }
+
+    async def receive() -> Message:
+        await anyio.sleep(3600)
+
+    async def send(message: Message) -> None:
+        events.append((message["type"], anyio.current_time()))
+        await anyio.sleep(0.05)
+
+    await app(scope, receive, send)
+
+    event_names = [name for name, _ in events]
+    bg_index = event_names.index("background-done")
+    final_body_index = max(i for i, name in enumerate(event_names) if name == "http.response.body")
+    assert bg_index > final_body_index
+
+
+@pytest.mark.anyio
 async def test_run_context_manager_exit_even_if_client_disconnects() -> None:
     # test for https://github.com/Kludex/starlette/issues/1678#issuecomment-1172916042
     response_complete = anyio.Event()


### PR DESCRIPTION
## Summary

- Defer `BackgroundTask` execution when responses are sent through `BaseHTTPMiddleware`'s buffered ASGI stream, so tasks run only after `_StreamingResponse` sends the final body chunk to the client.
- Forward the `defer_background` hook across ASGI `send` wrappers (`ServerErrorMiddleware`, exception handling) so inner responses can still defer tasks reliably.
- Add regression test that reproduces issue #3458 with a slow client `send` callback.

Fixes #3458

## Test plan

- [x] `pytest tests/middleware/test_base.py::test_background_task_runs_after_response_sent_with_slow_client`
- [x] `pytest tests/middleware/test_base.py::test_do_not_block_on_background_tasks`
- [x] `pytest tests/middleware/test_base.py::test_multiple_middlewares_stacked_client_disconnected`
- [x] `pytest tests/middleware/test_base.py tests/middleware/test_errors.py tests/test_background.py` (81 passed)