### PR TITLE
Use anyio.from_thread.BlockingPortal to avoid deprecation warning

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -50,7 +50,7 @@ else:
                 stacklevel=2,
             )
 
-_PortalFactoryType = Callable[[], AbstractContextManager[anyio.abc.BlockingPortal]]
+_PortalFactoryType = Callable[[], AbstractContextManager[anyio.from_thread.BlockingPortal]]
 
 ASGIInstance = Callable[[Receive, Send], Awaitable[None]]
 ASGI2App = Callable[[Scope], ASGIInstance]
@@ -371,7 +371,7 @@ class _TestClientTransport(httpx.BaseTransport):
 class TestClient(httpx.Client):
     __test__ = False
     task: Future[None]
-    portal: anyio.abc.BlockingPortal | None = None
+    portal: anyio.from_thread.BlockingPortal | None = None
 
     def __init__(
         self,
@@ -414,7 +414,7 @@ class TestClient(httpx.Client):
         )
 
     @contextlib.contextmanager
-    def _portal_factory(self) -> Generator[anyio.abc.BlockingPortal, None, None]:
+    def _portal_factory(self) -> Generator[anyio.from_thread.BlockingPortal, None, None]:
         if self.portal is not None:
             yield self.portal
         else:

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import subprocess
 import sys
 from asyncio import Task, current_task as asyncio_current_task
 from collections.abc import AsyncGenerator
@@ -490,3 +491,12 @@ def test_timeout_deprecation() -> None:
     ):
         client = TestClient(mock_service)
         client.get("/", timeout=1)
+
+
+def test_no_blocking_portal_deprecation_warning() -> None:
+    result = subprocess.run(
+        [sys.executable, "-W", "error::DeprecationWarning", "-c", "import starlette.testclient"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
# Summary

Fixes #3497.

In `anyio` 4.15.0+, `anyio.abc.BlockingPortal` was turned into a deprecated alias for `anyio.from_thread.BlockingPortal` (agronholm/anyio#1169). Because `_PortalFactoryType` is evaluated at module import time, importing `starlette.testclient` emitted:
```
DeprecationWarning: The anyio.abc.BlockingPortal alias is deprecated, use anyio.from_thread.BlockingPortal instead.
```
This causes test collection errors for downstream projects running with warnings as errors (e.g. `pydantic-ai`).

This PR updates `_PortalFactoryType`, `TestClient.portal`, and `TestClient._portal_factory` in `starlette/testclient.py` to use `anyio.from_thread.BlockingPortal` directly (which is already imported and supported across all `anyio>=3.6.2` versions), and adds a regression test.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

