### PR TITLE
Inline OpenTelemetryResponder and document middleware parameters

### DIFF
--- a/starlette/middleware/opentelemetry.py
+++ b/starlette/middleware/opentelemetry.py
@@ -19,6 +19,9 @@ class OpenTelemetryMiddleware:
     """Create OpenTelemetry server spans for incoming HTTP requests.
 
     Args:
+        app: The ASGI application to wrap.
+        excluded_urls: Regular expressions matched against the full request URL.
+            Pass a comma-separated string or a sequence. By default, exclude no URLs.
         tracer_provider: Optional tracer provider. If omitted, use the global tracer provider.
         meter_provider: Optional meter provider. If omitted, use the global meter provider.
     """
@@ -35,8 +38,8 @@ class OpenTelemetryMiddleware:
         self._meter_provider = meter_provider
         if isinstance(excluded_urls, str):
             excluded_urls = [pattern.strip() for pattern in excluded_urls.split(",")] if excluded_urls else ()
-        patterns = tuple(re.compile(pattern) for pattern in excluded_urls)
-        self._responder = OpenTelemetryResponder(app, patterns, tracer_provider)
+        self._excluded_urls = tuple(re.compile(pattern) for pattern in excluded_urls)
+        self._tracer_provider = tracer_provider or trace.get_tracer_provider()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or scope.get("starlette.opentelemetry"):
@@ -44,92 +47,77 @@ class OpenTelemetryMiddleware:
 
         scope["starlette.opentelemetry"] = True
         try:
-            await self._responder(scope, receive, send)
+            tracer_provider = self._tracer_provider
+            if isinstance(tracer_provider, trace.NoOpTracerProvider):
+                return await self.app(scope, receive, send)
+
+            url = URL(scope=scope)
+            if any(pattern.search(str(url)) for pattern in self._excluded_urls):
+                return await self.app(scope, receive, send)
+
+            original_method = scope.get("method", "")
+            method = original_method.upper()
+
+            headers: dict[str, list[str]] = {}
+            for name, value in scope.get("headers", []):
+                headers.setdefault(name.decode("latin-1").lower(), []).append(value.decode("latin-1"))
+
+            attributes: dict[str, str | int] = {
+                "http.request.method": method,
+                "url.path": scope.get("path", ""),
+                "url.scheme": scope.get("scheme", "http"),
+            }
+            if original_method != method:
+                attributes["http.request.method_original"] = original_method
+            if url.query:
+                attributes["url.query"] = url.query
+            if url.hostname is not None:
+                attributes["server.address"] = url.hostname
+                server = scope.get("server")
+                server_port = url.port if url.port is not None else server[1] if server is not None else None
+                if server_port is not None:
+                    attributes["server.port"] = server_port
+            if scope.get("http_version"):
+                attributes["network.protocol.version"] = scope["http_version"]
+            if scope.get("client") is not None:
+                attributes["client.address"] = scope["client"][0]
+            if headers.get("user-agent"):
+                attributes["user_agent.original"] = headers["user-agent"][0]
+
+            with tracer_provider.get_tracer("starlette", __version__).start_as_current_span(
+                method,
+                context=propagate.extract(headers),
+                kind=SpanKind.SERVER,
+                attributes=attributes,
+            ) as span:
+
+                async def send_with_telemetry(message: Message) -> None:
+                    if message["type"] == "http.response.start":
+                        status_code = message["status"]
+                        span.set_attribute("http.response.status_code", status_code)
+                        if status_code >= 500:
+                            span.set_attribute("error.type", str(status_code))
+                            span.set_status(Status(StatusCode.ERROR))
+                    await send(message)
+
+                try:
+                    await self.app(scope, receive, send_with_telemetry)
+                except Exception as exc:
+                    span.set_attribute("error.type", type(exc).__qualname__)
+                    raise
+                finally:
+                    route = scope.get("route")
+                    if isinstance(route, Mount):
+                        route_path = scope.get("root_path") or "/"
+                    else:
+                        path_format = getattr(route, "path_format", None)
+                        route_path = (
+                            scope.get("root_path", "").rstrip("/") + path_format or "/"
+                            if isinstance(path_format, str)
+                            else None
+                        )
+                    if route_path is not None:
+                        span.update_name(f"{method} {route_path}")
+                        span.set_attribute("http.route", route_path)
         finally:
             del scope["starlette.opentelemetry"]
