### PR TITLE
Reject negative request body size limits

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -52,6 +52,8 @@ class Starlette:
             max_body_size: Non-negative maximum total size in bytes of an HTTP request
                 body. The default, `None`, does not limit request body size.
         """
+        if max_body_size is not None and max_body_size < 0:
+            raise ValueError("`max_body_size` must be greater than or equal to 0")
         self.debug = debug
         self.state = State()
         self.router = Router(routes, lifespan=lifespan)

--- a/starlette/middleware/body_limit.py
+++ b/starlette/middleware/body_limit.py
@@ -31,6 +31,8 @@ class RequestBodyLimitMiddleware:
     """Limit the total size of an HTTP request body."""
 
     def __init__(self, app: ASGIApp, max_body_size: int) -> None:
+        if max_body_size < 0:
+            raise ValueError("`max_body_size` must be greater than or equal to 0")
         self.app = app
         self.max_body_size = max_body_size
 

--- a/tests/middleware/test_body_limit.py
+++ b/tests/middleware/test_body_limit.py
@@ -20,6 +20,31 @@ async def echo(request: Request) -> Response:
     return Response(await request.body())
 
 
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: RequestBodyLimitMiddleware(Starlette(), max_body_size=-1),
+        lambda: Starlette(max_body_size=-1),
+        lambda: Router(max_body_size=-1),
+        lambda: Mount("/", app=Starlette(), max_body_size=-1),
+        lambda: Route("/", endpoint=echo, max_body_size=-1),
+    ],
+)
+def test_negative_body_size_limit(factory: Callable[[], object]) -> None:
+    with pytest.raises(ValueError, match="`max_body_size` must be greater than or equal to 0"):
+        factory()
+
+
+def test_zero_body_size_limit(test_client_factory: TestClientFactory) -> None:
+    app = Starlette(routes=[Route("/", echo, methods=["POST"])], max_body_size=0)
+    client = test_client_factory(app)
+
+    response = client.post("/", content=b"")
+
+    assert response.status_code == 200
+    assert response.content == b""
+
+
 def test_body_size_limit(test_client_factory: TestClientFactory) -> None:
     app = RequestBodyLimitMiddleware(
         Starlette(routes=[Route("/", echo, methods=["POST"])]),


### PR DESCRIPTION
# Summary

Reject negative `max_body_size` values instead of accepting invalid configuration that turns valid requests into `413 Content Too Large` responses.

Validation in `RequestBodyLimitMiddleware` covers `Router`, `Mount`, and `Route`; `Starlette` validates eagerly because its middleware stack is built lazily. Zero remains a valid limit. Tests cover every public configuration entry point and the zero boundary.

Discussion: https://github.com/Kludex/starlette/discussions/3535
Context: #3431 documented the option as non-negative.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This does not apply to typos.)
- [x] I added a test for each change and kept the change atomic.
- [x] The existing documentation already specifies that the limit is non-negative.

# Validation

- `scripts/test` — 1250 passed, 2 skipped, 2 xfailed; 100% coverage
- Focused body-limit tests — 41 passed before the zero-boundary test was added; the final full suite includes all cases

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

