### PR TITLE
Add `URL.append_query_params()`

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -42,7 +42,7 @@ For example: `request.url.path`, `request.url.port`, `request.url.scheme`.
 
 ##### Modifying query parameters
 
-You can add, replace, and remove query parameters from a URL. Each method returns a new `URL` instance.
+You can add, replace, and remove query parameters from a URL. Each method returns a `URL` instance.
 
 ```python
 from starlette.datastructures import URL

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -40,6 +40,18 @@ components that can be parsed out of the URL.
 
 For example: `request.url.path`, `request.url.port`, `request.url.scheme`.
 
+Use `URL.append_query_params()` to add query parameters without replacing existing values. Pass a mapping or an
+iterable of key-value pairs. An iterable can contain the same key more than once.
+
+```python
+from starlette.datastructures import URL
+
+url = URL("https://example.com/?page=1")
+url = url.append_query_params([("category", "books"), ("category", "games")])
+
+assert str(url) == "https://example.com/?page=1&category=books&category=games"
+```
+
 #### Headers
 
 Headers are exposed as an immutable, case-insensitive, multi-dict.

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -40,18 +40,6 @@ components that can be parsed out of the URL.
 
 For example: `request.url.path`, `request.url.port`, `request.url.scheme`.
 
-Use `URL.append_query_params()` to add query parameters without replacing existing values. Pass a mapping or an
-iterable of key-value pairs. An iterable can contain the same key more than once.
-
-```python
-from starlette.datastructures import URL
-
-url = URL("https://example.com/?page=1")
-url = url.append_query_params([("category", "books"), ("category", "games")])
-
-assert str(url) == "https://example.com/?page=1&category=books&category=games"
-```
-
 #### Headers
 
 Headers are exposed as an immutable, case-insensitive, multi-dict.

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -40,6 +40,33 @@ components that can be parsed out of the URL.
 
 For example: `request.url.path`, `request.url.port`, `request.url.scheme`.
 
+##### Modifying query parameters
+
+You can add, replace, and remove query parameters from a URL. Each method returns a new `URL` instance.
+
+```python
+from starlette.datastructures import URL
+
+url = URL("https://example.com/?page=1")
+
+included = url.include_query_params(page=2, search="books")
+assert str(included) == "https://example.com/?page=2&search=books"
+
+appended = url.append_query_params([("category", "books"), ("category", "games")])
+assert str(appended) == "https://example.com/?page=1&category=books&category=games"
+
+replaced = url.replace_query_params(order="name")
+assert str(replaced) == "https://example.com/?order=name"
+
+removed = appended.remove_query_params("category")
+assert str(removed) == "https://example.com/?page=1"
+```
+
+Use `include_query_params()` to replace values for matching keys while preserving other parameters. Use
+`append_query_params()` with a mapping or an iterable of key-value pairs to preserve every existing value and add new
+ones. An iterable may contain the same key more than once. Use `replace_query_params()` to replace the complete query
+string, and `remove_query_params()` to remove one or more keys.
+
 #### Headers
 
 Headers are exposed as an immutable, case-insensitive, multi-dict.

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -49,23 +49,22 @@ from starlette.datastructures import URL
 
 url = URL("https://example.com/?page=1")
 
+# Replace matching query parameters while preserving other parameters.
 included = url.include_query_params(page=2, search="books")
 assert str(included) == "https://example.com/?page=2&search=books"
 
+# Append query parameters while preserving every existing value.
 appended = url.append_query_params([("category", "books"), ("category", "games")])
 assert str(appended) == "https://example.com/?page=1&category=books&category=games"
 
+# Replace the complete query string.
 replaced = url.replace_query_params(order="name")
 assert str(replaced) == "https://example.com/?order=name"
 
+# Remove one or more query parameters.
 removed = appended.remove_query_params("category")
 assert str(removed) == "https://example.com/?page=1"
 ```
-
-Use `include_query_params()` to replace values for matching keys while preserving other parameters. Use
-`append_query_params()` with a mapping or an iterable of key-value pairs to preserve every existing value and add new
-ones. An iterable may contain the same key more than once. Use `replace_query_params()` to replace the complete query
-string, and `remove_query_params()` to remove one or more keys.
 
 #### Headers
 

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -141,10 +141,10 @@ class URL:
         return self.__class__(components.geturl())
 
     def append_query_params(self, params: Mapping[Any, Any] | Iterable[tuple[Any, Any]]) -> URL:
-        existing = parse_qsl(self.query, keep_blank_values=True)
-        appended = MultiDict(params)
-        query = urlencode(existing + [(str(key), str(value)) for key, value in appended.multi_items()])
-        return self.replace(query=query)
+        params = MultiDict(params)
+        appended = urlencode([(str(key), str(value)) for key, value in params.multi_items()])
+        separator = "&" if self.query and appended and not self.query.endswith("&") else ""
+        return self.replace(query=f"{self.query}{separator}{appended}")
 
     def include_query_params(self, **kwargs: Any) -> URL:
         params = MultiDict(parse_qsl(self.query, keep_blank_values=True))

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -143,7 +143,9 @@ class URL:
     def append_query_params(self, params: Mapping[Any, Any] | Iterable[tuple[Any, Any]]) -> URL:
         params = MultiDict(params)
         appended = urlencode([(str(key), str(value)) for key, value in params.multi_items()])
