### PR TITLE
docs: the test client is built on httpx2, not httpx

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It is production-ready, and gives you the following:
 * WebSocket support.
 * In-process background tasks.
 * Startup and shutdown events.
-* Test client built on `httpx`.
+* Test client built on `httpx2`.
 * CORS, GZip, Static Files, Streaming responses.
 * Session and Cookie support.
 * 100% test coverage.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ It is production-ready, and gives you the following:
 * WebSocket support.
 * In-process background tasks.
 * Startup and shutdown events.
-* Test client built on `httpx`.
+* Test client built on `httpx2`.
 * CORS, GZip, Static Files, Streaming responses.
 * Session and Cookie support.
 * 100% test coverage.


### PR DESCRIPTION
The README's and docs index's feature bullets still said "Test client built on `httpx`" — but `starlette/testclient.py` deprecates `httpx` in favor of `httpx2` (installing httpx triggers a deprecation warning), and `docs/testclient.md` already states the client is built on `httpx2`. Both bullets updated.

(Typo-class doc accuracy fix, so per the PR template this doesn't need a prior discussion.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

