### PR TITLE
Fix deprecated anyio.abc.BlockingPortal alias in testclient (#3497)

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -50,7 +50,7 @@ else:
                 stacklevel=2,
             )
 
-_PortalFactoryType = Callable[[], AbstractContextManager[anyio.abc.BlockingPortal]]
+_PortalFactoryType = Callable[[], AbstractContextManager[anyio.from_thread.BlockingPortal]]
 
 ASGIInstance = Callable[[Receive, Send], Awaitable[None]]
 ASGI2App = Callable[[Scope], ASGIInstance]
@@ -371,7 +371,7 @@ class _TestClientTransport(httpx.BaseTransport):
 class TestClient(httpx.Client):
     __test__ = False
     task: Future[None]
-    portal: anyio.abc.BlockingPortal | None = None
+    portal: anyio.from_thread.BlockingPortal | None = None
 
     def __init__(
         self,
@@ -414,7 +414,7 @@ class TestClient(httpx.Client):
         )
 
     @contextlib.contextmanager
-    def _portal_factory(self) -> Generator[anyio.abc.BlockingPortal, None, None]:
+    def _portal_factory(self) -> Generator[anyio.from_thread.BlockingPortal, None, None]:
         if self.portal is not None:
             yield self.portal
         else:

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -490,3 +490,26 @@ def test_timeout_deprecation() -> None:
     ):
         client = TestClient(mock_service)
         client.get("/", timeout=1)
+
+
+def test_import_does_not_emit_anyio_deprecation_warning() -> None:
+    """Importing starlette.testclient must not emit anyio's deprecation warning.
+
+    anyio 4.15.0 turned ``anyio.abc.BlockingPortal`` into a deprecated alias for
+    ``anyio.from_thread.BlockingPortal``. testclient.py referenced the alias at
+    import time, so merely importing the module raised a DeprecationWarning. We
+    import in a fresh subprocess and promote only anyio's DeprecationWarnings to
+    errors, so an unrelated deprecation from another dependency cannot make this
+    check spuriously fail.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-W", "error::DeprecationWarning:anyio", "-c", "import starlette.testclient"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "BlockingPortal alias is deprecated" not in result.stderr


### PR DESCRIPTION
`starlette/testclient.py` referenced `anyio.abc.BlockingPortal`, which anyio 4.15.0 (2026-09-02) turned into a deprecated lazy alias for `anyio.from_thread.BlockingPortal`. Because the references are evaluated at import time, merely importing `starlette.testclient` now emits:

```
DeprecationWarning: The anyio.abc.BlockingPortal alias is deprecated, use anyio.from_thread.BlockingPortal instead.
```

Fixes #3497

## Reproduction

```console
$ pip install "starlette==1.6.0" "anyio==4.15.0" httpx2
$ python -W error::DeprecationWarning -c "import starlette.testclient"
```

## Fix

Replace the three `anyio.abc.BlockingPortal` references (the `_PortalFactoryType` alias, the `TestClient.portal` annotation, and the `_portal_factory` return annotation) with `anyio.from_thread.BlockingPortal`, which is already imported. `import anyio.abc` is kept because `anyio.abc.TaskStatus` is still used in the module.

## Tests

Added `test_import_does_not_emit_anyio_deprecation_warning`, which imports `starlette.testclient` in a fresh subprocess with `-W error::DeprecationWarning`. Verified it fails before the change and passes after. Full `tests/test_testclient.py` passes (59 tests); `ruff check`/`format` clean.

Note: with anyio 4.15.0 `mypy` reports pre-existing `create_memory_object_stream` assignment errors (lines 137/139/497/499) unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

