### PR TITLE
Avoid deprecated anyio.abc.BlockingPortal alias in testclient

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -50,7 +50,7 @@ else:
                 stacklevel=2,
             )
 
-_PortalFactoryType = Callable[[], AbstractContextManager[anyio.abc.BlockingPortal]]
+_PortalFactoryType = Callable[[], AbstractContextManager[anyio.from_thread.BlockingPortal]]
 
 ASGIInstance = Callable[[Receive, Send], Awaitable[None]]
 ASGI2App = Callable[[Scope], ASGIInstance]
@@ -371,7 +371,7 @@ class _TestClientTransport(httpx.BaseTransport):
 class TestClient(httpx.Client):
     __test__ = False
     task: Future[None]
-    portal: anyio.abc.BlockingPortal | None = None
+    portal: anyio.from_thread.BlockingPortal | None = None
 
     def __init__(
         self,
@@ -414,7 +414,7 @@ class TestClient(httpx.Client):
         )
 
     @contextlib.contextmanager
-    def _portal_factory(self) -> Generator[anyio.abc.BlockingPortal, None, None]:
+    def _portal_factory(self) -> Generator[anyio.from_thread.BlockingPortal, None, None]:
         if self.portal is not None:
             yield self.portal
         else:

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -499,8 +499,8 @@ def test_testclient_does_not_emit_anyio_deprecation_warnings() -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
-        client = TestClient(mock_service)
-        assert client.portal is None
+        with TestClient(mock_service) as client:
+            assert client.portal is not None
 
     # Verify that fresh module import with DeprecationWarning treated as error passes
     subprocess.check_call(

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -490,3 +490,25 @@ def test_timeout_deprecation() -> None:
     ):
         client = TestClient(mock_service)
         client.get("/", timeout=1)
+
+
+def test_testclient_does_not_emit_anyio_deprecation_warnings() -> None:
+    import subprocess
+    import sys
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        client = TestClient(mock_service)
+        assert client.portal is None
+
+    # Verify that fresh module import with DeprecationWarning treated as error passes
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-W",
+            "error::DeprecationWarning",
+            "-c",
+            "import starlette.testclient; from starlette.testclient import TestClient",
+        ]
+    )


### PR DESCRIPTION
.