### PR TITLE
fix: synchronize BackgroundTask execution in BaseHTTPMiddleware after response completion

### DIFF
--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -130,11 +130,13 @@ class BaseHTTPMiddleware:
                 return message
 
             async def send_no_error(message: Message) -> None:
+                ack = anyio.Event()
                 try:
-                    await send_stream.send(message)
+                    await send_stream.send((message, ack))
                 except anyio.BrokenResourceError:
                     # recv_stream has been closed, i.e. response_sent has been set.
                     return
+                await ack.wait()
 
             async def coro() -> None:
                 nonlocal app_exc
@@ -148,10 +150,12 @@ class BaseHTTPMiddleware:
             task_group.start_soon(coro)
 
             try:
-                message = await recv_stream.receive()
+                message, ack = await recv_stream.receive()
                 info = message.get("info", None)
                 if message["type"] == "http.response.debug" and info is not None:
-                    message = await recv_stream.receive()
+                    ack.set()
+                    message, ack = await recv_stream.receive()
+                ack.set()
             except anyio.EndOfStream:
                 if app_exc is not None:
                     nonlocal exception_already_raised
@@ -170,23 +174,26 @@ class BaseHTTPMiddleware:
 
             assert message["type"] == "http.response.start"
 
-            async def body_stream() -> BodyStreamGenerator:
-                async for message in recv_stream:
+            async def body_stream() -> AsyncGenerator[tuple[bytes | MutableMapping[str, Any], anyio.Event, bool], None]:
+                async for message, ack in recv_stream:
                     if message["type"] == "http.response.pathsend":
-                        yield message
+                        yield message, ack, True
                         break
                     assert message["type"] == "http.response.body", f"Unexpected message: {message}"
                     body = message.get("body", b"")
+                    more_body = message.get("more_body", False)
                     if body:
-                        yield body
-                    if not message.get("more_body", False):
+                        yield body, ack, not more_body
+                    else:
+                        ack.set()
+                    if not more_body:
                         break
 
             response = _StreamingResponse(status_code=message["status"], content=body_stream(), info=info)
             response.raw_headers = message["headers"]
             return response
 
-        send_stream, recv_stream = anyio.create_memory_object_stream[Message]()
+        send_stream, recv_stream = anyio.create_memory_object_stream[tuple[Message, anyio.Event]]()
         with recv_stream, send_stream:
             async with create_collapsing_task_group() as task_group:
                 response = await self.dispatch_func(request, call_next)
@@ -203,7 +210,7 @@ class BaseHTTPMiddleware:
 class _StreamingResponse(Response):
     def __init__(
         self,
-        content: AsyncContentStream,
+        content: Any,
         status_code: int = 200,
         headers: Mapping[str, str] | None = None,
         media_type: str | None = None,
@@ -228,13 +235,18 @@ class _StreamingResponse(Response):
         )
 
         should_close_body = True
-        async for chunk in self.body_iterator:
+        async for chunk, ack, is_last in self.body_iterator:
             if isinstance(chunk, dict):
                 # We got an ASGI message which is not response body (eg: pathsend)
                 should_close_body = False
                 await send(chunk)
+                ack.set()
                 continue
             await send({"type": "http.response.body", "body": chunk, "more_body": True})
+            if is_last and should_close_body:
+                await send({"type": "http.response.body", "body": b"", "more_body": False})
+                should_close_body = False
+            ack.set()
 
         if should_close_body:
             await send({"type": "http.response.body", "body": b"", "more_body": False})

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1316,3 +1316,50 @@ def test_error_context_propagation(test_client_factory: TestClientFactory) -> No
     assert str(ctx.value) == "Outer exception"
     assert ctx.value.__cause__ is not None
     assert str(ctx.value.__cause__) == "Inner exception"
+
+
+@pytest.mark.anyio
+async def test_background_task_runs_after_response_sent() -> None:
+    events: list[str] = []
+
+    async def bg() -> None:
+        events.append("background-done")
+
+    async def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("hello", background=BackgroundTask(bg))
+
+    async def passthrough(request: Request, call_next: RequestResponseEndpoint) -> Response:
+        return await call_next(request)
+
+    app = Starlette(routes=[Route("/", homepage)])
+    app = BaseHTTPMiddleware(app, dispatch=passthrough)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+        "query_string": b"",
+        "root_path": "",
+        "scheme": "http",
+        "server": ["t", 80],
+        "client": ("t", 1),
+        "http_version": "1.1",
+    }
+
+    async def receive() -> Message:
+        await anyio.sleep(3600)
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        events.append(message["type"])
+        await anyio.sleep(0.05)
+
+    await app(scope, receive, send)
+
+    assert events == [
+        "http.response.start",
+        "http.response.body",
+        "http.response.body",
+        "background-done",
+    ]

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1331,8 +1331,8 @@ async def test_background_task_runs_after_response_sent() -> None:
     async def passthrough(request: Request, call_next: RequestResponseEndpoint) -> Response:
         return await call_next(request)
 
-    app = Starlette(routes=[Route("/", homepage)])
-    app = BaseHTTPMiddleware(app, dispatch=passthrough)
+    inner_app = Starlette(routes=[Route("/", homepage)])
+    app = BaseHTTPMiddleware(inner_app, dispatch=passthrough)
 
     scope = {
         "type": "http",

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -1347,9 +1347,8 @@ async def test_background_task_runs_after_response_sent() -> None:
         "http_version": "1.1",
     }
 
-    async def receive() -> Message:
-        await anyio.sleep(3600)
-        return {"type": "http.disconnect"}
+    async def receive() -> Message:  # type: ignore[empty-body]
+        ...  # pragma: no cover
 
     async def send(message: Message) -> None:
         events.append(message["type"])


### PR DESCRIPTION
## Description

When `BaseHTTPMiddleware` is present in the middleware stack, a `BackgroundTask` attached to a response ran prematurely before the response body had finished transmitting to the client.

### Cause
The inner application's `Response.__call__` sends its messages into `BaseHTTPMiddleware`'s memory stream buffer (`send_stream`). Because `send_stream.send()` returns immediately once the message is in the buffer, `Response.__call__` invoked `await self.background()` before the outer `_StreamingResponse` had finished streaming all chunks to the downstream ASGI server's `send`.

### Changes
1. Updated `BaseHTTPMiddleware`'s memory object stream to pass acknowledgement synchronization events (`(Message, anyio.Event)`).
2. `send_no_error` in `call_next` awaits the acknowledgement event, ensuring `send()` in `Response.__call__` only unblocks after `_StreamingResponse` has dispatched the body chunk (and the final terminating empty body) to the real ASGI server `send`.
3. Added regression test `test_background_task_runs_after_response_sent` in `tests/middleware/test_base.py` verifying that background tasks execute strictly after all response body messages have completed transmission to the client.

Closes #3458


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

