### PR TITLE
docs: fix 'its not available' and 'This ensure' wording

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -137,7 +137,7 @@ multidict, containing both file uploads and text input. File upload items are re
 
 `UploadFile` has the following attributes:
 
-* `filename`: An `str` with the original file name that was uploaded or `None` if its not available (e.g. `myimage.jpg`).
+* `filename`: An `str` with the original file name that was uploaded or `None` if it's not available (e.g. `myimage.jpg`).
 * `content_type`: An `str` with the content type (MIME type / media type) or `None` if it's not available (e.g. `image/jpeg`).
 * `file`: A <a href="https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile" target="_blank">`SpooledTemporaryFile`</a> (a <a href="https://docs.python.org/3/glossary.html#term-file-like-object" target="_blank">file-like</a> object). This is the actual Python file that you can pass directly to other functions or libraries that expect a "file-like" object.
 * `headers`: A `Headers` object. Often this will only be the `Content-Type` header, but if additional headers were included in the multipart field they will be included here. Note that these headers have no relationship with the headers in `Request.headers`.

--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -194,7 +194,7 @@ def test_app():
 The operations on session are standard function calls, not awaitables.
 
 It's important to use the session within a context-managed `with` block. This
-ensure that the background thread on which the ASGI application is properly
+ensures that the background thread on which the ASGI application is properly
 terminated, and that any exceptions that occur within the application are
 always raised by the test client.
 


### PR DESCRIPTION
- `docs/requests.md`: "if **its** not available" → "if it's not available" (the adjacent `content_type` bullet uses the correct form)
- `docs/testclient.md": "This **ensure** that the background thread..." → "This ensures"

Both typo-class, no prior discussion needed per the PR template.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

