### PR TITLE
Document TestClient event loop isolation

### DIFF
--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -235,19 +235,15 @@ May raise `starlette.websockets.WebSocketDisconnect`.
 
 ### Asynchronous tests
 
-`TestClient` runs your application on its own event loop in a background thread.
-Sharing async resources, such as database connections, with another loop can raise
-`RuntimeError: ... attached to a different loop`.
+Sometimes you will want to do async things outside of your application.
+For example, you might want to check the state of your database after calling your app
+using your existing async database client/infrastructure.
 
-!!! warning "A pytest event loop fixture does not configure TestClient"
+For these situations, using `TestClient` is difficult because it creates its own event loop and async
+resources (like a database connection) often cannot be shared across event loops.
+The simplest way to work around this is to just make your entire test async and use an async client, like [httpx2.AsyncClient].
 
-    Defining an `event_loop` fixture does not make `TestClient` use that loop.
-
-For synchronous tests, create and close resources in [lifespan](lifespan.md#lifespan-state)
-and use [`TestClient` as a context manager](lifespan.md#running-lifespan-in-tests).
-
-To share resources between your test and application, use an async test with
-[httpx2.AsyncClient] and `ASGITransport`, so both run on the same loop:
+Here is an example of such a test:
 
 ```python
 from httpx2 import AsyncClient, ASGITransport
@@ -275,5 +271,11 @@ async def test_app() -> None:
         assert r.status_code == 200
         assert r.text == "Hello World!"
 ```
+
+!!! warning "A pytest event loop fixture does not configure TestClient"
+
+    Defining an `event_loop` fixture does not make `TestClient` use that loop.
+    For synchronous tests, create and close resources in [lifespan](lifespan.md#lifespan-state)
+    and use [`TestClient` as a context manager](lifespan.md#running-lifespan-in-tests).
 
 [httpx2.AsyncClient]: https://www.python-httpx.org/advanced/#calling-into-python-web-apps

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -235,15 +235,19 @@ May raise `starlette.websockets.WebSocketDisconnect`.
 
 ### Asynchronous tests
 
-Sometimes you will want to do async things outside of your application.
-For example, you might want to check the state of your database after calling your app
-using your existing async database client/infrastructure.
+`TestClient` runs your application on its own event loop in a background thread.
+Sharing async resources, such as database connections, with another loop can raise
+`RuntimeError: ... attached to a different loop`.
 
-For these situations, using `TestClient` is difficult because it creates its own event loop and async
-resources (like a database connection) often cannot be shared across event loops.
-The simplest way to work around this is to just make your entire test async and use an async client, like [httpx2.AsyncClient].
+!!! warning "A pytest event loop fixture does not configure TestClient"
 
-Here is an example of such a test:
+    Defining an `event_loop` fixture does not make `TestClient` use that loop.
+
+For synchronous tests, create and close resources in [lifespan](lifespan.md#lifespan-state)
+and use [`TestClient` as a context manager](lifespan.md#running-lifespan-in-tests).
+
+To share resources between your test and application, use an async test with
+[httpx2.AsyncClient] and `ASGITransport`, so both run on the same loop:
 
 ```python
 from httpx2 import AsyncClient, ASGITransport


### PR DESCRIPTION
Clarify that a pytest `event_loop` fixture does not configure `TestClient`'s loop. Point synchronous tests to lifespan resource management and context-managed `TestClient` usage.

Closes #1315.

Validation: strict documentation build, existing async documentation example, and `git diff --check` passed.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
