### PR TITLE
Expose redirect_slashes in Starlette constructor

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -54,6 +54,9 @@ routes = [
 app = Starlette(debug=True, routes=routes, lifespan=lifespan)
 ```
 
+By default, Starlette redirects requests when adding or removing a trailing slash
+would match a route. Pass `redirect_slashes=False` to disable these redirects.
+
 ### Storing state on the app instance
 
 You can store arbitrary extra state on the application instance, using the

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -28,6 +28,7 @@ class Starlette:
         exception_handlers: Mapping[Any, ExceptionHandler] | None = None,
         lifespan: Lifespan[AppType] | None = None,
         *,
+        redirect_slashes: bool = True,
         max_body_size: int | None = None,
     ) -> None:
         """Initializes the application.
@@ -49,12 +50,14 @@ class Starlette:
             lifespan: A lifespan context function, which can be used to perform
                 startup and shutdown tasks. This is a newer style that replaces the
                 `on_startup` and `on_shutdown` handlers. Use one or the other, not both.
+            redirect_slashes: Whether to redirect requests to a matching route with
+                an added or removed trailing slash.
             max_body_size: Non-negative maximum total size in bytes of an HTTP request
                 body. The default, `None`, does not limit request body size.
         """
         self.debug = debug
         self.state = State()
-        self.router = Router(routes, lifespan=lifespan)
+        self.router = Router(routes, redirect_slashes=redirect_slashes, lifespan=lifespan)
         self.max_body_size = max_body_size
         self.exception_handlers = {} if exception_handlers is None else dict(exception_handlers)
         self.user_middleware = [] if middleware is None else list(middleware)

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -195,6 +195,15 @@ def test_mounted_route(client: TestClient) -> None:
     assert response.text == "Hello, everyone!"
 
 
+def test_redirect_slashes_can_be_disabled(test_client_factory: TestClientFactory) -> None:
+    app = Starlette(routes=[Route("/users/", endpoint=all_users_page)], redirect_slashes=False)
+    client = test_client_factory(app)
+
+    response = client.get("/users", follow_redirects=False)
+
+    assert response.status_code == 404
+
+
 def test_mounted_route_path_params(client: TestClient) -> None:
     response = client.get("/users/tomchristie")
     assert response.status_code == 200


### PR DESCRIPTION
# Summary

Expose the existing router-level `redirect_slashes` setting through the `Starlette` constructor. This lets applications disable automatic trailing-slash redirects without mutating `app.router` after construction.

The default remains `True`, so existing applications are unchanged. The application reference now documents the option, and a regression test verifies that `redirect_slashes=False` returns 404 instead of redirecting.

Related to #869.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This does not apply to typos.)
- [x] I added a test for the change and kept it atomic.
- [x] I updated the documentation accordingly.

# Validation

- `scripts/test` — 1245 passed, 2 skipped, 2 xfailed; 100% coverage
- `uv run zensical build --strict` — passed
- `uv run pytest -q tests/test_routing.py` — 98 passed
- `uv run pytest -q tests/test_applications.py` — 57 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

