### PR TITLE
Delay background task execution until BaseHTTPMiddleware sends the response

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -106,6 +106,7 @@ class BaseHTTPMiddleware:
         request = _CachedRequest(scope, receive)
         wrapped_receive = request.wrapped_receive
         response_sent = anyio.Event()
+        response_transmitted = anyio.Event()
         app_exc: Exception | None = None
         exception_already_raised = False
 
@@ -135,6 +136,17 @@ class BaseHTTPMiddleware:
                 except anyio.BrokenResourceError:
                     # recv_stream has been closed, i.e. response_sent has been set.
                     return
+                # The memory stream only guarantees that `_StreamingResponse` has
+                # picked the message up, not that it has reached the real `send`
+                # yet. For the last message of the response, hold the downstream
+                # app here until that actually happens, so that anything it runs
+                # right after sending (e.g. a background task) can't start before
+                # the response has genuinely been sent to the client.
+                is_last_message = message["type"] == "http.response.pathsend" or (
+                    message["type"] == "http.response.body" and not message.get("more_body", False)
+                )
+                if is_last_message:
+                    await response_transmitted.wait()
 
             async def coro() -> None:
                 nonlocal app_exc
@@ -192,6 +204,7 @@ class BaseHTTPMiddleware:
             async with create_collapsing_task_group() as task_group:
                 response = await self.dispatch_func(request, call_next)
                 await response(scope, wrapped_receive, send)
+                response_transmitted.set()
                 response_sent.set()
                 recv_stream.close()
         if app_exc is not None and not exception_already_raised:

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -412,6 +412,56 @@ async def test_do_not_block_on_background_tasks() -> None:
 
 
 @pytest.mark.anyio
+async def test_background_task_started_after_response_is_sent_to_client() -> None:
+    # Regression test for https://github.com/encode/starlette/issues/3458
+    #
+    # `send_no_error` used to return as soon as the final body message reached
+    # the middleware's internal memory stream, not once it had actually been
+    # forwarded to the real `send`. With a slow client, that let a response's
+    # background task start well before the last byte had gone out.
+    events: list[str] = []
+
+    async def sleep_and_set() -> None:
+        events.append("background started")
+
+    async def endpoint_with_background_task(_: Request) -> PlainTextResponse:
+        return PlainTextResponse("hello", background=BackgroundTask(sleep_and_set))
+
+    async def passthrough(request: Request, call_next: RequestResponseEndpoint) -> Response:
+        return await call_next(request)
+
+    app = Starlette(
+        middleware=[Middleware(BaseHTTPMiddleware, dispatch=passthrough)],
+        routes=[Route("/", endpoint_with_background_task)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+    }
+
+    async def receive() -> Message:
+        raise NotImplementedError("Should not be called!")
+
+    async def send(message: Message) -> None:
+        if message["type"] == "http.response.body":
+            events.append("sent more_body=%s" % message.get("more_body", False))
+        # Simulate a slow client: every write to the real socket takes a
+        # while, which is what lets a background task race ahead of it.
+        await anyio.sleep(0.01)
+
+    await app(scope, receive, send)
+
+    assert events == [
+        "sent more_body=True",
+        "sent more_body=False",
+        "background started",
+    ]
+
+
+@pytest.mark.anyio
 async def test_run_context_manager_exit_even_if_client_disconnects() -> None:
     # test for https://github.com/Kludex/starlette/issues/1678#issuecomment-1172916042
     response_complete = anyio.Event()


### PR DESCRIPTION
Closes #3458.

When `BaseHTTPMiddleware` wraps an app, the wrapped response hands its final ASGI message off to the middleware's internal memory stream and then runs its own background task right away, without waiting for `_StreamingResponse` to actually forward that data through the real `send` callable. With a slow client, this lets a background task (logging, cache invalidation, metrics, etc.) start well before the last byte has gone out, which contradicts the documented guarantee that a background task runs only once the response has been sent.

Root cause: `send_no_error`'s call to `send_stream.send(message)` only rendezvous with `_StreamingResponse`'s internal generator picking the message up, not with that data actually reaching the outer `send`. For every message except the last one, that gap doesn't matter, but for the terminal message it means the downstream app can resume (and run its background task) before the real transmission finishes.

The fix adds a `response_transmitted` event that's set once the outer `await response(...)` call has finished writing everything to the real `send`, and makes `send_no_error` wait on it before returning for the terminal message only. Every other message is handed off exactly as before.

Added a regression test with a slow real `send` (mirroring the repro in the issue) that fails without the fix, since the background task fires right after the middleware's internal handoff instead of after the actual transmission.

Ran the full test suite plus ruff/mypy on the touched files; `starlette/middleware/base.py` stays at 100% branch coverage.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

