### PR TITLE
Honour Accept-Encoding qvalues in GZipMiddleware

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -329,7 +329,9 @@ header from bypassing the limit.
 
 ## GZipMiddleware
 
-Handles GZip responses for any request that includes `"gzip"` in the `Accept-Encoding` header.
+Handles GZip responses for any request whose `Accept-Encoding` header accepts the `gzip` content coding,
+following the rules in [RFC 9110, section 12.5.3](https://www.rfc-editor.org/rfc/rfc9110#section-12.5.3).
+A coding listed with a qvalue of `0` is not acceptable, so `Accept-Encoding: gzip;q=0` is not compressed.
 
 The middleware will handle both standard and streaming responses.
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -64,7 +64,7 @@ class GZipMiddleware:
 
         headers = Headers(scope=scope)
         responder: ASGIApp
-        if "gzip" in headers.get("Accept-Encoding", ""):
+        if _accepts_gzip(headers.get("Accept-Encoding", "")):
             responder = GZipResponder(
                 self.app,
                 self.minimum_size,
@@ -220,3 +220,36 @@ async def unattached_send(message: Message) -> NoReturn:
 
 def _normalize_content_types(content_types: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(content_type.partition(";")[0].strip().lower() for content_type in content_types)
+
+
+def _accepts_gzip(accept_encoding: str) -> bool:
+    """Whether `gzip` is acceptable per the rules in RFC 9110, section 12.5.3.
+
+    An explicit `gzip` entry wins over `*`, and either is unacceptable when it
+    carries a qvalue of 0. `x-gzip` is treated as equivalent to `gzip`, per
+    RFC 9110, section 8.4.1.3.
+    """
+    wildcard_qvalue: float | None = None
+
+    for element in accept_encoding.split(","):
+        coding, _, parameters = element.partition(";")
+        coding = coding.strip().lower()
+        if coding not in ("gzip", "x-gzip", "*"):
+            continue
+
+        qvalue = 1.0
+        for parameter in parameters.split(";"):
+            name, _, value = parameter.partition("=")
+            if name.strip().lower() == "q":
+                try:
+                    qvalue = float(value.strip())
+                except ValueError:  # A malformed weight is ignored.
+                    pass
+                break
+
+        if coding == "*":
+            wildcard_qvalue = qvalue
+        else:
+            return qvalue > 0
+
+    return wildcard_qvalue is not None and wildcard_qvalue > 0

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import zlib
 from typing import NoReturn
 
@@ -25,6 +26,9 @@ DEFAULT_EXCLUDED_CONTENT_TYPES = (
     "text/event-stream",
     "video/*",
 )
+
+# qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] ) -- RFC 9110, section 12.4.2.
+_QVALUE_RE = re.compile(r"0(?:\.[0-9]{0,3})?|1(?:\.0{0,3})?")
 
 _gzip_capacity_limiter: anyio.lowlevel.RunVar[anyio.CapacityLimiter] = anyio.lowlevel.RunVar("_gzip_capacity_limiter")
 
@@ -64,7 +68,7 @@ class GZipMiddleware:
 
         headers = Headers(scope=scope)
         responder: ASGIApp
-        if _accepts_gzip(headers.get("Accept-Encoding", "")):
+        if _accepts_gzip(",".join(headers.getlist("Accept-Encoding"))):
             responder = GZipResponder(
                 self.app,
                 self.minimum_size,
@@ -241,10 +245,8 @@ def _accepts_gzip(accept_encoding: str) -> bool:
         for parameter in parameters.split(";"):
             name, _, value = parameter.partition("=")
             if name.strip().lower() == "q":
-                try:
+                if _QVALUE_RE.fullmatch(value.strip()):  # A malformed weight is ignored.
                     qvalue = float(value.strip())
-                except ValueError:  # A malformed weight is ignored.
-                    pass
                 break
 
         if coding == "*":

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -448,8 +448,11 @@ def test_gzip_responder_normalizes_content_types(test_client_factory: TestClient
         # Codings that merely contain "gzip" are not gzip.
         ("notgzip", False),
         ("br", False),
-        # A malformed weight is ignored rather than treated as a rejection.
+        # A malformed weight is ignored rather than treated as a rejection,
+        # including values that float() would accept but the grammar does not.
         ("gzip;q=high", True),
+        ("gzip;q=-1", True),
+        ("gzip;q=0.0001", True),
     ],
 )
 def test_gzip_accept_encoding_negotiation(
@@ -469,3 +472,38 @@ def test_gzip_accept_encoding_negotiation(
     assert response.text == "x" * 4000
     assert response.headers["Vary"] == "Accept-Encoding"
     assert ("Content-Encoding" in response.headers) is expect_gzip
+
+
+@pytest.mark.anyio
+async def test_gzip_accept_encoding_across_multiple_field_lines() -> None:
+    # RFC 9110, section 5.3: field lines with the same name are combined by
+    # appending each value in order, separated by a comma.
+    events: list[Message] = []
+
+    async def homepage(request: Request) -> PlainTextResponse:
+        _ = await request.body()
+        return PlainTextResponse("x" * 4000, status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(GZipMiddleware)],
+    )
+
+    scope = {
+        "type": "http",
+        "version": "3",
+        "method": "GET",
+        "path": "/",
+        "headers": [(b"accept-encoding", b"br"), (b"accept-encoding", b"gzip")],
+    }
+
+    async def receive() -> Message:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: Message) -> None:
+        events.append(message)
+
+    await app(scope, receive, send)
+
+    assert events[0]["type"] == "http.response.start"
+    assert (b"content-encoding", b"gzip") in events[0]["headers"]

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -424,3 +424,48 @@ def test_gzip_responder_normalizes_content_types(test_client_factory: TestClient
     assert response.status_code == 200
     assert response.content == b"x" * 4000
     assert "Content-Encoding" not in response.headers
+
+
+@pytest.mark.parametrize(
+    "accept_encoding,expect_gzip",
+    [
+        # Examples from RFC 9110, section 12.5.3.
+        ("compress, gzip", True),
+        ("*", True),
+        ("compress;q=0.5, gzip;q=1.0", True),
+        ("gzip;q=1.0, identity; q=0.5, *;q=0", True),
+        # "a qvalue of 0 means 'not acceptable'".
+        ("gzip;q=0", False),
+        ("gzip;q=0.000", False),
+        ("identity, gzip;q=0", False),
+        ("*;q=0", False),
+        # An explicit entry takes precedence over the wildcard.
+        ("*, gzip;q=0", False),
+        ("*;q=0, gzip", True),
+        # "A recipient SHOULD consider 'x-gzip' to be equivalent to 'gzip'."
+        ("x-gzip", True),
+        ("x-gzip;q=0", False),
+        # Codings that merely contain "gzip" are not gzip.
+        ("notgzip", False),
+        ("br", False),
+        # A malformed weight is ignored rather than treated as a rejection.
+        ("gzip;q=high", True),
+    ],
+)
+def test_gzip_accept_encoding_negotiation(
+    accept_encoding: str, expect_gzip: bool, test_client_factory: TestClientFactory
+) -> None:
+    def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("x" * 4000, status_code=200)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(GZipMiddleware)],
+    )
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"accept-encoding": accept_encoding})
+    assert response.status_code == 200
+    assert response.text == "x" * 4000
+    assert response.headers["Vary"] == "Accept-Encoding"
+    assert ("Content-Encoding" in response.headers) is expect_gzip


