### PR TITLE
Expand list/tuple values in include_query_params

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -142,12 +142,22 @@ class URL:
 
     def include_query_params(self, **kwargs: Any) -> URL:
         params = MultiDict(parse_qsl(self.query, keep_blank_values=True))
-        params.update({str(key): str(value) for key, value in kwargs.items()})
+        for key, value in kwargs.items():
+            if isinstance(value, (list, tuple)):
+                params.setlist(str(key), [str(item) for item in value])
+            else:
+                params[str(key)] = str(value)
         query = urlencode(params.multi_items())
         return self.replace(query=query)
 
     def replace_query_params(self, **kwargs: Any) -> URL:
-        query = urlencode([(str(key), str(value)) for key, value in kwargs.items()])
+        params: list[tuple[str, str]] = []
+        for key, value in kwargs.items():
+            if isinstance(value, (list, tuple)):
+                params.extend((str(key), str(item)) for item in value)
+            else:
+                params.append((str(key), str(value)))
+        query = urlencode(params)
         return self.replace(query=query)
 
     def remove_query_params(self, keys: str | Sequence[str]) -> URL:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -86,6 +86,13 @@ def test_url_query_params() -> None:
     assert str(u) == "https://example.org/path/?page=4&search=testing"
     u = u.remove_query_params(["page", "search"])
     assert str(u) == "https://example.org/path/"
+    # Multi-valued query params should expand rather than stringify.
+    u = u.include_query_params(a="b", c=["d", "e"])
+    assert str(u) == "https://example.org/path/?a=b&c=d&c=e"
+    u = u.include_query_params(c=("f", "g"))
+    assert str(u) == "https://example.org/path/?a=b&c=f&c=g"
+    u = u.replace_query_params(tag=["x", "y"], page=1)
+    assert str(u) == "https://example.org/path/?tag=x&tag=y&page=1"
 
 
 def test_hidden_password() -> None:


### PR DESCRIPTION
## Summary

`URL.include_query_params` stringified list/tuple values, so:

```python
url.include_query_params(a="b", c=["d", "e"])
# -> "?a=b&c=%5B%27d%27%2C+%27e%27%5D"
```

instead of the usual multi-valued form `?a=b&c=d&c=e`.

This expands `list` / `tuple` values via `MultiDict.setlist`, and applies the same expansion in `replace_query_params` for consistency. Scalar values are unchanged. Strings are not treated as sequences.

## Test plan

- [x] Extended `tests/test_datastructures.py::test_url_query_params` for list and tuple expansion on `include_query_params`, plus multi-value `replace_query_params`
- [x] `uv run pytest tests/test_datastructures.py` (52 passed)
- [x] `uv run ruff check` / `ruff format --check` on the touched files

Fixes #3528

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

