### PR TITLE
Include Vary: Origin on all normal CORS responses

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -84,11 +84,7 @@ class CORSMiddleware:
         headers = Headers(scope=scope)
         origin = headers.get("origin")
 
-        if origin is None:
-            await self.app(scope, receive, send)
-            return
-
-        if method == "OPTIONS" and "access-control-request-method" in headers:
+        if origin is not None and method == "OPTIONS" and "access-control-request-method" in headers:
             response = self.preflight_response(request_headers=headers)
             await response(scope, receive, send)
             return
@@ -160,20 +156,21 @@ class CORSMiddleware:
 
         message.setdefault("headers", [])
         headers = MutableHeaders(scope=message)
-        headers.update(self.simple_headers)
-        origin = request_headers["Origin"]
+        origin = request_headers.get("Origin")
+        if origin is not None:
+            headers.update(self.simple_headers)
 
-        # If credentials are allowed, then we must respond with the specific origin instead of '*'.
-        if self.allow_all_origins and self.allow_credentials:
+        if origin is not None and (
+            (self.allow_all_origins and self.allow_credentials)
+            or (not self.allow_all_origins and self.is_allowed_origin(origin=origin))
+        ):
             self.allow_explicit_origin(headers, origin)
-
-        # If we only allow specific origins, then we have to mirror back the Origin header in the response.
-        elif not self.allow_all_origins and self.is_allowed_origin(origin=origin):
-            self.allow_explicit_origin(headers, origin)
+        else:
+            headers["Vary"] = ", ".join([*headers.getlist("Vary"), "Origin"])
 
         await send(message)
 
     @staticmethod
     def allow_explicit_origin(headers: MutableHeaders, origin: str) -> None:
         headers["Access-Control-Allow-Origin"] = origin
-        headers.add_vary_header("Origin")
+        headers["Vary"] = ", ".join([*headers.getlist("Vary"), "Origin"])

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -160,10 +160,12 @@ class CORSMiddleware:
         if origin is not None:
             headers.update(self.simple_headers)
 
-        if origin is not None and (
-            (self.allow_all_origins and self.allow_credentials)
-            or (not self.allow_all_origins and self.is_allowed_origin(origin=origin))
-        ):
+        # If credentials are allowed, then we must respond with the specific origin instead of '*'.
+        if origin is not None and self.allow_all_origins and self.allow_credentials:
+            self.allow_explicit_origin(headers, origin)
+
+        # If we only allow specific origins, then we have to mirror back the Origin header in the response.
+        elif origin is not None and not self.allow_all_origins and self.is_allowed_origin(origin=origin):
             self.allow_explicit_origin(headers, origin)
         else:
             headers["Vary"] = ", ".join([*headers.getlist("Vary"), "Origin"])

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -1,5 +1,4 @@
 import pytest
