### PR TITLE
Stabilize CodSpeed upload buffer allocations

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,8 @@ jobs:
     env:
       PYTHONHASHSEED: "0"
       # https://sourceware.org/glibc/manual/latest/html_node/Hardware-Capability-Tunables.html
-      GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX512F,-AVX512VL,-AVX512BW,-ERMS,-FSRM"
+      # Keep upload buffers above a fixed mmap threshold to reduce heap-dependent realloc copies.
+      GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX512F,-AVX512VL,-AVX512BW,-ERMS,-FSRM:glibc.malloc.mmap_threshold=32768"
 
     steps:
       - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -115,6 +115,20 @@ Run it locally with:
 uv run pytest benchmarks/multipart_benchmark.py --codspeed
 ```
 
+On Linux with glibc, you can use the same allocator setting as CI:
+
+```console
+GLIBC_TUNABLES=glibc.malloc.mmap_threshold=32768 PYTHONHASHSEED=0 uv run pytest benchmarks/multipart_benchmark.py --codspeed
+```
+
+glibc normally adjusts the
+[`mmap` threshold](https://sourceware.org/glibc/manual/2.39/html_node/Memory-Allocation-Tunables.html)
+based on earlier allocations. This can make an upload buffer grow in place
+in one run and require a copy in another. CI fixes the threshold at 32 KiB,
+below the 64 KiB upload chunks, to reduce this variation. Allocation, parsing,
+and cleanup stay inside the measured region. Changing this setting shifts
+the simulation baseline, so compare runs that use the same setting.
+
 ## Routing
 
 The routing benchmark exercises `Router` dispatch through its ASGI interface


### PR DESCRIPTION
Pin glibc's `mmap` threshold to 32 KiB in benchmark CI to reduce heap-dependent upload buffer copies. The latest multipart regression profile showed a buffer growing in place in one run and being copied during `realloc` in another; changing the allocator setting shifts the simulation baseline once.

Validation: all 121 benchmarks passed locally and in Linux using the simulation execution path without measurement hooks, and `actionlint` passed. A Linux allocation probe found no heap-copy reallocations in the two flaky cases across 20 perturbed heap layouts with this setting; cross-runner CodSpeed measurements still need CI confirmation.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