-
-
-class OpenTelemetryResponder:
-    def __init__(
-        self,
-        app: ASGIApp,
-        excluded_urls: tuple[re.Pattern[str], ...],
-        tracer_provider: trace.TracerProvider | None,
-    ) -> None:
-        self.app = app
-        self._excluded_urls = excluded_urls
-        self._tracer_provider = tracer_provider or trace.get_tracer_provider()
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        tracer_provider = self._tracer_provider
-        if isinstance(tracer_provider, trace.NoOpTracerProvider):
-            return await self.app(scope, receive, send)
-
-        url = URL(scope=scope)
-        if any(pattern.search(str(url)) for pattern in self._excluded_urls):
-            return await self.app(scope, receive, send)
-
-        original_method = scope.get("method", "")
-        method = original_method.upper()
-
-        headers: dict[str, list[str]] = {}
-        for name, value in scope.get("headers", []):
-            headers.setdefault(name.decode("latin-1").lower(), []).append(value.decode("latin-1"))
-
-        attributes: dict[str, str | int] = {
-            "http.request.method": method,
-            "url.path": scope.get("path", ""),
-            "url.scheme": scope.get("scheme", "http"),
-        }
-        if original_method != method:
-            attributes["http.request.method_original"] = original_method
-        if url.query:
-            attributes["url.query"] = url.query
-        if url.hostname is not None:
-            attributes["server.address"] = url.hostname
-            server = scope.get("server")
-            server_port = url.port if url.port is not None else server[1] if server is not None else None
-            if server_port is not None:
-                attributes["server.port"] = server_port
-        if scope.get("http_version"):
-            attributes["network.protocol.version"] = scope["http_version"]
-        if scope.get("client") is not None:
-            attributes["client.address"] = scope["client"][0]
-        if headers.get("user-agent"):
-            attributes["user_agent.original"] = headers["user-agent"][0]
-
-        with tracer_provider.get_tracer("starlette", __version__).start_as_current_span(
-            method,
-            context=propagate.extract(headers),
-            kind=SpanKind.SERVER,
-            attributes=attributes,
-        ) as span:
-
-            async def send_with_telemetry(message: Message) -> None:
-                if message["type"] == "http.response.start":
-                    status_code = message["status"]
-                    span.set_attribute("http.response.status_code", status_code)
-                    if status_code >= 500:
-                        span.set_attribute("error.type", str(status_code))
-                        span.set_status(Status(StatusCode.ERROR))
-                await send(message)
-
-            try:
-                await self.app(scope, receive, send_with_telemetry)
-            except Exception as exc:
-                span.set_attribute("error.type", type(exc).__qualname__)
-                raise
-            finally:
-                route = scope.get("route")
-                if isinstance(route, Mount):
-                    route_path = scope.get("root_path") or "/"
-                else:
-                    path_format = getattr(route, "path_format", None)
-                    route_path = (
-                        scope.get("root_path", "").rstrip("/") + path_format or "/"
-                        if isinstance(path_format, str)
-                        else None
-                    )
-                if route_path is not None:
-                    span.update_name(f"{method} {route_path}")
-                    span.set_attribute("http.route", route_path)


### PR DESCRIPTION
Inline `OpenTelemetryResponder` into `OpenTelemetryMiddleware` and document `app` and `excluded_urls`. Tracing behavior stays unchanged.

Validation: 1,241 tests passed with 100% coverage; formatting, lint, type, and version checks passed.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] Existing public-API tests cover this refactor.
- [x] I've updated the documentation accordingly.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