### PR DESCRIPTION
# Summary

`GZipMiddleware` decided whether to compress with `"gzip" in headers.get("Accept-Encoding", "")` — a substring match over the raw header value. [RFC 9110 §12.5.3](https://www.rfc-editor.org/rfc/rfc9110#section-12.5.3) rule 3:

> If the representation's content coding is one of the content codings listed in the Accept-Encoding field value, then it is acceptable **unless it is accompanied by a qvalue of 0**. (As defined in Section 12.4.2, a qvalue of 0 means "not acceptable".)

Measured on `main`, 4000-byte `PlainTextResponse`:

```
Accept-Encoding: 'gzip;q=0'           -> Content-Encoding: 'gzip'   # client refused it
Accept-Encoding: 'identity, gzip;q=0' -> Content-Encoding: 'gzip'
Accept-Encoding: 'notgzip'            -> Content-Encoding: 'gzip'   # not a real coding
Accept-Encoding: '*'                  -> (none)                    # client accepts anything
```

`_accepts_gzip()` implements rule 3 instead: an explicit entry wins over `*`, and either is unacceptable at `q=0`. `x-gzip` is accepted too, per §8.4.1.3, which is also what the old substring match did.

**Behaviour change worth calling out:** `Accept-Encoding: *` now compresses, where it previously did not. That is rule 3's asterisk clause and it is in the RFC's own example list, but it is a change for anyone sending a bare `*`. Say the word and I'll restrict the patch to the `q=0` half.

The test is a parametrised conformance table seeded with the five examples printed in §12.5.3. Eight of its fifteen rows pass on `main` and are pins; seven change. Second commit, both from the cubic review, both verified before acting on them:

1. `float()` accepts strings the [§12.4.2](https://www.rfc-editor.org/rfc/rfc9110#section-12.4.2) `qvalue` grammar does not, so `gzip;q=-1` and `gzip;q=nan` were read as *rejections* while `gzip;q=inf` and `gzip;q=0.0001` were read as acceptances. Now matched against the grammar. **This one I introduced.**
2. `Accept-Encoding` is a list-based field and may arrive as several field lines; `headers.get()` returns only the first, so `br` / `gzip` on two lines missed the explicit token. Combined per [§5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3). **This half is pre-existing** — the old substring test had exactly the same gap — so it is a second, independent fix riding along; happy to split it out.

Mutants, all four measured against the final test set: reverting `gzip.py` to `main` fails 16 of the 34 new instances (8 cases) and nothing else, so the other 9 rows are pins; exact-token matching that ignores qvalues fails 12; keeping the `float()`/`try-except` qvalue parse fails 2; using `headers.get()` instead of the combined field lines fails 2.

Ran `scripts/check` (ruff format, mypy, ruff check — all clean) and `scripts/test`: 1241 passed, 2 xfailed, coverage 100% with `--fail-under=100`. Docs line for the middleware updated, since it described the old substring rule.

Not verified: I only exercised this through `TestClient`, not against a real server, and I did not benchmark — the helper runs once per request on a short header, but I have no measurement to offer.

AI assistance disclosure: investigated and drafted with the help of Claude Opus 5 (`claude-opus-5`); every command, measurement and mutant above was run and checked before submitting.

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

Left the first box unticked deliberately — there was no prior discussion. Happy to move this to an issue first if you'd rather.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


