### PR TITLE
Support multivalued query parameters in URL.include_query_params and replace_query_params

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -142,12 +142,22 @@ class URL:
 
     def include_query_params(self, **kwargs: Any) -> URL:
         params = MultiDict(parse_qsl(self.query, keep_blank_values=True))
-        params.update({str(key): str(value) for key, value in kwargs.items()})
+        for key, value in kwargs.items():
+            if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+                params.setlist(str(key), [str(v) for v in value])
+            else:
+                params[str(key)] = str(value)
         query = urlencode(params.multi_items())
         return self.replace(query=query)
 
     def replace_query_params(self, **kwargs: Any) -> URL:
-        query = urlencode([(str(key), str(value)) for key, value in kwargs.items()])
+        items: list[tuple[str, str]] = []
+        for key, value in kwargs.items():
+            if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+                items.extend((str(key), str(v)) for v in value)
+            else:
+                items.append((str(key), str(value)))
+        query = urlencode(items)
         return self.replace(query=query)
 
     def remove_query_params(self, keys: str | Sequence[str]) -> URL:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -88,6 +88,28 @@ def test_url_query_params() -> None:
     assert str(u) == "https://example.org/path/"
 
 
+def test_url_multivalued_query_params() -> None:
+    u = URL("https://example.org/path/")
+    u = u.include_query_params(a="b", c=["d", "e"])
+    assert str(u) == "https://example.org/path/?a=b&c=d&c=e"
+
+    # Updating multivalued query params
+    u = u.include_query_params(c=["f", "g"])
+    assert str(u) == "https://example.org/path/?a=b&c=f&c=g"
+
+    # Tuple and non-string sequences
+    u = u.include_query_params(num=(1, 2))
+    assert str(u) == "https://example.org/path/?a=b&c=f&c=g&num=1&num=2"
+
+    # Empty sequence removes the key
+    u = u.include_query_params(c=[])
+    assert str(u) == "https://example.org/path/?a=b&num=1&num=2"
+
+    # replace_query_params with multivalued values
+    u = u.replace_query_params(tag=["python", "asgi"], debug="true")
+    assert str(u) == "https://example.org/path/?tag=python&tag=asgi&debug=true"
+
+
 def test_hidden_password() -> None:
     u = URL("https://example.org/path/to/somewhere")
     assert repr(u) == "URL('https://example.org/path/to/somewhere')"


### PR DESCRIPTION
# Summary

Fixes #3528
Initial discussion: #3481

When calling `request.url_for(...).include_query_params(a="b", c=["d", "e"])` or `URL.include_query_params(**kwargs)`, passing sequences (such as `list` or `tuple`) previously converted the sequence directly via `str(value)`, resulting in escaped representations like `c=%5B%27d%27%2C+%27e%27%5D` (`c=['d', 'e']`) rather than standard multi-valued query parameters (`c=d&c=e`).

Similarly, `URL.replace_query_params(**kwargs)` stringified sequence values.

### Changes:
- In `URL.include_query_params`: If `value` is a `Sequence` (excluding `str` and `bytes`), uses `params.setlist(str(key), [str(v) for v in value])` to properly register multi-valued query parameters in the underlying `MultiDict`.
- In `URL.replace_query_params`: If `value` is a `Sequence` (excluding `str` and `bytes`), unpacks each element into `(str(key), str(v))` tuples for `urlencode`.
- Added regression test `tests/test_datastructures.py::test_url_multivalued_query_params` covering multi-valued parameter inclusion, updating, sequence element casting, and replacement.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

