### PR TITLE
Support multi valued query params in `include_query_params` and `replace_query_params`

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -142,12 +142,22 @@ class URL:
 
     def include_query_params(self, **kwargs: Any) -> URL:
         params = MultiDict(parse_qsl(self.query, keep_blank_values=True))
-        params.update({str(key): str(value) for key, value in kwargs.items()})
+        for key, value in kwargs.items():
+            if not isinstance(value, (str, bytes, bytearray)) and isinstance(value, Sequence):
+                params.setlist(str(key), [str(item) for item in value])
+            else:
+                params[str(key)] = str(value)
         query = urlencode(params.multi_items())
         return self.replace(query=query)
 
     def replace_query_params(self, **kwargs: Any) -> URL:
-        query = urlencode([(str(key), str(value)) for key, value in kwargs.items()])
+        params: list[tuple[str, str]] = []
+        for key, value in kwargs.items():
+            if not isinstance(value, (str, bytes, bytearray)) and isinstance(value, Sequence):
+                params.extend((str(key), str(item)) for item in value)
+            else:
+                params.append((str(key), str(value)))
+        query = urlencode(params)
         return self.replace(query=query)
 
     def remove_query_params(self, keys: str | Sequence[str]) -> URL:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -82,9 +82,17 @@ def test_url_query_params() -> None:
     assert str(u) == "https://example.org/path/?order=name"
     u = u.remove_query_params("order")
     assert str(u) == "https://example.org/path/"
+    u = u.replace_query_params(order=["name", "id"])
+    assert str(u) == "https://example.org/path/?order=name&order=id"
+    u = u.remove_query_params("order")
+    assert str(u) == "https://example.org/path/"
     u = u.include_query_params(page=4, search="testing")
     assert str(u) == "https://example.org/path/?page=4&search=testing"
     u = u.remove_query_params(["page", "search"])
+    assert str(u) == "https://example.org/path/"
+    u = u.include_query_params(page=4, category=["cat1", "cat2"])
+    assert str(u) == "https://example.org/path/?page=4&category=cat1&category=cat2"
+    u = u.remove_query_params(["page", "category"])
     assert str(u) == "https://example.org/path/"
 
 


### PR DESCRIPTION
Fix #3528 

# Summary

Previously when things like `lists` or `tuple`'s were passed to `starlette.datastructures.URL.include_query_params()` and `starlette.datastructures.URL.replace_query_params()`, the whole `list` would be serialized as a string. With this change, the `list` is unpacked and proper query parameters are made for each value in the list.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

