### PR TITLE
Raise WebSocketDisconnect instead of RuntimeError when sending on disconnected websocket (#2766)

### DIFF
--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -59,6 +59,8 @@ For example: `websocket.path_params['username']`
 * `await websocket.send_bytes(data)`
 * `await websocket.send_json(data)`
 
+May raise `starlette.websockets.WebSocketDisconnect()`.
+
 JSON messages default to being sent over text data frames, from version 0.10.0 onwards.
 Use `websocket.send_json(data, mode="binary")` to send JSON over binary data frames.
 

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -95,7 +95,7 @@ class WebSocket(HTTPConnection[StateT]):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            raise WebSocketDisconnect(code=1000)
 
     async def accept(
         self,

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -488,9 +488,24 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect) as exc:
         with client.websocket_connect("/"):
             pass  # pragma: no cover
+    assert exc.value.code == status.WS_1000_NORMAL_CLOSURE
+
+
+def test_send_after_close(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive=receive, send=send)
+        await websocket.accept()
+        await websocket.close()
+        await websocket.send_text("Hello, world!")
+
+    client = test_client_factory(app)
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/"):
+            pass  # pragma: no cover
+    assert exc.value.code == status.WS_1000_NORMAL_CLOSURE
 
 
 def test_duplicate_disconnect(test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
# Summary

Fixes #2766

When calling `WebSocket.send()` (or higher-level helpers like `close()` or `send_text()`) on a WebSocket that is already disconnected (`application_state == WebSocketState.DISCONNECTED`), Starlette previously raised a `RuntimeError` instead of `WebSocketDisconnect`.

This PR updates the disconnected branch of `WebSocket.send()` to raise `WebSocketDisconnect(code=1000)`, matching expected exception handling across WebSocket operations.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

