### PR TITLE
Allow HTTPException to use non-standard status codes

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -120,6 +120,9 @@ The `ExceptionMiddleware` implementation defaults to returning plain-text HTTP r
 
 * `HTTPException(status_code, detail=None, headers=None)`
 
+When `detail` is not provided, it defaults to the standard phrase for the status code. If no standard phrase exists,
+it defaults to an empty string.
+
 You should only raise `HTTPException` inside routing or endpoints.
 Middleware classes should instead just return appropriate responses directly.
 

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import http
+import http.client
 from collections.abc import Mapping
 
 
 class HTTPException(Exception):
     def __init__(self, status_code: int, detail: str | None = None, headers: Mapping[str, str] | None = None) -> None:
         if detail is None:
-            detail = http.HTTPStatus(status_code).phrase
+            detail = http.client.responses.get(status_code, "")
         self.status_code = status_code
         self.detail = detail
         self.headers = headers

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -34,6 +34,10 @@ def with_headers(request: Request) -> None:
     raise HTTPException(status_code=200, headers={"x-potato": "always"})
 
 
+def non_standard_status_code(request: Request) -> None:
+    raise HTTPException(status_code=499)
+
+
 class BadBodyException(HTTPException):
     pass
 
@@ -62,6 +66,7 @@ router = Router(
         Route("/no_content", endpoint=no_content),
         Route("/not_modified", endpoint=not_modified),
         Route("/with_headers", endpoint=with_headers),
+        Route("/non_standard_status_code", endpoint=non_standard_status_code),
         Route("/handled_exc_after_response", endpoint=HandledExcAfterResponse()),
         WebSocketRoute("/runtime_error", endpoint=raise_runtime_error),
         Route("/consume_body_in_endpoint_and_handler", endpoint=read_body_and_raise_exc, methods=["POST"]),
@@ -103,6 +108,12 @@ def test_with_headers(client: TestClient) -> None:
     response = client.get("/with_headers")
     assert response.status_code == 200
     assert response.headers["x-potato"] == "always"
+
+
+def test_non_standard_status_code(client: TestClient) -> None:
+    response = client.get("/non_standard_status_code")
+    assert response.status_code == 499
+    assert response.text == ""
 
 
 def test_websockets_should_raise(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

Allow `HTTPException` to use a non-standard status code without requiring an explicit `detail`. Standard status codes keep their standard phrase, while unknown codes default to an empty string.

This uses the public `http.client.responses` mapping and adds a response-level regression test for status code 499.

Alternative to [#3530](https://github.com/Kludex/starlette/pull/3530). Refs https://github.com/Kludex/starlette/discussions/3499.

## Tests

- `uv run coverage run -m pytest`
- `uv run coverage report`
- `uv run ruff check starlette/exceptions.py tests/test_exceptions.py`
- `uv run ruff format --check starlette/exceptions.py tests/test_exceptions.py`
- `uv run mypy starlette tests`
- `uv run zensical build --strict`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

