### PR TITLE
Support partitioned cookies in SessionMiddleware

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -231,6 +231,7 @@ The following arguments are supported:
 * `path` - The path set for the session cookie. Defaults to `'/'`.
 * `https_only` - Indicate that the `"Secure"` flag should be set (can be used with HTTPS only). Defaults to `False`. Set this to `True` in production to ensure the session cookie is only sent over HTTPS.
 * `domain` - Domain of the cookie used to share cookie between subdomains or cross-domains. The browser defaults the domain to the same host that set the cookie, excluding subdomains ([reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#domain_attribute)).
+* `partitioned` - Set the `Partitioned` flag when you write or clear the session cookie. Defaults to `False`. Set `https_only=True` when you enable it. For cross-site embeds, also set `same_site="none"`. This gives your embedded app a separate session for each top-level site ([reference](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies)).
 
 
 ```python

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -24,6 +24,7 @@ class SessionMiddleware:
         same_site: Literal["lax", "strict", "none"] = "lax",
         https_only: bool = False,
         domain: str | None = None,
+        partitioned: bool = False,
     ) -> None:
         self.app = app
         self.signer = itsdangerous.TimestampSigner(str(secret_key))
@@ -35,6 +36,8 @@ class SessionMiddleware:
             self.security_flags += "; secure"
         if domain is not None:
             self.security_flags += f"; domain={domain}"
+        if partitioned:
+            self.security_flags += "; partitioned"
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] not in ("http", "websocket"):  # pragma: no cover

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import re
 
 import pytest

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import re
 
+import httpx
 import pytest
 
 from starlette.applications import Starlette
@@ -74,6 +77,48 @@ def test_session(test_client_factory: TestClientFactory) -> None:
 
     response = client.get("/view_session")
     assert response.json() == {"session": {}}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("partitioned", [False, True])
+async def test_partitioned_session(partitioned: bool) -> None:
+    app = Starlette(
+        routes=[
+            Route("/view_session", endpoint=view_session),
+            Route("/update_session", endpoint=update_session, methods=["POST"]),
+            Route("/clear_session", endpoint=clear_session, methods=["POST"]),
+        ],
+        middleware=[
+            Middleware(
+                SessionMiddleware,
+                secret_key="example",
+                https_only=True,
+                same_site="none",
+                partitioned=partitioned,
+            )
+        ],
+    )
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="https://testserver") as client:
+        response = await client.post("/update_session", json={"some": "data"})
+        assert response.json() == {"session": {"some": "data"}}
+        attributes = response.headers["set-cookie"].split("; ")
+        assert ("partitioned" in attributes) is partitioned
+        assert "secure" in attributes
+        assert "samesite=none" in attributes
+
+        response = await client.get("/view_session")
+        assert response.json() == {"session": {"some": "data"}}
+
+        response = await client.post("/clear_session")
+        assert response.json() == {"session": {}}
+        attributes = response.headers["set-cookie"].split("; ")
+        assert ("partitioned" in attributes) is partitioned
+        assert "secure" in attributes
+        assert "samesite=none" in attributes
+        assert "expires=Thu, 01 Jan 1970 00:00:00 GMT" in attributes
+
+        response = await client.get("/view_session")
+        assert response.json() == {"session": {}}
 
 
 def test_session_expires(test_client_factory: TestClientFactory) -> None:

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -84,7 +84,6 @@ def test_session(test_client_factory: TestClientFactory) -> None:
 async def test_partitioned_session(partitioned: bool) -> None:
     app = Starlette(
         routes=[
-            Route("/view_session", endpoint=view_session),
             Route("/update_session", endpoint=update_session, methods=["POST"]),
             Route("/clear_session", endpoint=clear_session, methods=["POST"]),
         ],
@@ -100,25 +99,12 @@ async def test_partitioned_session(partitioned: bool) -> None:
     )
     async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="https://testserver") as client:
         response = await client.post("/update_session", json={"some": "data"})
-        assert response.json() == {"session": {"some": "data"}}
         attributes = response.headers["set-cookie"].split("; ")
         assert ("partitioned" in attributes) is partitioned
-        assert "secure" in attributes
-        assert "samesite=none" in attributes
-
-        response = await client.get("/view_session")
-        assert response.json() == {"session": {"some": "data"}}
 
         response = await client.post("/clear_session")
-        assert response.json() == {"session": {}}
         attributes = response.headers["set-cookie"].split("; ")
         assert ("partitioned" in attributes) is partitioned
-        assert "secure" in attributes
-        assert "samesite=none" in attributes
-        assert "expires=Thu, 01 Jan 1970 00:00:00 GMT" in attributes
-
-        response = await client.get("/view_session")
-        assert response.json() == {"session": {}}
 
 
 def test_session_expires(test_client_factory: TestClientFactory) -> None:

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 
-import httpx
 import pytest
 
 from starlette.applications import Starlette
@@ -79,9 +78,8 @@ def test_session(test_client_factory: TestClientFactory) -> None:
     assert response.json() == {"session": {}}
 
 
-@pytest.mark.anyio
 @pytest.mark.parametrize("partitioned", [False, True])
-async def test_partitioned_session(partitioned: bool) -> None:
+def test_partitioned_session(test_client_factory: TestClientFactory, partitioned: bool) -> None:
     app = Starlette(
         routes=[
             Route("/update_session", endpoint=update_session, methods=["POST"]),
@@ -97,14 +95,14 @@ async def test_partitioned_session(partitioned: bool) -> None:
             )
         ],
     )
-    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="https://testserver") as client:
-        response = await client.post("/update_session", json={"some": "data"})
-        attributes = response.headers["set-cookie"].split("; ")
-        assert ("partitioned" in attributes) is partitioned
+    client = test_client_factory(app, base_url="https://testserver")
+    response = client.post("/update_session", json={"some": "data"})
+    attributes = response.headers["set-cookie"].split("; ")
+    assert ("partitioned" in attributes) is partitioned
 
-        response = await client.post("/clear_session")
-        attributes = response.headers["set-cookie"].split("; ")
-        assert ("partitioned" in attributes) is partitioned
+    response = client.post("/clear_session")
+    attributes = response.headers["set-cookie"].split("; ")
+    assert ("partitioned" in attributes) is partitioned
 
 
 def test_session_expires(test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
Add `partitioned=False` to `SessionMiddleware`. When enabled, include `Partitioned` when writing and clearing the session cookie, so embedded apps can maintain sessions scoped to each top-level site. Document `https_only=True` and `same_site="none"` for cross-site embeds.

Extract the partitioned-cookie support proposed in [#2527](https://github.com/Kludex/starlette/pull/2527) without its persistence or refresh changes. Add request-level tests for enabled and disabled partitioning on session creation and clearing.

Validation: 1,211 tests passed, 2 skipped, 2 expected failures; 100% coverage. Ruff lint/format and mypy passed on Python 3.14.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

