### PR TITLE
Drop support for AnyIO 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "anyio>=3.6.2,<5",
+    "anyio>=4.0.0,<5",
     "typing_extensions>=4.10.0; python_version < '3.13'",
 ]
 
@@ -54,7 +54,6 @@ dev = [
     "httpx2[zstd]>=2.0.0",
     "coverage>=7.8.2",
     "importlib-metadata==9.0.0",
-    # Pinned to 2.1.0: mypy 2.2+ no longer honors the tuple return type of `create_memory_object_stream.__new__`.
     "mypy==2.1.0",
     "opentelemetry-sdk==1.44.0",
     "pytest-codspeed>=4.1.1",

--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -22,12 +22,7 @@ else:  # pragma: no cover
     from typing_extensions import TypeIs
 
 if sys.version_info < (3, 11):  # pragma: no cover
-    try:
-        from exceptiongroup import BaseExceptionGroup
-    except ImportError:
-
-        class BaseExceptionGroup(BaseException):  # type: ignore[no-redef]
-            pass
+    from exceptiongroup import BaseExceptionGroup
 
 
 T = TypeVar("T")

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -186,8 +186,7 @@ class BaseHTTPMiddleware:
             response.raw_headers = message["headers"]
             return response
 
-        streams: anyio.create_memory_object_stream[Message] = anyio.create_memory_object_stream()
-        send_stream, recv_stream = streams
+        send_stream, recv_stream = anyio.create_memory_object_stream[Message]()
         with recv_stream, send_stream:
             async with create_collapsing_task_group() as task_group:
                 response = await self.dispatch_func(request, call_next)

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -7,7 +7,7 @@ import json
 import math
 import sys
 import warnings
-from collections.abc import Awaitable, Callable, Generator, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Awaitable, Callable, Generator, Iterable, Mapping, Sequence
 from concurrent.futures import Future
 from contextlib import AbstractContextManager
 from types import GeneratorType
@@ -134,10 +134,8 @@ class WebSocketTestSession:
         """
         The sub-thread in which the websocket session runs.
         """
-        send: anyio.create_memory_object_stream[Message] = anyio.create_memory_object_stream(math.inf)
-        send_tx, send_rx = send
-        receive: anyio.create_memory_object_stream[Message] = anyio.create_memory_object_stream(math.inf)
-        receive_tx, receive_rx = receive
+        send_tx, send_rx = anyio.create_memory_object_stream[Message](math.inf)
+        receive_tx, receive_rx = anyio.create_memory_object_stream[Message](math.inf)
         with send_tx, send_rx, receive_tx, receive_rx, anyio.CancelScope() as cs:
             self._receive_tx = receive_tx
             self._send_rx = send_rx
@@ -493,12 +491,8 @@ class TestClient(httpx.Client):
             def reset_portal() -> None:
                 self.portal = None
 
-            send: anyio.create_memory_object_stream[MutableMapping[str, Any] | None] = (
-                anyio.create_memory_object_stream(math.inf)
-            )
-            receive: anyio.create_memory_object_stream[MutableMapping[str, Any]] = anyio.create_memory_object_stream(
-                math.inf
-            )
+            send = anyio.create_memory_object_stream[Message | None](math.inf)
+            receive = anyio.create_memory_object_stream[Message](math.inf)
             for channel in (*send, *receive):
                 stack.callback(channel.close)
             self.stream_send = StapledObjectStream(*send)

--- a/uv.lock
+++ b/uv.lock
@@ -1535,7 +1535,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", specifier = ">=3.6.2,<5" },
+    { name = "anyio", specifier = ">=4.0.0,<5" },
     { name = "httpx", marker = "extra == 'full'", specifier = ">=0.27.0,<0.29.0" },
     { name = "httpx2", marker = "extra == 'full'", specifier = ">=2.0.0" },
     { name = "itsdangerous", marker = "extra == 'full'" },


### PR DESCRIPTION
Require `anyio>=4.0.0,<5`, use generic `create_memory_object_stream` calls, and remove the fallback for a missing `exceptiongroup` package on Python 3.10. This drops AnyIO 3 support and allows the mypy upgrade in [#3509](https://github.com/Kludex/starlette/pull/3509) without verbose tuple annotations; merge this prerequisite first.

Validation: full suite (1,211 passed, 100% coverage), lint, package build, and mypy 2.1.0/2.3.1. Middleware, TestClient, and WebSocket tests also pass on Python 3.10 with AnyIO 4.0.0 and Trio 0.22.2 (194 passed).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

