### PR TITLE
Ensure BackgroundTask runs after response is sent when BaseHTTPMiddleware is in stack (#3458)

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -109,6 +109,8 @@ class BaseHTTPMiddleware:
         app_exc: Exception | None = None
         exception_already_raised = False
 
+        pending_acks: set[anyio.Event] = set()
+
         async def call_next(request: Request) -> Response:
             async def receive_or_disconnect() -> Message:
                 if response_sent.is_set():
@@ -130,11 +132,18 @@ class BaseHTTPMiddleware:
                 return message
 
             async def send_no_error(message: Message) -> None:
-                try:
-                    await send_stream.send(message)
-                except anyio.BrokenResourceError:
-                    # recv_stream has been closed, i.e. response_sent has been set.
+                if response_sent.is_set():
+                    await anyio.lowlevel.checkpoint()
                     return
+                ack = anyio.Event()
+                pending_acks.add(ack)
+                try:
+                    await send_stream.send((message, ack))
+                    await ack.wait()
+                except anyio.BrokenResourceError:  # pragma: no cover
+                    return
+                finally:
+                    pending_acks.discard(ack)
 
             async def coro() -> None:
                 nonlocal app_exc
@@ -148,10 +157,12 @@ class BaseHTTPMiddleware:
             task_group.start_soon(coro)
 
             try:
-                message = await recv_stream.receive()
+                message, ack = await recv_stream.receive()
+                ack.set()
                 info = message.get("info", None)
                 if message["type"] == "http.response.debug" and info is not None:
-                    message = await recv_stream.receive()
+                    message, ack = await recv_stream.receive()
+                    ack.set()
             except anyio.EndOfStream:
                 if app_exc is not None:
                     nonlocal exception_already_raised
@@ -170,29 +181,59 @@ class BaseHTTPMiddleware:
 
             assert message["type"] == "http.response.start"
 
-            async def body_stream() -> BodyStreamGenerator:
-                async for message in recv_stream:
-                    if message["type"] == "http.response.pathsend":
-                        yield message
-                        break
-                    assert message["type"] == "http.response.body", f"Unexpected message: {message}"
-                    body = message.get("body", b"")
-                    if body:
-                        yield body
-                    if not message.get("more_body", False):
-                        break
+            last_ack: anyio.Event | None = None
 
-            response = _StreamingResponse(status_code=message["status"], content=body_stream(), info=info)
+            async def body_stream() -> BodyStreamGenerator:
+                nonlocal last_ack
+                curr_ack: anyio.Event | None = None
+                try:
+                    async for message, ack in recv_stream:
+                        curr_ack = ack
+                        if message["type"] == "http.response.pathsend":
+                            last_ack = ack
+                            yield message
+                            break
+                        assert message["type"] == "http.response.body", f"Unexpected message: {message}"
+                        body = message.get("body", b"")
+                        more_body = message.get("more_body", False)
+                        if body:
+                            yield body
+                        if more_body:
+                            ack.set()
+                            curr_ack = None
+                        else:
+                            last_ack = ack
+                            break
+                finally:
+                    if curr_ack is not None:
+                        curr_ack.set()
+                    if last_ack is not None:
+                        last_ack.set()
+
+            def ack_response() -> None:
+                nonlocal last_ack
+                if last_ack is not None:
+                    last_ack.set()
+                    last_ack = None
+
+            response = _StreamingResponse(
+                status_code=message["status"],
+                content=body_stream(),
+                info=info,
+                ack=ack_response,
+            )
             response.raw_headers = message["headers"]
             return response
 
-        streams: anyio.create_memory_object_stream[Message] = anyio.create_memory_object_stream()
+        streams: anyio.create_memory_object_stream[tuple[Message, anyio.Event]] = anyio.create_memory_object_stream()
         send_stream, recv_stream = streams
         with recv_stream, send_stream:
             async with create_collapsing_task_group() as task_group:
                 response = await self.dispatch_func(request, call_next)
                 await response(scope, wrapped_receive, send)
                 response_sent.set()
+                for ack in list(pending_acks):
+                    ack.set()
                 recv_stream.close()
         if app_exc is not None and not exception_already_raised:
             raise app_exc
@@ -209,6 +250,7 @@ class _StreamingResponse(Response):
         headers: Mapping[str, str] | None = None,
         media_type: str | None = None,
         info: Mapping[str, Any] | None = None,
+        ack: Callable[[], None] | None = None,
     ) -> None:
         self.info = info
         self.body_iterator = content
@@ -216,6 +258,7 @@ class _StreamingResponse(Response):
         self.media_type = media_type
         self.init_headers(headers)
         self.background = None
+        self._ack = ack
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if self.info is not None:
@@ -239,6 +282,9 @@ class _StreamingResponse(Response):
 
         if should_close_body:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+        if self._ack is not None:  # pragma: no branch
+            self._ack()
 
         if self.background:
             await self.background()

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -412,6 +412,210 @@ async def test_do_not_block_on_background_tasks() -> None:
 
 
 @pytest.mark.anyio