-from httpx2 import ASGITransport, AsyncClient
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -571,7 +570,6 @@ def test_cors_private_network_access_disallowed(test_client_factory: TestClientF
     assert "access-control-allow-private-network" not in response.headers
 
 
-@pytest.mark.anyio
 @pytest.mark.parametrize(
     "allow_origins,allow_origin_regex,allow_credentials,origin,expected_origin",
     [
@@ -592,7 +590,8 @@ def test_cors_private_network_access_disallowed(test_client_factory: TestClientF
     ],
 )
 @pytest.mark.parametrize("vary_headers", [[], ["Accept-Encoding"], ["Accept-Encoding", "Accept-Language"], ["*"]])
-async def test_cors_vary_origin(
+def test_cors_vary_origin(
+    test_client_factory: TestClientFactory,
     allow_origins: list[str],
     allow_origin_regex: str | None,
     allow_credentials: bool,
@@ -612,8 +611,8 @@ async def test_cors_vary_origin(
         allow_origin_regex=allow_origin_regex,
         allow_credentials=allow_credentials,
     )
-    async with AsyncClient(transport=ASGITransport(app), base_url="https://server.example") as client:
-        response = await client.get("/", headers={"Origin": origin} if origin is not None else {})
+    client = test_client_factory(app)
+    response = client.get("/", headers={"Origin": origin} if origin is not None else {})
 
     assert response.status_code == 200
     assert response.text == "Homepage"
@@ -624,11 +623,12 @@ async def test_cors_vary_origin(
     )
 
 
-@pytest.mark.anyio
 @pytest.mark.parametrize(
     "headers", [{}, {"Access-Control-Request-Method": "GET"}, {"Origin": "https://allowed.example"}]
 )
-async def test_cors_vary_origin_on_non_preflight_options(headers: dict[str, str]) -> None:
+def test_cors_vary_origin_on_non_preflight_options(
+    test_client_factory: TestClientFactory, headers: dict[str, str]
+) -> None:
     async def options(request: Request) -> PlainTextResponse:
         return PlainTextResponse("Application OPTIONS")
 
@@ -636,17 +636,16 @@ async def test_cors_vary_origin_on_non_preflight_options(headers: dict[str, str]
         Starlette(routes=[Route("/", options, methods=["OPTIONS"])]),
         allow_origins=["https://allowed.example"],
     )
-    async with AsyncClient(transport=ASGITransport(app), base_url="https://server.example") as client:
-        response = await client.options("/", headers=headers)
+    client = test_client_factory(app)
+    response = client.options("/", headers=headers)
 
     assert response.status_code == 200
     assert response.text == "Application OPTIONS"
     assert response.headers["vary"] == "Origin"
 
 
-@pytest.mark.anyio
 @pytest.mark.parametrize("cors_outermost", [True, False])
-async def test_cors_vary_origin_with_gzip(cors_outermost: bool) -> None:
+def test_cors_vary_origin_with_gzip(test_client_factory: TestClientFactory, cors_outermost: bool) -> None:
     async def homepage(request: Request) -> PlainTextResponse:
         return PlainTextResponse("Homepage", headers={"Vary": "Accept-Language"})
 
@@ -656,8 +655,8 @@ async def test_cors_vary_origin_with_gzip(cors_outermost: bool) -> None:
     else:
         app = GZipMiddleware(CORSMiddleware(app, allow_origins=["https://allowed.example"]), minimum_size=0)
 
-    async with AsyncClient(transport=ASGITransport(app), base_url="https://server.example") as client:
-        response = await client.get("/", headers={"Origin": "https://allowed.example", "Accept-Encoding": "gzip"})
+    client = test_client_factory(app)
+    response = client.get("/", headers={"Origin": "https://allowed.example", "Accept-Encoding": "gzip"})
 
     assert response.status_code == 200
     assert response.text == "Homepage"

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -1,5 +1,3 @@
-import pytest
-
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,7 +5,6 @@ from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
-from starlette.types import ASGIApp
 from tests.types import TestClientFactory
 
 
@@ -70,6 +67,8 @@ def test_cors_allow_all(
     assert response.status_code == 200
     assert response.text == "Homepage"
     assert "access-control-allow-origin" not in response.headers
+    assert response.headers["vary"] == "Origin"
+    assert "access-control-allow-credentials" not in response.headers
 
 
 def test_cors_allow_all_except_credentials(
@@ -121,6 +120,7 @@ def test_cors_allow_all_except_credentials(
     assert response.status_code == 200
     assert response.text == "Homepage"
     assert "access-control-allow-origin" not in response.headers
+    assert response.headers["vary"] == "Origin"
 
 
 def test_cors_allow_specific_origin(
@@ -170,6 +170,7 @@ def test_cors_allow_specific_origin(
     assert response.status_code == 200
     assert response.text == "Homepage"
     assert "access-control-allow-origin" not in response.headers
+    assert response.headers["vary"] == "Origin"
 
 
 def test_cors_disallowed_preflight(
@@ -299,6 +300,11 @@ def test_cors_allow_all_methods(
         response = getattr(client, method)("/", headers=headers)
         assert response.status_code == 200
 
+    response = client.options("/", headers={"Access-Control-Request-Method": "GET"})
+    assert response.status_code == 200
+    assert response.text == "Homepage"
+    assert response.headers["vary"] == "Origin"
+
 
 def test_cors_allow_origin_regex(
     test_client_factory: TestClientFactory,
@@ -427,7 +433,9 @@ def test_cors_vary_header_defaults_to_origin(test_client_factory: TestClientFact
 
 def test_cors_vary_header_is_set_for_non_credentialed_request(test_client_factory: TestClientFactory) -> None:
     def homepage(request: Request) -> PlainTextResponse:
-        return PlainTextResponse("Homepage", status_code=200, headers={"Vary": "Accept-Encoding"})
+        response = PlainTextResponse("Homepage", headers={"Vary": "Accept-Encoding"})
+        response.headers.append("Vary", "Accept-Language")
+        return response
 
     app = Starlette(
         routes=[Route("/", endpoint=homepage)],
@@ -437,12 +445,14 @@ def test_cors_vary_header_is_set_for_non_credentialed_request(test_client_factor
 
     response = client.get("/", headers={"Origin": "https://someplace.org"})
     assert response.status_code == 200
-    assert response.headers["vary"] == "Accept-Encoding, Origin"
+    assert response.headers["vary"] == "Accept-Encoding, Accept-Language, Origin"
 
 
 def test_cors_vary_header_is_properly_set_for_credentialed_request(test_client_factory: TestClientFactory) -> None:
     def homepage(request: Request) -> PlainTextResponse:
-        return PlainTextResponse("Homepage", status_code=200, headers={"Vary": "Accept-Encoding"})
+        response = PlainTextResponse("Homepage", headers={"Vary": "Accept-Encoding"})
+        response.headers.append("Vary", "Accept-Language")
+        return response
 
     app = Starlette(
         routes=[Route("/", endpoint=homepage)],
@@ -452,7 +462,7 @@ def test_cors_vary_header_is_properly_set_for_credentialed_request(test_client_f
 
     response = client.get("/", headers={"Origin": "https://someplace.org"})
     assert response.status_code == 200
-    assert response.headers["vary"] == "Accept-Encoding, Origin"
+    assert response.headers["vary"] == "Accept-Encoding, Accept-Language, Origin"
 
 
 def test_cors_vary_header_is_properly_set_when_allow_origins_is_not_wildcard(
@@ -490,6 +500,7 @@ def test_cors_allowed_origin_does_not_leak_between_requests(test_client_factory:
 
     response = client.get("/", headers={"Origin": "https://other.org"})
     assert "access-control-allow-origin" not in response.headers
+    assert response.headers["vary"] == "Origin"
 
     response = client.get("/", headers={"Origin": "https://example.org"})
     assert response.headers["access-control-allow-origin"] == "https://example.org"
@@ -570,81 +581,14 @@ def test_cors_private_network_access_disallowed(test_client_factory: TestClientF
     assert "access-control-allow-private-network" not in response.headers
 
 
-@pytest.mark.parametrize(
-    "allow_origins,allow_credentials,origin,expected_origin,vary_headers",
-    [
-        (
-            ["https://example.org"],
-            False,
-            "https://example.org",
-            "https://example.org",
-            ["Accept-Encoding", "Accept-Language"],
-        ),
-        (["https://example.org"], False, "https://denied.example", None, ["Accept-Encoding", "Accept-Language"]),
-        (["https://example.org"], False, None, None, []),
-        (["*"], False, "https://example.org", "*", ["*"]),
-        (["*"], False, None, None, []),
-        (["*"], True, "https://example.org", "https://example.org", []),
-        (["*"], True, None, None, []),
-    ],
-)
-def test_cors_vary_origin(
-    test_client_factory: TestClientFactory,
-    allow_origins: list[str],
-    allow_credentials: bool,
-    origin: str | None,
-    expected_origin: str | None,
-    vary_headers: list[str],
-) -> None:
-    async def homepage(request: Request) -> PlainTextResponse:
-        response = PlainTextResponse("Homepage")
-        for vary in vary_headers:
-            response.headers.append("Vary", vary)
-        return response
-
-    app = CORSMiddleware(
-        Starlette(routes=[Route("/", homepage)]),
-        allow_origins=allow_origins,
-        allow_credentials=allow_credentials,
-    )
-    client = test_client_factory(app)
-    response = client.get("/", headers={"Origin": origin} if origin is not None else {})
-
-    assert response.status_code == 200
-    assert response.text == "Homepage"
-    assert {value.strip() for value in response.headers["vary"].split(",")} == {*vary_headers, "Origin"}
-    assert response.headers.get("access-control-allow-origin") == expected_origin
-    assert response.headers.get("access-control-allow-credentials") == (
-        "true" if allow_credentials and origin is not None else None
-    )
-
-
-def test_cors_vary_origin_on_options_without_origin(test_client_factory: TestClientFactory) -> None:
-    async def options(request: Request) -> PlainTextResponse:
-        return PlainTextResponse("Application OPTIONS")
-
-    app = CORSMiddleware(
-        Starlette(routes=[Route("/", options, methods=["OPTIONS"])]),
-        allow_origins=["https://allowed.example"],
-    )
-    client = test_client_factory(app)
-    response = client.options("/", headers={"Access-Control-Request-Method": "GET"})
-
-    assert response.status_code == 200
-    assert response.text == "Application OPTIONS"
-    assert response.headers["vary"] == "Origin"
-
-
-@pytest.mark.parametrize("cors_outermost", [True, False])
-def test_cors_vary_origin_with_gzip(test_client_factory: TestClientFactory, cors_outermost: bool) -> None:
+def test_cors_vary_origin_with_gzip(test_client_factory: TestClientFactory) -> None:
     async def homepage(request: Request) -> PlainTextResponse:
         return PlainTextResponse("Homepage", headers={"Vary": "Accept-Language"})
 
-    app: ASGIApp = Starlette(routes=[Route("/", homepage)])
-    if cors_outermost:
-        app = CORSMiddleware(GZipMiddleware(app, minimum_size=0), allow_origins=["https://allowed.example"])
-    else:
-        app = GZipMiddleware(CORSMiddleware(app, allow_origins=["https://allowed.example"]), minimum_size=0)
+    app = GZipMiddleware(
+        CORSMiddleware(Starlette(routes=[Route("/", homepage)]), allow_origins=["https://allowed.example"]),
+        minimum_size=0,
+    )
 
     client = test_client_factory(app)
     response = client.get("/", headers={"Origin": "https://allowed.example", "Accept-Encoding": "gzip"})

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -571,29 +571,26 @@ def test_cors_private_network_access_disallowed(test_client_factory: TestClientF
 
 
 @pytest.mark.parametrize(
-    "allow_origins,allow_origin_regex,allow_credentials,origin,expected_origin",
+    "allow_origins,allow_credentials,origin,expected_origin,vary_headers",
     [
-        (["https://allowed.example"], None, False, "https://allowed.example", "https://allowed.example"),
-        (["https://allowed.example"], None, False, "https://denied.example", None),
-        (["https://allowed.example"], None, False, None, None),
-        (["https://allowed.example"], None, False, "null", None),
-        ([], r"https://[a-z]+\.allowed\.example", False, "https://app.allowed.example", "https://app.allowed.example"),
-        ([], r"https://[a-z]+\.allowed\.example", False, "https://denied.example", None),
-        ([], r"https://[a-z]+\.allowed\.example", False, None, None),
-        (["*"], None, False, "https://allowed.example", "*"),
-        (["*"], None, False, "null", "*"),
-        (["*"], None, False, None, None),
-        (["*"], None, True, "https://allowed.example", "https://allowed.example"),
-        (["*"], None, True, "null", "null"),
-        (["*"], None, True, None, None),
-        ([], None, False, "https://denied.example", None),
+        (
+            ["https://example.org"],
+            False,
+            "https://example.org",
+            "https://example.org",
+            ["Accept-Encoding", "Accept-Language"],
+        ),
+        (["https://example.org"], False, "https://denied.example", None, ["Accept-Encoding", "Accept-Language"]),
+        (["https://example.org"], False, None, None, []),
+        (["*"], False, "https://example.org", "*", ["*"]),
+        (["*"], False, None, None, []),
+        (["*"], True, "https://example.org", "https://example.org", []),
+        (["*"], True, None, None, []),
     ],
 )
-@pytest.mark.parametrize("vary_headers", [[], ["Accept-Encoding"], ["Accept-Encoding", "Accept-Language"], ["*"]])
 def test_cors_vary_origin(
     test_client_factory: TestClientFactory,
     allow_origins: list[str],
-    allow_origin_regex: str | None,
     allow_credentials: bool,
     origin: str | None,
     expected_origin: str | None,
@@ -608,7 +605,6 @@ def test_cors_vary_origin(
     app = CORSMiddleware(
         Starlette(routes=[Route("/", homepage)]),
         allow_origins=allow_origins,
-        allow_origin_regex=allow_origin_regex,
         allow_credentials=allow_credentials,
     )
     client = test_client_factory(app)
@@ -623,12 +619,7 @@ def test_cors_vary_origin(
     )
 
 
-@pytest.mark.parametrize(
-    "headers", [{}, {"Access-Control-Request-Method": "GET"}, {"Origin": "https://allowed.example"}]
-)
-def test_cors_vary_origin_on_non_preflight_options(
-    test_client_factory: TestClientFactory, headers: dict[str, str]
-) -> None:
+def test_cors_vary_origin_on_options_without_origin(test_client_factory: TestClientFactory) -> None:
     async def options(request: Request) -> PlainTextResponse:
         return PlainTextResponse("Application OPTIONS")
 
@@ -637,7 +628,7 @@ def test_cors_vary_origin_on_non_preflight_options(
         allow_origins=["https://allowed.example"],
     )
     client = test_client_factory(app)
-    response = client.options("/", headers=headers)
+    response = client.options("/", headers={"Access-Control-Request-Method": "GET"})
 
     assert response.status_code == 200
     assert response.text == "Application OPTIONS"

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -1,9 +1,14 @@
+import pytest
+from httpx2 import ASGITransport, AsyncClient
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
+from starlette.types import ASGIApp
 from tests.types import TestClientFactory
 
 
@@ -421,7 +426,7 @@ def test_cors_vary_header_defaults_to_origin(test_client_factory: TestClientFact
     assert response.headers["vary"] == "Origin"
 
 
-def test_cors_vary_header_is_not_set_for_non_credentialed_request(test_client_factory: TestClientFactory) -> None:
+def test_cors_vary_header_is_set_for_non_credentialed_request(test_client_factory: TestClientFactory) -> None:
     def homepage(request: Request) -> PlainTextResponse:
         return PlainTextResponse("Homepage", status_code=200, headers={"Vary": "Accept-Encoding"})
 
@@ -433,7 +438,7 @@ def test_cors_vary_header_is_not_set_for_non_credentialed_request(test_client_fa
 
     response = client.get("/", headers={"Origin": "https://someplace.org"})
     assert response.status_code == 200
-    assert response.headers["vary"] == "Accept-Encoding"
+    assert response.headers["vary"] == "Accept-Encoding, Origin"
 
 
 def test_cors_vary_header_is_properly_set_for_credentialed_request(test_client_factory: TestClientFactory) -> None:
@@ -564,3 +569,102 @@ def test_cors_private_network_access_disallowed(test_client_factory: TestClientF
     assert response.status_code == 400
     assert response.text == "Disallowed CORS private-network"
     assert "access-control-allow-private-network" not in response.headers
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "allow_origins,allow_origin_regex,allow_credentials,origin,expected_origin",
+    [
+        (["https://allowed.example"], None, False, "https://allowed.example", "https://allowed.example"),
+        (["https://allowed.example"], None, False, "https://denied.example", None),
+        (["https://allowed.example"], None, False, None, None),
+        (["https://allowed.example"], None, False, "null", None),
+        ([], r"https://[a-z]+\.allowed\.example", False, "https://app.allowed.example", "https://app.allowed.example"),
+        ([], r"https://[a-z]+\.allowed\.example", False, "https://denied.example", None),
+        ([], r"https://[a-z]+\.allowed\.example", False, None, None),
+        (["*"], None, False, "https://allowed.example", "*"),
+        (["*"], None, False, "null", "*"),
+        (["*"], None, False, None, None),
+        (["*"], None, True, "https://allowed.example", "https://allowed.example"),
+        (["*"], None, True, "null", "null"),
+        (["*"], None, True, None, None),
+        ([], None, False, "https://denied.example", None),
+    ],
+)
+@pytest.mark.parametrize("vary_headers", [[], ["Accept-Encoding"], ["Accept-Encoding", "Accept-Language"], ["*"]])
+async def test_cors_vary_origin(
+    allow_origins: list[str],
+    allow_origin_regex: str | None,
+    allow_credentials: bool,
+    origin: str | None,
+    expected_origin: str | None,
+    vary_headers: list[str],
+) -> None:
+    async def homepage(request: Request) -> PlainTextResponse:
+        response = PlainTextResponse("Homepage")
+        for vary in vary_headers:
+            response.headers.append("Vary", vary)
+        return response
+
+    app = CORSMiddleware(
+        Starlette(routes=[Route("/", homepage)]),
+        allow_origins=allow_origins,
+        allow_origin_regex=allow_origin_regex,
+        allow_credentials=allow_credentials,
+    )
+    async with AsyncClient(transport=ASGITransport(app), base_url="https://server.example") as client:
+        response = await client.get("/", headers={"Origin": origin} if origin is not None else {})
+
+    assert response.status_code == 200
+    assert response.text == "Homepage"
+    assert {value.strip() for value in response.headers["vary"].split(",")} == {*vary_headers, "Origin"}
+    assert response.headers.get("access-control-allow-origin") == expected_origin
+    assert response.headers.get("access-control-allow-credentials") == (
+        "true" if allow_credentials and origin is not None else None
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "headers", [{}, {"Access-Control-Request-Method": "GET"}, {"Origin": "https://allowed.example"}]
+)
+async def test_cors_vary_origin_on_non_preflight_options(headers: dict[str, str]) -> None:
+    async def options(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("Application OPTIONS")
+
+    app = CORSMiddleware(
+        Starlette(routes=[Route("/", options, methods=["OPTIONS"])]),
+        allow_origins=["https://allowed.example"],
+    )
+    async with AsyncClient(transport=ASGITransport(app), base_url="https://server.example") as client:
+        response = await client.options("/", headers=headers)
+
+    assert response.status_code == 200
+    assert response.text == "Application OPTIONS"
+    assert response.headers["vary"] == "Origin"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("cors_outermost", [True, False])
+async def test_cors_vary_origin_with_gzip(cors_outermost: bool) -> None:
+    async def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("Homepage", headers={"Vary": "Accept-Language"})
+
+    app: ASGIApp = Starlette(routes=[Route("/", homepage)])
+    if cors_outermost:
+        app = CORSMiddleware(GZipMiddleware(app, minimum_size=0), allow_origins=["https://allowed.example"])
+    else:
+        app = GZipMiddleware(CORSMiddleware(app, allow_origins=["https://allowed.example"]), minimum_size=0)
+
+    async with AsyncClient(transport=ASGITransport(app), base_url="https://server.example") as client:
+        response = await client.get("/", headers={"Origin": "https://allowed.example", "Accept-Encoding": "gzip"})
+
+    assert response.status_code == 200
+    assert response.text == "Homepage"
+    assert response.headers["content-encoding"] == "gzip"
+    assert response.headers["access-control-allow-origin"] == "https://allowed.example"
+    assert {value.strip() for value in response.headers["vary"].split(",")} == {
+        "Accept-Language",
+        "Accept-Encoding",
+        "Origin",
+    }


### PR DESCRIPTION
# Summary

Add `Vary: Origin` to normal responses for denied or missing origins and wildcard configurations. Preserve existing `Vary` values, including separate header fields. Preflight handling is unchanged.

## Why this is needed

Starlette's CORS response headers depend on the request's `Origin`, but responses to missing or denied origins currently omit `Vary: Origin`.

For example, a cacheable response to `GET /data` without `Origin` contains no `Access-Control-Allow-Origin`. A browser or shared cache can then reuse that response for a request from an allowed origin. The browser rejects the response because the required CORS header is missing, even though the server would have allowed the request. This follows from the [HTTP cache matching rules](https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1) and the browser's [CORS check](https://fetch.spec.whatwg.org/#cors-check).

Wildcard configurations also need this change: Starlette sends `Access-Control-Allow-Origin: *` when `Origin` is present, but omits it when `Origin` is absent.

## Benefit for browsers

`Vary: Origin` tells caches to match the request's origin before reusing a response, including distinguishing an absent header from a present one. This prevents cache-induced CORS failures for allowed requests. Matching responses remain reusable under the usual cache freshness rules. The benefit is correct cache reuse; it does not reduce preflight requests, and additional variants can reduce cache hit rates. See [RFC 9111, section 4.1](https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1).

## Other implementations

The same approach is already used elsewhere, with a different wildcard strategy in Express:

| Implementation | Normal-response behavior |
| --- | --- |
| [Go `rs/cors`](https://github.com/rs/cors/blob/2f30c9cf7731f7b5e0e372678d05acb22f2c2b4a/cors.go#L396-L431) | Adds `Vary: Origin` before returning for missing or denied origins, including wildcard configurations. |
| [`django-cors-headers`](https://github.com/adamchainz/django-cors-headers/blob/d6a75e42e24b367c07d16df25359c6e14552a93f/src/corsheaders/middleware.py#L93-L114) | Adds `Vary: Origin` for CORS-enabled requests before checking whether the origin is present or allowed, including wildcard configurations. |
| [Express `cors`](https://github.com/expressjs/cors/blob/5317ebe670db2aaebc1d496eb5d33493deefb3ed/lib/index.js#L36-L70) | Static allowlist/regex options add `Vary: Origin` even when the origin does not match. Wildcard mode omits it and consistently sends `Access-Control-Allow-Origin: *`, including requests without `Origin`. |

## Validation

1,215 tests passed, with 100% coverage. Ruff formatting/lint, mypy, and version consistency checks passed.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly. (No documentation changes needed.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Credits

Co-authored with [Kamil Monicz (@Zaczero)](https://github.com/Zaczero), based on his CORS improvements proposed in [#3067](https://github.com/Kludex/starlette/pull/3067).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
