### PR TITLE
fix: use anyio.from_thread.BlockingPortal to avoid deprecation warning (Fixes #3497)

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -50,7 +50,7 @@ else:
                 stacklevel=2,
             )
 
-_PortalFactoryType = Callable[[], AbstractContextManager[anyio.abc.BlockingPortal]]
+_PortalFactoryType = Callable[[], AbstractContextManager[anyio.from_thread.BlockingPortal]]
 
 ASGIInstance = Callable[[Receive, Send], Awaitable[None]]
 ASGI2App = Callable[[Scope], ASGIInstance]
@@ -371,7 +371,7 @@ class _TestClientTransport(httpx.BaseTransport):
 class TestClient(httpx.Client):
     __test__ = False
     task: Future[None]
-    portal: anyio.abc.BlockingPortal | None = None
+    portal: anyio.from_thread.BlockingPortal | None = None
 
     def __init__(
         self,
@@ -414,7 +414,7 @@ class TestClient(httpx.Client):
         )
 
     @contextlib.contextmanager
-    def _portal_factory(self) -> Generator[anyio.abc.BlockingPortal, None, None]:
+    def _portal_factory(self) -> Generator[anyio.from_thread.BlockingPortal, None, None]:
         if self.portal is not None:
             yield self.portal
         else:


### PR DESCRIPTION
### Summary of Changes

In AnyIO 4.15.0, `anyio.abc.BlockingPortal` became a deprecated alias emitting a `DeprecationWarning: The anyio.abc.BlockingPortal alias is deprecated, use anyio.from_thread.BlockingPortal instead.`

Because `_PortalFactoryType` in `starlette/testclient.py` is evaluated at import time, importing `starlette.testclient` raises this warning and causes test collection errors downstream in projects running with `-W error` (such as `pydantic-ai`).

This PR updates the annotations in `starlette/testclient.py` to use `anyio.from_thread.BlockingPortal`, which avoids the warning and is consistent with the existing import of `anyio.from_thread` on line 19 and usage on line 421.

Fixes #3497


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

