### PR TITLE
Support the HTML protocol in HTMLResponse

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -70,7 +70,7 @@ For cross-site requests, use `samesite="none"`.
 
 ### HTMLResponse
 
-Takes some text or bytes and returns an HTML response.
+Takes some text, bytes, or an object implementing `__html__()` and returns an HTML response.
 
 ```python
 from starlette.responses import HTMLResponse

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -175,6 +175,11 @@ class Response:
 class HTMLResponse(Response):
     media_type = "text/html"
 
+    def render(self, content: Any) -> bytes | memoryview:
+        if hasattr(content, "__html__"):
+            content = content.__html__()
+        return super().render(content)
+
 
 class PlainTextResponse(Response):
     media_type = "text/plain"

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -17,7 +17,7 @@ from starlette import status
 from starlette.background import BackgroundTask
 from starlette.datastructures import Headers
 from starlette.requests import ClientDisconnect, Request
-from starlette.responses import FileResponse, JSONResponse, RedirectResponse, Response, StreamingResponse
+from starlette.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse, Response, StreamingResponse
 from starlette.testclient import TestClient
 from starlette.types import Message, Receive, Scope, Send
 from tests.types import TestClientFactory
@@ -41,6 +41,17 @@ def test_bytes_response(test_client_factory: TestClientFactory) -> None:
     client = test_client_factory(app)
     response = client.get("/")
     assert response.content == b"xxxxx"
+
+
+def test_html_response_supports_html_protocol(test_client_factory: TestClientFactory) -> None:
+    class HTML:
+        def __html__(self) -> str:
+            return "<strong>hello, world</strong>"
+
+    client = test_client_factory(HTMLResponse(HTML()))
+    response = client.get("/")
+    assert response.text == "<strong>hello, world</strong>"
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
 
 
 def test_json_none_response(test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
# Summary

- Let `HTMLResponse` render objects that implement `__html__()` before encoding the result.
- Keep the behavior scoped to the established safe-HTML protocol; notebook-only `_repr_html_()` objects are unchanged.
- Add regression coverage and update the response documentation.

Discussion: https://github.com/Kludex/starlette/discussions/3399

# Validation

- `scripts/check`
- `uv run coverage run -m pytest` — 1,245 passed, 2 skipped, 2 xfailed
- `uv run coverage report --fail-under=100` — 100%
- `uv run zensical build`

# Checklist

- [x] Previous discussion exists.
- [x] Regression tests are included.
- [x] Documentation reflects the behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

