### PR TITLE
Support Python 3.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -14,7 +14,7 @@ import pytest
 
 from starlette.applications import Starlette
 from starlette.datastructures import Headers, UploadFile
-from starlette.formparsers import FormParser, MultiPartException, MultiPartParser, _user_safe_decode
+from starlette.formparsers import FormParser, MultiPartException, MultiPartParser
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Mount
@@ -613,14 +613,26 @@ async def test_urlencoded_limits_stop_parsing_within_a_single_chunk() -> None:
     assert sum(len(data) for _, data in parser.messages) <= 1024
 
 
-def test_user_safe_decode_helper() -> None:
-    result = _user_safe_decode(b"\xc4\x99\xc5\xbc\xc4\x87", "utf-8")
-    assert result == "ężć"
-
-
-def test_user_safe_decode_ignores_wrong_charset() -> None:
-    result = _user_safe_decode(b"abc", "latin-8")
-    assert result == "abc"
+@pytest.mark.parametrize(
+    "charset,value,expected",
+    [
+        ("utf-8", b"\xc4\x99\xc5\xbc\xc4\x87", "ężć"),
+        ("utf-8", b"\xe9", "é"),
+        ("invalid-charset", b"\xe9", "é"),
+    ],
+)
+def test_multipart_request_decodes_charset(
+    charset: str, value: bytes, expected: str, test_client_factory: TestClientFactory
+) -> None:
+    content = b'--boundary\r\nContent-Disposition: form-data; name="value"\r\n\r\n' + value + b"\r\n--boundary--\r\n"
+    client = test_client_factory(app)
+    response = client.post(
+        "/",
+        content=content,
+        headers={"Content-Type": f"multipart/form-data; charset={charset}; boundary=boundary"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"value": expected}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add Python 3.15 to the CI matrix and package classifiers. Replace the charset helper tests with multipart requests covering valid UTF-8, invalid UTF-8, and an unknown charset, since Python 3.15 recognizes the previously invalid `latin-8` alias.

Validated with 1,207 passing tests and 100% coverage on Python 3.15.0rc1, charset tests on Python 3.10 through 3.14, and passing lint, type, package, and docs checks.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