-        separator = "&" if self.query and appended and not self.query.endswith("&") else ""
+        if not appended:
+            return self
+        separator = "&" if self.query and not self.query.endswith("&") else ""
         return self.replace(query=f"{self.query}{separator}{appended}")
 
     def include_query_params(self, **kwargs: Any) -> URL:

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -140,6 +140,12 @@ class URL:
         components = self.components._replace(**kwargs)
         return self.__class__(components.geturl())
 
+    def append_query_params(self, params: Mapping[Any, Any] | Iterable[tuple[Any, Any]]) -> URL:
+        existing = parse_qsl(self.query, keep_blank_values=True)
+        appended = MultiDict(params)
+        query = urlencode(existing + [(str(key), str(value)) for key, value in appended.multi_items()])
+        return self.replace(query=query)
+
     def include_query_params(self, **kwargs: Any) -> URL:
         params = MultiDict(parse_qsl(self.query, keep_blank_values=True))
         params.update({str(key): str(value) for key, value in kwargs.items()})

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -104,6 +104,11 @@ def test_url_append_query_params_preserves_existing_query() -> None:
     assert str(u) == "https://example.org/path/?flag&q=hello%20world&&invalid=%FF&category=books"
 
 
+def test_url_append_empty_query_params() -> None:
+    u = URL("https://example.org/path/?")
+    assert str(u.append_query_params({})) == "https://example.org/path/?"
+
+
 def test_hidden_password() -> None:
     u = URL("https://example.org/path/to/somewhere")
     assert repr(u) == "URL('https://example.org/path/to/somewhere')"

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -88,6 +88,16 @@ def test_url_query_params() -> None:
     assert str(u) == "https://example.org/path/"
 
 
+def test_url_append_query_params() -> None:
+    u = URL("https://example.org/path/?page=3")
+    u = u.append_query_params([("category", "cat1"), ("category", "cat2")])
+    assert str(u) == "https://example.org/path/?page=3&category=cat1&category=cat2"
+    u = u.append_query_params({"page": 4})
+    assert str(u) == "https://example.org/path/?page=3&category=cat1&category=cat2&page=4"
+    u = u.append_query_params(MultiDict([("filter", "new"), ("filter", "popular")]))
+    assert str(u) == ("https://example.org/path/?page=3&category=cat1&category=cat2&page=4&filter=new&filter=popular")
+
+
 def test_hidden_password() -> None:
     u = URL("https://example.org/path/to/somewhere")
     assert repr(u) == "URL('https://example.org/path/to/somewhere')"

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -89,13 +89,19 @@ def test_url_query_params() -> None:
 
 
 def test_url_append_query_params() -> None:
-    u = URL("https://example.org/path/?page=3")
+    u = URL("https://example.org/path/")
     u = u.append_query_params([("category", "cat1"), ("category", "cat2")])
-    assert str(u) == "https://example.org/path/?page=3&category=cat1&category=cat2"
+    assert str(u) == "https://example.org/path/?category=cat1&category=cat2"
     u = u.append_query_params({"page": 4})
-    assert str(u) == "https://example.org/path/?page=3&category=cat1&category=cat2&page=4"
+    assert str(u) == "https://example.org/path/?category=cat1&category=cat2&page=4"
     u = u.append_query_params(MultiDict([("filter", "new"), ("filter", "popular")]))
-    assert str(u) == ("https://example.org/path/?page=3&category=cat1&category=cat2&page=4&filter=new&filter=popular")
+    assert str(u) == "https://example.org/path/?category=cat1&category=cat2&page=4&filter=new&filter=popular"
+
+
+def test_url_append_query_params_preserves_existing_query() -> None:
+    u = URL("https://example.org/path/?flag&q=hello%20world&&invalid=%FF")
+    u = u.append_query_params([("category", "books")])
+    assert str(u) == "https://example.org/path/?flag&q=hello%20world&&invalid=%FF&category=books"
 
 
 def test_hidden_password() -> None:


### PR DESCRIPTION
## Summary

- Add `URL.append_query_params()` for mappings and iterables of key-value pairs.
- Preserve existing parameters, ordering, and duplicate keys without changing current serialization behavior.
- Document all `URL` query parameter methods together.
- Cover mappings, iterables, `MultiDict` inputs, and noncanonical existing queries.

This provides a backwards-compatible alternative to [#3529](https://github.com/Kludex/starlette/pull/3529).

Closes #3528.

## Tests

- `scripts/test`
- `uv run zensical build`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