+async def test_background_task_starts_after_response_sent_with_base_http_middleware() -> None:
+    # Test for https://github.com/encode/starlette/issues/3458
+    events: list[str] = []
+    response_complete = anyio.Event()
+
+    async def bg() -> None:
+        events.append("background")
+
+    async def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("hello", background=BackgroundTask(bg))
+
+    async def passthrough(request: Request, call_next: RequestResponseEndpoint) -> Response:
+        return await call_next(request)
+
+    app = Starlette(
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=passthrough)],
+        routes=[Route("/", homepage)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+    }
+
+    async def receive() -> Message:
+        raise NotImplementedError("Should not be called!")  # pragma: no cover
+
+    async def send(message: Message) -> None:
+        if message["type"] == "http.response.body":
+            events.append(f"body(more_body={message.get('more_body', False)})")
+            if not message.get("more_body", False):
+                response_complete.set()
+            await anyio.sleep(0.05)  # simulate slow client/send
+
+    await app(scope, receive, send)
+
+    assert events == [
+        "body(more_body=True)",
+        "body(more_body=False)",
+        "background",
+    ]
+
+
+@pytest.mark.anyio
+async def test_streaming_background_task_starts_after_response_sent_with_base_http_middleware() -> None:
+    # Test for https://github.com/encode/starlette/issues/3458
+    events: list[str] = []
+    response_complete = anyio.Event()
+
+    async def bg() -> None:
+        events.append("background")
+
+    async def stream_gen() -> AsyncGenerator[bytes, None]:
+        events.append("stream_chunk_1")
+        yield b"chunk1"
+        events.append("stream_chunk_2")
+        yield b"chunk2"
+
+    async def streaming_endpoint(request: Request) -> StreamingResponse:
+        return StreamingResponse(stream_gen(), background=BackgroundTask(bg))
+
+    async def passthrough(request: Request, call_next: RequestResponseEndpoint) -> Response:
+        return await call_next(request)
+
+    app = Starlette(
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=passthrough)],
+        routes=[Route("/", streaming_endpoint)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+    }
+
+    async def receive() -> Message:
+        await response_complete.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        if message["type"] == "http.response.body":
+            events.append(f"body(more_body={message.get('more_body', False)})")
+            if not message.get("more_body", False):
+                response_complete.set()
+            await anyio.sleep(0.05)  # simulate slow client/send
+
+    await app(scope, receive, send)
+
+    assert events == [
+        "stream_chunk_1",
+        "body(more_body=True)",
+        "stream_chunk_2",
+        "body(more_body=True)",
+        "body(more_body=False)",
+        "background",
+    ]
+
+
+@pytest.mark.anyio
+async def test_file_response_background_task_starts_after_response_sent_with_base_http_middleware(
+    tmp_path: Path,
+) -> None:
+    # Test for https://github.com/encode/starlette/issues/3458
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("file content")
+    events: list[str] = []
+    response_complete = anyio.Event()
+
+    async def bg() -> None:
+        events.append("background")
+
+    async def file_endpoint(request: Request) -> FileResponse:
+        return FileResponse(file_path, background=BackgroundTask(bg))
+
+    async def passthrough(request: Request, call_next: RequestResponseEndpoint) -> Response:
+        return await call_next(request)
+
+    app = Starlette(
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=passthrough)],
+        routes=[Route("/", file_endpoint)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+    }
+
+    async def receive() -> Message:
+        raise NotImplementedError("Should not be called!")  # pragma: no cover
+
+    async def send(message: Message) -> None:
+        if message["type"] == "http.response.body":
+            events.append(f"body(more_body={message.get('more_body', False)})")
+            if not message.get("more_body", False):
+                response_complete.set()
+            await anyio.sleep(0.05)  # simulate slow client/send
+
+    await app(scope, receive, send)
+
+    assert events == [
+        "body(more_body=True)",
+        "body(more_body=False)",
+        "background",
+    ]
+
+
+@pytest.mark.anyio
+async def test_inner_and_outer_background_tasks_run_after_response_sent_with_base_http_middleware() -> None:
+    # Test for https://github.com/encode/starlette/issues/3458
+    events: list[str] = []
+    response_complete = anyio.Event()
+
+    async def inner_bg() -> None:
+        events.append("inner_background")
+
+    async def outer_bg() -> None:
+        events.append("outer_background")
+
+    async def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("hello", background=BackgroundTask(inner_bg))
+
+    async def attach_bg(request: Request, call_next: RequestResponseEndpoint) -> Response:
+        response = await call_next(request)
+        response.background = BackgroundTask(outer_bg)
+        return response
+
+    app = Starlette(
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=attach_bg)],
+        routes=[Route("/", homepage)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+    }
+
+    async def receive() -> Message:
+        raise NotImplementedError("Should not be called!")  # pragma: no cover
+
+    async def send(message: Message) -> None:
+        if message["type"] == "http.response.body":
+            events.append(f"body(more_body={message.get('more_body', False)})")
+            if not message.get("more_body", False):
+                response_complete.set()
+            await anyio.sleep(0.05)
+
+    await app(scope, receive, send)
+
+    assert events[:2] == [
+        "body(more_body=True)",
+        "body(more_body=False)",
+    ]
+    assert set(events[2:]) == {"inner_background", "outer_background"}
+
+
+@pytest.mark.anyio
 async def test_run_context_manager_exit_even_if_client_disconnects() -> None:
     # test for https://github.com/Kludex/starlette/issues/1678#issuecomment-1172916042
     response_complete = anyio.Event()


### PR DESCRIPTION
# Summary

Fixes #3458.

When `BaseHTTPMiddleware` is present in the middleware stack, downstream response handlers (such as `Response`, `StreamingResponse`, `FileResponse`) attached with a `BackgroundTask` previously executed their background task as soon as their ASGI messages were written to the middleware memory stream, before the outer `_StreamingResponse` completed transmitting all body bytes and the final closing message (`more_body=False`) to the client's ASGI `send`.

This change coordinates message delivery between the downstream application and `_StreamingResponse` using acknowledgement events, ensuring that the downstream response only finishes its final `send()` call (and therefore executes its background task) once the response body has been completely sent to the client.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

