### PR TITLE
Vary CORS preflight responses by their request inputs

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -46,13 +46,11 @@ class CORSMiddleware:
 
         preflight_headers: dict[str, str] = {
             "Vary": (
-                "Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"
+                "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, "
+                "Access-Control-Request-Private-Network"
             )
         }
-        if preflight_explicit_allow_origin:
-            # The origin value will be set in preflight_response() if it is allowed.
-            preflight_headers["Vary"] = "Origin, " + preflight_headers["Vary"]
-        else:
+        if not preflight_explicit_allow_origin:
             preflight_headers["Access-Control-Allow-Origin"] = "*"
         preflight_headers.update(
             {

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -44,7 +44,9 @@ class CORSMiddleware:
         if expose_headers:
             simple_headers["Access-Control-Expose-Headers"] = ", ".join(expose_headers)
 
-        preflight_headers: dict[str, str] = {"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"}  # noqa: E501  # fmt: skip
+        preflight_headers: dict[str, str] = {
+            "Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"  # noqa: E501  # fmt: skip
+        }
         if not preflight_explicit_allow_origin:
             preflight_headers["Access-Control-Allow-Origin"] = "*"
         preflight_headers.update(

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -44,10 +44,14 @@ class CORSMiddleware:
         if expose_headers:
             simple_headers["Access-Control-Expose-Headers"] = ", ".join(expose_headers)
 
-        preflight_headers: dict[str, str] = {}
+        preflight_headers: dict[str, str] = {
+            "Vary": (
+                "Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"
+            )
+        }
         if preflight_explicit_allow_origin:
             # The origin value will be set in preflight_response() if it is allowed.
-            preflight_headers["Vary"] = "Origin"
+            preflight_headers["Vary"] = "Origin, " + preflight_headers["Vary"]
         else:
             preflight_headers["Access-Control-Allow-Origin"] = "*"
         preflight_headers.update(

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -44,12 +44,7 @@ class CORSMiddleware:
         if expose_headers:
             simple_headers["Access-Control-Expose-Headers"] = ", ".join(expose_headers)
 
-        preflight_headers: dict[str, str] = {
-            "Vary": (
-                "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, "
-                "Access-Control-Request-Private-Network"
-            )
-        }
+        preflight_headers: dict[str, str] = {"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"}  # noqa: E501  # fmt: skip
         if not preflight_explicit_allow_origin:
             preflight_headers["Access-Control-Allow-Origin"] = "*"
         preflight_headers.update(

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -107,8 +107,12 @@ def test_cors_allow_all_except_credentials(
     assert response.headers["access-control-allow-headers"] == "X-Example"
     assert "access-control-allow-credentials" not in response.headers
     assert response.headers["vary"] == (
-        "Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"
+        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"
     )
+
+    del headers["Origin"]
+    response = client.options("/", headers=headers)
+    assert response.status_code == 405
 
     # Test standard response
     headers = {"Origin": "https://example.org"}

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -42,7 +42,9 @@ def test_cors_allow_all(
     assert response.headers["access-control-allow-origin"] == "https://example.org"
     assert response.headers["access-control-allow-headers"] == "X-Example"
     assert response.headers["access-control-allow-credentials"] == "true"
-    assert response.headers["vary"] == "Origin"
+    assert response.headers["vary"] == (
+        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"
+    )
 
     # Test standard response
     headers = {"Origin": "https://example.org"}
@@ -104,7 +106,9 @@ def test_cors_allow_all_except_credentials(
     assert response.headers["access-control-allow-origin"] == "*"
     assert response.headers["access-control-allow-headers"] == "X-Example"
     assert "access-control-allow-credentials" not in response.headers
-    assert "vary" not in response.headers
+    assert response.headers["vary"] == (
+        "Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"
+    )
 
     # Test standard response
     headers = {"Origin": "https://example.org"}
@@ -201,6 +205,9 @@ def test_cors_disallowed_preflight(
     response = client.options("/", headers=headers)
     assert response.status_code == 400
     assert response.text == "Disallowed CORS origin, method, headers"
+    assert response.headers["vary"] == (
+        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"
+    )
     assert "access-control-allow-origin" not in response.headers
 
     # Bug specific test, https://github.com/Kludex/starlette/pull/1199
@@ -246,7 +253,9 @@ def test_preflight_allows_request_origin_if_origins_wildcard_and_credentials_all
     assert response.status_code == 200
     assert response.headers["access-control-allow-origin"] == "https://example.org"
     assert response.headers["access-control-allow-credentials"] == "true"
-    assert response.headers["vary"] == "Origin"
+    assert response.headers["vary"] == (
+        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network"
+    )
 
 
 def test_cors_preflight_allow_all_methods(
@@ -270,6 +279,11 @@ def test_cors_preflight_allow_all_methods(
         response = client.options("/", headers=headers)
         assert response.status_code == 200
         assert method in response.headers["access-control-allow-methods"]
+
+    response = client.options("/", headers={"Origin": "https://example.org", "Access-Control-Request-Method": "CUSTOM"})
+    assert response.status_code == 400
+    assert response.text == "Disallowed CORS method"
+    assert "Access-Control-Request-Method" in response.headers["vary"].split(", ")
 
 
 def test_cors_allow_all_methods(

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -284,6 +284,11 @@ def test_cors_preflight_allow_all_methods(
         assert response.status_code == 200
         assert method in response.headers["access-control-allow-methods"]
 
+
+def test_cors_preflight_rejects_custom_method_with_wildcard(test_client_factory: TestClientFactory) -> None:
+    app = Starlette(middleware=[Middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"])])
+    client = test_client_factory(app)
+
     response = client.options("/", headers={"Origin": "https://example.org", "Access-Control-Request-Method": "CUSTOM"})
     assert response.status_code == 400
     assert response.text == "Disallowed CORS method"


### PR DESCRIPTION
# Summary

Include `Origin`, the requested method, requested headers, and private-network request header in every preflight `Vary` value. This follows the normal-response changes in [#3516](https://github.com/Kludex/starlette/pull/3516).

## Why

For deployments that explicitly cache OPTIONS responses at a proxy, varying only by origin can reuse a response with the wrong allowed headers or rejection status. For example, `allow_headers=["*"]` mirrors the requested headers, so a response for `X-One` differs from one for `X-Two`.

Each added field can change the response:

| Request header | Response variation |
| --- | --- |
| `Origin` | Its presence selects preflight handling; without it, OPTIONS reaches the application. This matters even with wildcard origins and credentials disabled. |
| `Access-Control-Request-Method` | Allowed methods return 200; disallowed methods return 400. Even `allow_methods=["*"]` expands to known methods and rejects an unknown method. |
| `Access-Control-Request-Headers` | Headers are mirrored in wildcard mode or validated against the configured allowlist. |
| `Access-Control-Request-Private-Network` | Its presence adds an allow header when enabled, or causes a 400 response when disabled. |

Optional request headers are included in `Vary` even when absent, so absence can be distinguished from presence. The values are computed once during middleware initialization and apply to both successful and rejected preflights.

## Caching scope

HTTP normally treats [OPTIONS responses as non-cacheable](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7). This supplies defensive metadata for explicit proxy caching; it does not enable caching or change the browser's [separate preflight cache](https://fetch.spec.whatwg.org/#cors-preflight-cache), which uses `Access-Control-Max-Age`.

[Go's `rs/cors`](https://github.com/rs/cors/blob/2f30c9cf7731f7b5e0e372678d05acb22f2c2b4a/cors.go) also varies preflights by the requested method and headers. Starlette includes the private-network field even when disabled because its presence changes the rejection outcome.

## Validation

Extended existing tests and added a focused test for custom-method rejection with wildcard configuration. All 1,217 tests pass with 100% coverage; Ruff, mypy, and version consistency checks pass.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly. (No documentation changes needed.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Credits

Co-authored with [Kamil Monicz (@Zaczero)](https://github.com/Zaczero), based on his CORS improvements proposed in [#3067](https://github.com/Kludex/starlette/pull/3067).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
