### PR TITLE
Prefer explicit HEAD routes over implicit GET handling

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -276,6 +276,9 @@ routes = [
 ]
 ```
 
+Explicit `HEAD` routes are an exception to route priority: they take precedence over an earlier matching `GET` route,
+which otherwise handles `HEAD` requests automatically.
+
 ## Working with Router instances
 
 If you're working at a low-level you might want to use a plain `Router`

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -705,9 +705,7 @@ class Router:
                     if implicit_head is None:
                         implicit_head = route
                         implicit_head_scope = child_scope
-                        continue
-                    route = implicit_head
-                    child_scope = implicit_head_scope
+                    continue
                 elif implicit_head is not None and not (
                     isinstance(route, Route) and route.methods is not None and "HEAD" in route.methods
                 ):

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -234,8 +234,10 @@ class Route(BaseRoute):
 
         if methods is None:
             self.methods = None
+            self._head_is_implicit = False
         else:
             self.methods = {method.upper() for method in methods}
+            self._head_is_implicit = "GET" in self.methods and "HEAD" not in self.methods
             if "GET" in self.methods:
                 self.methods.add("HEAD")
 
@@ -287,6 +289,7 @@ class Route(BaseRoute):
             and self.path == other.path
             and self.endpoint == other.endpoint
             and self.methods == other.methods
+            and self._head_is_implicit == other._head_is_implicit
         )
 
     def __repr__(self) -> str:
@@ -686,12 +689,30 @@ class Router:
             return
 
         partial = None
+        implicit_head: Route | None = None
 
         for route in self.routes:
             # Determine if any route matches the incoming scope,
             # and hand over to the matching route if found.
             match, child_scope = route.matches(scope)
             if match == Match.FULL:
+                if (
+                    scope["type"] == "http"
+                    and scope["method"] == "HEAD"
+                    and isinstance(route, Route)
+                    and route._head_is_implicit
+                ):
+                    if implicit_head is None:
+                        implicit_head = route
+                        implicit_head_scope = child_scope
+                        continue
+                    route = implicit_head
+                    child_scope = implicit_head_scope
+                elif implicit_head is not None and not (
+                    isinstance(route, Route) and route.methods is not None and "HEAD" in route.methods
+                ):
+                    route = implicit_head
+                    child_scope = implicit_head_scope
                 scope["route"] = route
                 scope.update(child_scope)
                 await route.handle(scope, receive, send)
@@ -699,6 +720,12 @@ class Router:
             elif match == Match.PARTIAL and partial is None:
                 partial = route
                 partial_scope = child_scope
+
+        if implicit_head is not None:
+            scope["route"] = implicit_head
+            scope.update(implicit_head_scope)
+            await implicit_head.handle(scope, receive, send)
+            return
 
         if partial is not None:
             #  Handle partial matches. These are cases where an endpoint is

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1094,6 +1094,69 @@ def test_route_repr_without_methods() -> None:
     assert repr(route) == "Route(path='/welcome', name='Endpoint', methods=[])"
 
 
+def test_route_equality_distinguishes_implicit_head() -> None:
+    assert Route("/", homepage, methods=["GET"]) != Route("/", homepage, methods=["GET", "HEAD"])
+
+
+def test_explicit_head_route_takes_precedence(test_client_factory: TestClientFactory) -> None:
+    calls: list[str] = []
+
+    async def get_endpoint(request: Request) -> PlainTextResponse:
+        calls.append("GET")
+        return PlainTextResponse("GET")
+
+    async def head_endpoint(request: Request) -> PlainTextResponse:
+        calls.append("HEAD")
+        return PlainTextResponse("HEAD")
+
+    app = Starlette(
+        routes=[
+            Route("/", get_endpoint, methods=["GET"]),
+            Route("/other", get_endpoint, methods=["GET"]),
+            Route("/", head_endpoint, methods=["HEAD"]),
+        ]
+    )
+
+    client = test_client_factory(app)
+    assert client.head("/").status_code == 200
+    assert calls == ["HEAD"]
+
+    calls.clear()
+    assert client.get("/").text == "GET"
+    assert calls == ["GET"]
+
+
+def test_implicit_head_keeps_route_priority(test_client_factory: TestClientFactory) -> None:
+    async def first_endpoint(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("first")
+
+    async def second_endpoint(request: Request) -> PlainTextResponse:  # pragma: no cover
+        return PlainTextResponse("second")
+
+    app = Starlette(
+        routes=[
+            Route("/", first_endpoint, methods=["GET"]),
+            Route("/", second_endpoint, methods=["GET"]),
+            Mount("/", app=PlainTextResponse("mount")),
+        ]
+    )
+
+    response = test_client_factory(app).head("/")
+    assert response.status_code == 200
+    assert response.headers["content-length"] == "5"
+
+
+def test_implicit_head_keeps_priority_over_later_mount(test_client_factory: TestClientFactory) -> None:
+    async def get_endpoint(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("GET")
+
+    app = Starlette(routes=[Route("/", get_endpoint, methods=["GET"]), Mount("/", app=PlainTextResponse("mount"))])
+
+    response = test_client_factory(app).head("/")
+    assert response.status_code == 200
+    assert response.headers["content-length"] == "3"
+
+
 def test_websocket_route_repr() -> None:
     route = WebSocketRoute("/ws", endpoint=websocket_endpoint)
     assert repr(route) == "WebSocketRoute(path='/ws', name='websocket_endpoint')"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1109,10 +1109,15 @@ def test_explicit_head_route_takes_precedence(test_client_factory: TestClientFac
         calls.append("HEAD")
         return PlainTextResponse("HEAD")
 
+    async def second_get_endpoint(request: Request) -> PlainTextResponse:  # pragma: no cover
+        calls.append("second GET")
+        return PlainTextResponse("second GET")
+
     app = Starlette(
         routes=[
             Route("/", get_endpoint, methods=["GET"]),
             Route("/other", get_endpoint, methods=["GET"]),
+            Route("/", second_get_endpoint, methods=["GET"]),
             Route("/", head_endpoint, methods=["HEAD"]),
         ]
     )
@@ -1137,7 +1142,6 @@ def test_implicit_head_keeps_route_priority(test_client_factory: TestClientFacto
         routes=[
             Route("/", first_endpoint, methods=["GET"]),
             Route("/", second_endpoint, methods=["GET"]),
-            Mount("/", app=PlainTextResponse("mount")),
         ]
     )
 


### PR DESCRIPTION
# Summary

- Defer an implicit `HEAD` match from a `GET` route while checking for a later explicit `HEAD` route.
- Preserve normal first-match priority against later implicit or catch-all routes.
- Keep route equality consistent with the new behavior and document the exception.

Discussion: https://github.com/Kludex/starlette/discussions/3128

# Validation

- `scripts/check`
- `uv run coverage run -m pytest` — 1,250 passed, 2 skipped, 2 xfailed
- `uv run coverage report --fail-under=100` — 100%
- `uv run zensical build`

# Checklist

- [x] Previous discussion exists.
- [x] Regression and compatibility tests are included.
- [x] Documentation reflects the behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

