### PR TITLE
Handle non-standard status codes in HTTPException defaults

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -121,7 +121,7 @@ The `ExceptionMiddleware` implementation defaults to returning plain-text HTTP r
 * `HTTPException(status_code, detail=None, headers=None)`
 
 When `detail` is not provided, it defaults to the standard phrase for the status code,
-or an empty string for a non-standard status code.
+or an empty string for a non-standard status code between 100 and 599.
 
 You should only raise `HTTPException` inside routing or endpoints.
 Middleware classes should instead just return appropriate responses directly.

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -120,6 +120,9 @@ The `ExceptionMiddleware` implementation defaults to returning plain-text HTTP r
 
 * `HTTPException(status_code, detail=None, headers=None)`
 
+When `detail` is not provided, it defaults to the standard phrase for the status code,
+or an empty string for a non-standard status code.
+
 You should only raise `HTTPException` inside routing or endpoints.
 Middleware classes should instead just return appropriate responses directly.
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -121,7 +121,7 @@ The `ExceptionMiddleware` implementation defaults to returning plain-text HTTP r
 * `HTTPException(status_code, detail=None, headers=None)`
 
 When `detail` is not provided, it defaults to the standard phrase for the status code,
-or an empty string for a non-standard status code between 100 and 599.
+or an empty string for a non-standard integer status code between 100 and 599.
 
 You should only raise `HTTPException` inside routing or endpoints.
 Middleware classes should instead just return appropriate responses directly.

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -7,7 +7,10 @@ from collections.abc import Mapping
 class HTTPException(Exception):
     def __init__(self, status_code: int, detail: str | None = None, headers: Mapping[str, str] | None = None) -> None:
         if detail is None:
-            detail = http.HTTPStatus(status_code).phrase
+            try:
+                detail = http.HTTPStatus(status_code).phrase
+            except ValueError:
+                detail = ""
         self.status_code = status_code
         self.detail = detail
         self.headers = headers

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -10,7 +10,7 @@ class HTTPException(Exception):
             try:
                 detail = http.HTTPStatus(status_code).phrase
             except ValueError:
-                if not 100 <= status_code <= 599:
+                if not isinstance(status_code, int) or not 100 <= status_code <= 599:
                     raise
                 detail = ""
         self.status_code = status_code

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -10,6 +10,8 @@ class HTTPException(Exception):
             try:
                 detail = http.HTTPStatus(status_code).phrase
             except ValueError:
+                if not 100 <= status_code <= 599:
+                    raise
                 detail = ""
         self.status_code = status_code
         self.detail = detail

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator
 from typing import Any
 
@@ -102,6 +104,34 @@ def test_not_modified(client: TestClient) -> None:
 def test_with_headers(client: TestClient) -> None:
     response = client.get("/with_headers")
     assert response.status_code == 200
+    assert response.headers["x-potato"] == "always"
+
+
+@pytest.mark.parametrize(
+    ("status_code", "detail", "expected_detail"),
+    [
+        (404, None, "Not Found"),
+        (499, None, ""),
+        (599, None, ""),
+        (499, "Client Closed Request", "Client Closed Request"),
+        (499, "", ""),
+        (404, "", ""),
+    ],
+)
+def test_http_exception_detail(
+    test_client_factory: TestClientFactory,
+    status_code: int,
+    detail: str | None,
+    expected_detail: str,
+) -> None:
+    async def endpoint(request: Request) -> None:
+        raise HTTPException(status_code, detail=detail, headers={"x-potato": "always"})
+
+    app = ExceptionMiddleware(Router([Route("/", endpoint=endpoint)]))
+    with test_client_factory(app) as client:
+        response = client.get("/")
+    assert response.status_code == status_code
+    assert response.text == expected_detail
     assert response.headers["x-potato"] == "always"
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -179,6 +179,18 @@ def test_http_str() -> None:
     assert str(HTTPException(404, headers={"key": "value"})) == "404: Not Found"
 
 
+@pytest.mark.parametrize("status_code", [-1, 99, 600])
+def test_http_exception_invalid_status_without_detail(status_code: int) -> None:
+    with pytest.raises(ValueError, match="is not a valid HTTPStatus"):
+        HTTPException(status_code)
+
+
+def test_http_exception_explicit_detail_does_not_validate_status() -> None:
+    exc = HTTPException(600, detail="Custom")
+    assert exc.status_code == 600
+    assert exc.detail == "Custom"
+
+
 def test_http_repr() -> None:
     assert repr(HTTPException(404)) == ("HTTPException(status_code=404, detail='Not Found')")
     assert repr(HTTPException(404, detail="Not Found: foo")) == (

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -179,10 +179,10 @@ def test_http_str() -> None:
     assert str(HTTPException(404, headers={"key": "value"})) == "404: Not Found"
 
 
-@pytest.mark.parametrize("status_code", [-1, 99, 600])
-def test_http_exception_invalid_status_without_detail(status_code: int) -> None:
+@pytest.mark.parametrize("status_code", [-1, 99, 600, 499.0, "499"])
+def test_http_exception_invalid_status_without_detail(status_code: int | float | str) -> None:
     with pytest.raises(ValueError, match="is not a valid HTTPStatus"):
-        HTTPException(status_code)
+        HTTPException(status_code)  # type: ignore[arg-type]
 
 
 def test_http_exception_explicit_detail_does_not_validate_status() -> None:


### PR DESCRIPTION
# Summary

`HTTPException(499)` raises `ValueError` when no detail is supplied, even though the same status works with an explicit detail. Use an empty default detail for non-standard integer codes between 100 and 599. Out-of-range codes still raise `ValueError` when detail is omitted; explicitly supplied details and headers keep their existing behavior.

Refs https://github.com/Kludex/starlette/discussions/3499.

Tests exercise actual endpoint responses through asyncio and trio, plus invalid-code boundaries, invalid fallback types, and the existing explicit-detail behavior. Validation on macOS and Linux with Python 3.13: 1,263 passed, 2 expected failures, and 100% coverage. Ruff, mypy, package checks, and documentation builds pass on both platforms. The original code fails the four endpoint regression cases for 499 and 599.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

