### PR TITLE
Document trusted hosts for URL generation

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -210,47 +210,10 @@ url = app.url_path_for("user_detail", username=...)
 
 ### Trusted absolute URLs
 
-Choose the URL source based on where you will use the URL.
+Use this pattern for absolute URLs that must always point to your public site, such as password reset links and OAuth
+callbacks. An absolute URL includes an origin and path. The origin is the scheme, hostname, and port.
 
-#### Match the current request
-
-Use `request.url_for()` when the URL should match the scheme, hostname, and port of the current request. This is suitable
-for links and redirects returned to the same client. Configure
-[TrustedHostMiddleware](middleware.md#trustedhostmiddleware) to reject unexpected hostnames before generating the URL:
-
-```python
-from __future__ import annotations
-
-from starlette.applications import Starlette
-from starlette.middleware import Middleware
-from starlette.middleware.trustedhost import TrustedHostMiddleware
-from starlette.requests import Request
-from starlette.responses import PlainTextResponse
-from starlette.routing import Route
-
-
-async def homepage(request: Request) -> PlainTextResponse:
-    return PlainTextResponse(str(request.url_for("homepage")))
-
-
-routes = [Route("/", homepage, name="homepage")]
-middleware = [Middleware(TrustedHostMiddleware, allowed_hosts=["example.com"])]
-app = Starlette(routes=routes, middleware=middleware)
-```
-
-`request.url_for()` uses the request scheme and the authority from the `Host` header. The authority contains the
-hostname and an optional port. The client can choose the `Host` value, so you should validate it before using the
-generated URL.
-
-!!! warning "The port is not validated"
-
-    `TrustedHostMiddleware` validates the hostname but does not restrict the port. Use a configured public base URL when
-    the complete origin must be trusted.
-
-#### Use a fixed public origin
-
-An origin is the scheme, hostname, and port. Use a configured public base URL for links in emails, OAuth callbacks, and
-other URLs used outside the current response:
+Configure the public base URL and combine it with the path returned by `app.url_path_for()`:
 
 ```python
 from __future__ import annotations
@@ -276,6 +239,12 @@ app = Starlette(routes=routes)
 `app.url_path_for()` returns the route path. `make_absolute_url()` combines that path with the configured URL without
 using request data. The scheme, hostname, and port come from your configuration. Include the deployment prefix in this
 URL when your application uses a `root_path`, such as `https://example.com/api`.
+
+!!! warning "Validate request-derived URLs"
+
+    `request.url_for()` uses the request scheme and the authority from the `Host` header. A client can choose the `Host`
+    value, including its port. Configure [TrustedHostMiddleware](middleware.md#trustedhostmiddleware) to reject
+    unexpected hostnames. The middleware validates the hostname but does not restrict the port.
 
 ## Host-based routing
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -193,16 +193,17 @@ An absolute URL includes the scheme and host. `request.url_for()` returns an abs
 header. The `Host` header identifies the domain that received the request.
 
 [TrustedHostMiddleware](middleware.md#trustedhostmiddleware) rejects a request when its `Host` is not allowed. This
-prevents a client from making `request.url_for()` generate a URL for an unexpected domain.
+prevents a client from making `request.url_for()` generate a URL for an unexpected domain. It validates the hostname but
+does not restrict the port.
 
 For links in emails, OAuth callbacks, and other URLs used outside the current response, use a configured public base URL.
 `app.url_path_for()` returns the route path. `make_absolute_url()` combines that path with the configured URL without
-using request data.
+using request data. This ensures that the scheme, hostname, and port come from your configuration.
 
 !!! warning "Validate the Host header"
 
-    A client can choose any syntactically valid `Host` header. Configure `TrustedHostMiddleware` before using
-    request-derived absolute URLs in security-sensitive contexts.
+    A client can choose any syntactically valid `Host` header, including its port. Configure `TrustedHostMiddleware`
+    before using request-derived absolute URLs. Use a configured public base URL when the complete origin must be trusted.
 
 URL lookups can include path parameters...
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -164,6 +164,8 @@ url = request.url_for("homepage")
 
 ### Generate trusted absolute URLs
 
+`request.url_for()` needs a validated `Host` header. A configured public base URL avoids request data entirely:
+
 ```python
 from starlette.applications import Starlette
 from starlette.middleware import Middleware

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -210,10 +210,10 @@ url = app.url_path_for("user_detail", username=...)
 
 ### Trusted absolute URLs
 
-Use this pattern for absolute URLs that must always point to your public site, such as password reset links and OAuth
-callbacks. An absolute URL includes an origin and path. The origin is the scheme, hostname, and port.
+Use a configured public base URL when an absolute URL must always point to your public site, such as password reset links
+and OAuth callbacks. An absolute URL includes an origin and path. The origin is the scheme, hostname, and port.
 
-Configure the public base URL and combine it with the path returned by `app.url_path_for()`:
+Combine the configured URL with the path returned by `app.url_path_for()`:
 
 ```python
 from __future__ import annotations

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -162,6 +162,46 @@ routes = [
 url = request.url_for("homepage")
 ```
 
+### Generate trusted absolute URLs
+
+```python
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+
+PUBLIC_BASE_URL = "https://example.com"
+
+
+async def homepage(request: Request) -> JSONResponse:
+    request_url = request.url_for("homepage")
+    public_url = app.url_path_for("homepage").make_absolute_url(PUBLIC_BASE_URL)
+    return JSONResponse({"request_url": str(request_url), "public_url": str(public_url)})
+
+
+routes = [Route("/", homepage, name="homepage")]
+middleware = [Middleware(TrustedHostMiddleware, allowed_hosts=["example.com"])]
+app = Starlette(routes=routes, middleware=middleware)
+```
+
+An absolute URL includes the scheme and host. `request.url_for()` returns an absolute URL using the request's `Host`
+header. The `Host` header identifies the domain that received the request.
+
+[TrustedHostMiddleware](middleware.md#trustedhostmiddleware) rejects a request when its `Host` is not allowed. This
+prevents a client from making `request.url_for()` generate a URL for an unexpected domain.
+
+For links in emails, OAuth callbacks, and other URLs used outside the current response, use a configured public base URL.
+`app.url_path_for()` returns the route path. `make_absolute_url()` combines that path with the configured URL without
+using request data.
+
+!!! warning "Validate the Host header"
+
+    A client can choose any syntactically valid `Host` header. Configure `TrustedHostMiddleware` before using
+    request-derived absolute URLs in security-sensitive contexts.
+
 URL lookups can include path parameters...
 
 ```python

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -162,49 +162,6 @@ routes = [
 url = request.url_for("homepage")
 ```
 
-### Generate trusted absolute URLs
-
-`request.url_for()` needs a validated `Host` header. A configured public base URL avoids request data entirely:
-
-```python
-from starlette.applications import Starlette
-from starlette.middleware import Middleware
-from starlette.middleware.trustedhost import TrustedHostMiddleware
-from starlette.requests import Request
-from starlette.responses import JSONResponse
-from starlette.routing import Route
-
-
-PUBLIC_BASE_URL = "https://example.com"
-
-
-async def homepage(request: Request) -> JSONResponse:
-    request_url = request.url_for("homepage")
-    public_url = app.url_path_for("homepage").make_absolute_url(PUBLIC_BASE_URL)
-    return JSONResponse({"request_url": str(request_url), "public_url": str(public_url)})
-
-
-routes = [Route("/", homepage, name="homepage")]
-middleware = [Middleware(TrustedHostMiddleware, allowed_hosts=["example.com"])]
-app = Starlette(routes=routes, middleware=middleware)
-```
-
-An absolute URL includes the scheme and host. `request.url_for()` returns an absolute URL using the request's `Host`
-header. The `Host` header identifies the domain that received the request.
-
-[TrustedHostMiddleware](middleware.md#trustedhostmiddleware) rejects a request when its `Host` is not allowed. This
-prevents a client from making `request.url_for()` generate a URL for an unexpected domain. It validates the hostname but
-does not restrict the port.
-
-For links in emails, OAuth callbacks, and other URLs used outside the current response, use a configured public base URL.
-`app.url_path_for()` returns the route path. `make_absolute_url()` combines that path with the configured URL without
-using request data. This ensures that the scheme, hostname, and port come from your configuration.
-
-!!! warning "Validate the Host header"
-
-    A client can choose any syntactically valid `Host` header, including its port. Configure `TrustedHostMiddleware`
-    before using request-derived absolute URLs. Use a configured public base URL when the complete origin must be trusted.
-
 URL lookups can include path parameters...
 
 ```python
@@ -250,6 +207,50 @@ against the application, although these will only return the URL path.
 ```python
 url = app.url_path_for("user_detail", username=...)
 ```
+
+### Trusted absolute URLs
+
+`request.url_for()` needs a validated `Host` header. A configured public base URL avoids request data entirely:
+
+```python
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+
+PUBLIC_BASE_URL = "https://example.com"
+
+
+async def homepage(request: Request) -> JSONResponse:
+    request_url = request.url_for("homepage")
+    public_url = app.url_path_for("homepage").make_absolute_url(PUBLIC_BASE_URL)
+    return JSONResponse({"request_url": str(request_url), "public_url": str(public_url)})
+
+
+routes = [Route("/", homepage, name="homepage")]
+middleware = [Middleware(TrustedHostMiddleware, allowed_hosts=["example.com"])]
+app = Starlette(routes=routes, middleware=middleware)
+```
+
+An absolute URL includes the scheme and host. `request.url_for()` uses the request scheme and the authority from the
+`Host` header. The authority contains the hostname and an optional port. The `Host` header reports which domain the
+client requested, but the client can choose its value.
+
+[TrustedHostMiddleware](middleware.md#trustedhostmiddleware) rejects a request when its hostname is not allowed. This
+prevents a client from making `request.url_for()` generate a URL for an unexpected domain.
+
+For links in emails, OAuth callbacks, and other URLs used outside the current response, use a configured public base
+URL. `app.url_path_for()` returns the route path. `make_absolute_url()` combines that path with the configured URL
+without using request data. This ensures that the scheme, hostname, and port come from your configuration. Include the
+deployment prefix in this URL when your application uses a `root_path`, such as `https://example.com/api`.
+
+!!! warning "TrustedHostMiddleware does not validate the port"
+
+    `TrustedHostMiddleware` validates the hostname but does not restrict the port. Use a configured public base URL when
+    the complete origin must be trusted.
 
 ## Host-based routing
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -210,24 +210,27 @@ url = app.url_path_for("user_detail", username=...)
 
 ### Trusted absolute URLs
 
-`request.url_for()` needs a validated `Host` header. A configured public base URL avoids request data entirely:
+Choose the URL source based on where you will use the URL.
+
+#### Match the current request
+
+Use `request.url_for()` when the URL should match the scheme, hostname, and port of the current request. This is suitable
+for links and redirects returned to the same client. Configure
+[TrustedHostMiddleware](middleware.md#trustedhostmiddleware) to reject unexpected hostnames before generating the URL:
 
 ```python
+from __future__ import annotations
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 
 
-PUBLIC_BASE_URL = "https://example.com"
-
-
-async def homepage(request: Request) -> JSONResponse:
-    request_url = request.url_for("homepage")
-    public_url = app.url_path_for("homepage").make_absolute_url(PUBLIC_BASE_URL)
-    return JSONResponse({"request_url": str(request_url), "public_url": str(public_url)})
+async def homepage(request: Request) -> PlainTextResponse:
+    return PlainTextResponse(str(request.url_for("homepage")))
 
 
 routes = [Route("/", homepage, name="homepage")]
@@ -235,22 +238,44 @@ middleware = [Middleware(TrustedHostMiddleware, allowed_hosts=["example.com"])]
 app = Starlette(routes=routes, middleware=middleware)
 ```
 
-An absolute URL includes the scheme and host. `request.url_for()` uses the request scheme and the authority from the
-`Host` header. The authority contains the hostname and an optional port. The `Host` header reports which domain the
-client requested, but the client can choose its value.
+`request.url_for()` uses the request scheme and the authority from the `Host` header. The authority contains the
+hostname and an optional port. The client can choose the `Host` value, so you should validate it before using the
+generated URL.
 
-[TrustedHostMiddleware](middleware.md#trustedhostmiddleware) rejects a request when its hostname is not allowed. This
-prevents a client from making `request.url_for()` generate a URL for an unexpected domain.
-
-For links in emails, OAuth callbacks, and other URLs used outside the current response, use a configured public base
-URL. `app.url_path_for()` returns the route path. `make_absolute_url()` combines that path with the configured URL
-without using request data. This ensures that the scheme, hostname, and port come from your configuration. Include the
-deployment prefix in this URL when your application uses a `root_path`, such as `https://example.com/api`.
-
-!!! warning "TrustedHostMiddleware does not validate the port"
+!!! warning "The port is not validated"
 
     `TrustedHostMiddleware` validates the hostname but does not restrict the port. Use a configured public base URL when
     the complete origin must be trusted.
+
+#### Use a fixed public origin
+
+An origin is the scheme, hostname, and port. Use a configured public base URL for links in emails, OAuth callbacks, and
+other URLs used outside the current response:
+
+```python
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+
+PUBLIC_BASE_URL = "https://example.com"
+
+
+async def homepage(_request: Request) -> PlainTextResponse:
+    path = app.url_path_for("homepage")
+    return PlainTextResponse(str(path.make_absolute_url(PUBLIC_BASE_URL)))
+
+
+routes = [Route("/", homepage, name="homepage")]
+app = Starlette(routes=routes)
+```
+
+`app.url_path_for()` returns the route path. `make_absolute_url()` combines that path with the configured URL without
+using request data. The scheme, hostname, and port come from your configuration. Include the deployment prefix in this
+URL when your application uses a `root_path`, such as `https://example.com/api`.
 
 ## Host-based routing
 


### PR DESCRIPTION
## Summary

- Explain that `request.url_for()` uses the request's `Host` header.
- Show how `TrustedHostMiddleware` validates request-derived absolute URLs.
- Show how to combine `app.url_path_for()` with a configured public base URL for emails and OAuth callbacks.

Closes #1855.

## Testing

- `uv run zensical build --clean`
- Executed the documented example with allowed and rejected hosts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
