### PR TITLE
Return 400 for invalid multipart parser input

### DIFF
--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -11,14 +11,17 @@ from starlette.datastructures import FormData, Headers, UploadFile
 
 if TYPE_CHECKING:
     import python_multipart as multipart
+    from python_multipart.exceptions import FormParserError, MultipartParseError
     from python_multipart.multipart import MultipartCallbacks, QuerystringCallbacks, parse_options_header
 else:
     try:
         try:
             import python_multipart as multipart
+            from python_multipart.exceptions import FormParserError, MultipartParseError
             from python_multipart.multipart import parse_options_header
         except ModuleNotFoundError:  # pragma: no cover
             import multipart
+            from multipart.exceptions import FormParserError, MultipartParseError
             from multipart.multipart import parse_options_header
     except ModuleNotFoundError:  # pragma: no cover
         multipart = None
@@ -268,8 +271,10 @@ class MultiPartParser:
             "on_end": self.on_end,
         }
 
-        # Create the parser.
-        parser = multipart.MultipartParser(boundary, callbacks)
+        try:
+            parser = multipart.MultipartParser(boundary, callbacks)
+        except FormParserError as exc:
+            raise MultiPartException("Invalid multipart data.") from exc
         try:
             # Feed the parser with data from the request.
             async for chunk in self.stream:
@@ -288,10 +293,12 @@ class MultiPartParser:
                 self._file_parts_to_write.clear()
                 self._file_parts_to_finish.clear()
             parser.finalize()
-        except BaseException:
+        except BaseException as exc:
             # Close all the files if parsing or reading the request stream fails.
             for file in self._files_to_close_on_error:
                 file.close()
+            if isinstance(exc, MultipartParseError):
+                raise MultiPartException("Invalid multipart data.") from exc
             raise
 
         return FormData(self.items)

--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -11,17 +11,17 @@ from starlette.datastructures import FormData, Headers, UploadFile
 
 if TYPE_CHECKING:
     import python_multipart as multipart
-    from python_multipart.exceptions import FormParserError, MultipartParseError
+    from python_multipart.exceptions import FormParserError
     from python_multipart.multipart import MultipartCallbacks, QuerystringCallbacks, parse_options_header
 else:
     try:
         try:
             import python_multipart as multipart
-            from python_multipart.exceptions import FormParserError, MultipartParseError
+            from python_multipart.exceptions import FormParserError
             from python_multipart.multipart import parse_options_header
         except ModuleNotFoundError:  # pragma: no cover
             import multipart
-            from multipart.exceptions import FormParserError, MultipartParseError
+            from multipart.exceptions import FormParserError
             from multipart.multipart import parse_options_header
     except ModuleNotFoundError:  # pragma: no cover
         multipart = None
@@ -273,9 +273,6 @@ class MultiPartParser:
 
         try:
             parser = multipart.MultipartParser(boundary, callbacks)
-        except FormParserError as exc:
-            raise MultiPartException("Invalid multipart data.") from exc
-        try:
             # Feed the parser with data from the request.
             async for chunk in self.stream:
                 parser.write(chunk)
@@ -297,7 +294,7 @@ class MultiPartParser:
             # Close all the files if parsing or reading the request stream fails.
             for file in self._files_to_close_on_error:
                 file.close()
-            if isinstance(exc, MultipartParseError):
+            if isinstance(exc, FormParserError):
                 raise MultiPartException("Invalid multipart data.") from exc
             raise
 

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -658,6 +658,57 @@ def test_missing_boundary_parameter(
         (Starlette(routes=[Mount("/", app=app)]), does_not_raise()),
     ],
 )
+def test_multipart_boundary_exceeds_limit(
+    app: ASGIApp,
+    expectation: AbstractContextManager[Exception],
+    test_client_factory: TestClientFactory,
+) -> None:
+    client = test_client_factory(app)
+    boundary = "X" * 257
+    with expectation:
+        response = client.post(
+            "/",
+            content=f"--{boundary}\r\n\r\n--{boundary}--\r\n".encode(),
+            headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+        )
+        assert response.status_code == 400
+        assert response.text == "Invalid multipart data."
+
+
+@pytest.mark.parametrize(
+    "app,expectation",
+    [
+        (app, pytest.raises(MultiPartException)),
+        (Starlette(routes=[Mount("/", app=app)]), does_not_raise()),
+    ],
+)
+def test_multipart_headers_exceed_limit(
+    app: ASGIApp,
+    expectation: AbstractContextManager[Exception],
+    test_client_factory: TestClientFactory,
+) -> None:
+    client = test_client_factory(app)
+    extra_headers = b"".join(f"X-Extra-{index}: value\r\n".encode() for index in range(8))
+    with expectation:
+        response = client.post(
+            "/",
+            content=(
+                b"--boundary\r\n"
+                b'Content-Disposition: form-data; name="field"\r\n' + extra_headers + b"\r\nvalue\r\n--boundary--\r\n"
+            ),
+            headers={"Content-Type": "multipart/form-data; boundary=boundary"},
+        )
+        assert response.status_code == 400
+        assert response.text == "Invalid multipart data."
+
+
+@pytest.mark.parametrize(
+    "app,expectation",
+    [
+        (app, pytest.raises(MultiPartException)),
+        (Starlette(routes=[Mount("/", app=app)]), does_not_raise()),
+    ],
+)
 def test_missing_name_parameter_on_content_disposition(
     app: ASGIApp,
     expectation: AbstractContextManager[Exception],


### PR DESCRIPTION
## Summary

- Translate multipart parser construction and parsing errors into `MultiPartException`.
- Return a consistent `400` response for invalid multipart boundaries and headers.
- Preserve cleanup and propagation for stream and file errors.

## Tests

- `scripts/test -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

